### PR TITLE
feat: anonymized guest availability share link

### DIFF
--- a/src/app/admin/calendar/_components/share-calendar-card.tsx
+++ b/src/app/admin/calendar/_components/share-calendar-card.tsx
@@ -3,8 +3,8 @@
 import { useState, useTransition } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import type { LucideIcon } from 'lucide-react';
 import { Copy, Check, RefreshCw, Smartphone } from 'lucide-react';
-import { generateShareCalendarToken } from '../actions';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,9 +20,23 @@ import {
 interface ShareCalendarCardProps {
   propertyId: string;
   shareToken?: string;
+  /** Server action that (re)generates the token and returns the new value. */
+  generateAction: (propertyId: string) => Promise<{ token?: string; error?: string }>;
+  title?: string;
+  description?: string;
+  icon?: LucideIcon;
+  generateLabel?: string;
 }
 
-export function ShareCalendarCard({ propertyId, shareToken }: ShareCalendarCardProps) {
+export function ShareCalendarCard({
+  propertyId,
+  shareToken,
+  generateAction,
+  title = 'Public Share Link',
+  description = 'A read-only mobile-friendly calendar view. Share with housekeeping, co-hosts, or anyone who needs visibility without admin access. Shows guest names, dates, and notes — hides payment, contact info, and source.',
+  icon: Icon = Smartphone,
+  generateLabel = 'Generate Share Link',
+}: ShareCalendarCardProps) {
   const [token, setToken] = useState(shareToken);
   const [copied, setCopied] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -33,7 +47,7 @@ export function ShareCalendarCard({ propertyId, shareToken }: ShareCalendarCardP
 
   const handleGenerate = () => {
     startTransition(async () => {
-      const result = await generateShareCalendarToken(propertyId);
+      const result = await generateAction(propertyId);
       if (result.token) setToken(result.token);
     });
   };
@@ -49,13 +63,11 @@ export function ShareCalendarCard({ propertyId, shareToken }: ShareCalendarCardP
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          <Smartphone className="h-5 w-5" />
-          Public Share Link
+          <Icon className="h-5 w-5" />
+          {title}
         </CardTitle>
         <CardDescription>
-          A read-only mobile-friendly calendar view. Share with housekeeping, co-hosts, or anyone
-          who needs visibility without admin access. Shows guest names, dates, and notes — hides
-          payment, contact info, and source.
+          {description}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -101,7 +113,7 @@ export function ShareCalendarCard({ propertyId, shareToken }: ShareCalendarCardP
               Generate a token to create your share URL.
             </p>
             <Button onClick={handleGenerate} disabled={isPending}>
-              {isPending ? 'Generating...' : 'Generate Share Link'}
+              {isPending ? 'Generating...' : generateLabel}
             </Button>
           </div>
         )}

--- a/src/app/admin/calendar/actions.ts
+++ b/src/app/admin/calendar/actions.ts
@@ -228,14 +228,17 @@ export async function fetchExportConfig(propertyId: string): Promise<{
   }
 }
 
-export async function fetchShareCalendarConfig(propertyId: string): Promise<{ token?: string }> {
+export async function fetchShareCalendarConfig(propertyId: string): Promise<{ token?: string; guestToken?: string }> {
   try {
     await requirePropertyAccess(propertyId);
     const db = await getAdminDb();
     const propertyDoc = await db.collection('properties').doc(propertyId).get();
     if (!propertyDoc.exists) return {};
     const data = propertyDoc.data()!;
-    return { token: data.shareCalendarToken || undefined };
+    return {
+      token: data.shareCalendarToken || undefined,
+      guestToken: data.guestCalendarToken || undefined,
+    };
   } catch (error) {
     if (error instanceof AuthorizationError) return {};
     logger.error('Error fetching share calendar config', error as Error, { propertyId });
@@ -258,6 +261,28 @@ export async function generateShareCalendarToken(propertyId: string): Promise<{ 
   } catch (error) {
     if (error instanceof AuthorizationError) return { error: error.message };
     logger.error('Error generating share calendar token', error as Error, { propertyId });
+    return { error: 'Failed to generate token' };
+  }
+}
+
+// Anonymized guest-facing share link — same /calendar/<token> route, but the
+// token lands in a separate field so it can be rotated independently of the
+// housekeeping link, and the view shows only booked-vs-available (no PII).
+export async function generateGuestCalendarToken(propertyId: string): Promise<{ token?: string; error?: string }> {
+  try {
+    await requirePropertyAccess(propertyId);
+    const db = await getAdminDb();
+    const token = randomUUID();
+    await db.collection('properties').doc(propertyId).update({
+      guestCalendarToken: token,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    logger.info('Guest calendar token generated', { propertyId });
+    revalidatePath('/admin/calendar');
+    return { token };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { error: error.message };
+    logger.error('Error generating guest calendar token', error as Error, { propertyId });
     return { error: 'Failed to generate token' };
   }
 }

--- a/src/app/admin/calendar/page.tsx
+++ b/src/app/admin/calendar/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Settings2 } from 'lucide-react';
+import { Settings2, Users } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -8,7 +8,7 @@ import { ExportUrlCard } from './_components/export-url-card';
 import { ICalFeedsTable } from './_components/ical-feeds-table';
 import { AddFeedDialog } from './_components/add-feed-dialog';
 import { ShareCalendarCard } from './_components/share-calendar-card';
-import { fetchICalFeeds, fetchExportConfig, fetchAvailabilityCalendarData, fetchShareCalendarConfig } from './actions';
+import { fetchICalFeeds, fetchExportConfig, fetchAvailabilityCalendarData, fetchShareCalendarConfig, generateShareCalendarToken, generateGuestCalendarToken } from './actions';
 import { AvailabilityCalendar } from './_components/availability-calendar';
 import { format, addMonths } from 'date-fns';
 import type { MonthAvailabilityData } from './_lib/availability-types';
@@ -85,6 +85,18 @@ export default async function CalendarSyncPage({
             <ShareCalendarCard
               propertyId={propertyId}
               shareToken={shareConfig.token}
+              generateAction={generateShareCalendarToken}
+            />
+
+            {/* Guest Availability Link (anonymized — booked vs free only) */}
+            <ShareCalendarCard
+              propertyId={propertyId}
+              shareToken={shareConfig.guestToken}
+              generateAction={generateGuestCalendarToken}
+              title="Guest Availability Link"
+              description="A read-only calendar that shows only which dates are booked vs free — no guest names, notes, or any other detail. Share with past guests when promoting open dates. Screenshot it or send the link directly."
+              icon={Users}
+              generateLabel="Generate Guest Link"
             />
 
             {/* Export Section */}

--- a/src/app/calendar/[token]/_components/public-calendar.tsx
+++ b/src/app/calendar/[token]/_components/public-calendar.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Ban, CheckCircle, Clock, Globe, LogOut, StickyNote, Users } from 'lucide-react';
-import type { PublicMonthData, PublicDayData, PublicDayStatus } from '../_lib/fetch-public-calendar';
+import type { CalendarMode, PublicMonthData, PublicDayData, PublicDayStatus } from '../_lib/fetch-public-calendar';
 
 const RO_MONTHS = ['ianuarie', 'februarie', 'martie', 'aprilie', 'mai', 'iunie', 'iulie', 'august', 'septembrie', 'octombrie', 'noiembrie', 'decembrie'];
 const WEEKDAY_HEADERS = ['L', 'M', 'M', 'J', 'V', 'S', 'D'];
@@ -14,6 +14,7 @@ const STATUS_BG: Record<PublicDayStatus, string> = {
   'on-hold': 'bg-amber-50',
   'external-block': 'bg-blue-50',
   'manual-block': 'bg-slate-100',
+  unavailable: 'bg-slate-300', // anonymized view only; styled directly in DayCell
 };
 
 interface BarSegment {
@@ -120,21 +121,31 @@ function computeBarSegments(week: (number | null)[], bookings: Map<string, Booki
   return segments;
 }
 
-export function PublicCalendar({ months }: { months: PublicMonthData[] }) {
+export function PublicCalendar({ months, mode = 'full' }: { months: PublicMonthData[]; mode?: CalendarMode }) {
   const today = new Date();
   const todayBucharestStr = new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Bucharest' }).format(today);
   const [todayY, todayM, todayD] = todayBucharestStr.split('-').map(Number);
 
   return (
     <div className="space-y-5">
+      {mode === 'anonymized' && (
+        <div className="flex items-center justify-center gap-4 text-[11px] text-slate-600">
+          <span className="flex items-center gap-1.5">
+            <span className="h-3 w-3 rounded-sm bg-slate-300 border border-slate-400" /> Rezervat
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="h-3 w-3 rounded-sm bg-white border border-slate-300" /> Liber
+          </span>
+        </div>
+      )}
       {months.map(monthData => (
-        <MonthBlock key={monthData.month} monthData={monthData} todayY={todayY} todayM={todayM} todayD={todayD} />
+        <MonthBlock key={monthData.month} monthData={monthData} todayY={todayY} todayM={todayM} todayD={todayD} mode={mode} />
       ))}
     </div>
   );
 }
 
-function MonthBlock({ monthData, todayY, todayM, todayD }: { monthData: PublicMonthData; todayY: number; todayM: number; todayD: number }) {
+function MonthBlock({ monthData, todayY, todayM, todayD, mode }: { monthData: PublicMonthData; todayY: number; todayM: number; todayD: number; mode: CalendarMode }) {
   const [year, month] = monthData.month.split('-').map(Number);
   const date = new Date(year, month - 1, 1);
   const dim = new Date(year, month, 0).getDate();
@@ -179,7 +190,7 @@ function MonthBlock({ monthData, todayY, todayM, todayD }: { monthData: PublicMo
             const dayData = monthData.days[day];
             const isToday = isCurrentMonth && day === todayD;
             const isPast = isCurrentMonth && day < todayD;
-            return <DayCell key={day} dayData={dayData} isToday={isToday} isPast={isPast} />;
+            return <DayCell key={day} dayData={dayData} isToday={isToday} isPast={isPast} mode={mode} />;
           })}
           {weekSegments[wi].map(segment => {
             const roundL = segment.isCheckIn ? 'rounded-l-full' : '';
@@ -204,8 +215,28 @@ function MonthBlock({ monthData, todayY, todayM, todayD }: { monthData: PublicMo
   );
 }
 
-function DayCell({ dayData, isToday, isPast }: { dayData: PublicDayData; isToday: boolean; isPast: boolean }) {
+function DayCell({ dayData, isToday, isPast, mode }: { dayData: PublicDayData; isToday: boolean; isPast: boolean; mode: CalendarMode }) {
   const status = dayData.status;
+
+  // Anonymized view: a clean, centered, icon-free cell — booked is filled, free is plain.
+  // No popover, no detail; nothing beyond "taken vs open" is rendered.
+  if (mode === 'anonymized') {
+    const taken = status !== 'available';
+    return (
+      <div className="p-0.5">
+        <div
+          className={`h-12 rounded border flex items-center justify-center select-none ${
+            taken ? 'bg-slate-300 border-slate-400' : 'bg-white border-slate-200'
+          } ${isPast ? 'opacity-40' : ''} ${isToday ? 'ring-2 ring-blue-500' : ''}`}
+        >
+          <span className={`text-[11px] font-semibold ${taken ? 'text-slate-500' : 'text-slate-700'}`}>
+            {dayData.day}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   const config = STATUS_BG[status];
   const hasPopover = dayData.bookingDetails || dayData.checkoutBooking || status === 'external-block';
 

--- a/src/app/calendar/[token]/_lib/fetch-public-calendar.ts
+++ b/src/app/calendar/[token]/_lib/fetch-public-calendar.ts
@@ -1,7 +1,14 @@
 // Public-facing calendar data fetcher. Looks up which property a share token belongs to
-// and returns calendar data with PII filtered for the housekeeping use case:
-//   - Shown: first + last name, persons/adults/children, notes, dates
-//   - Hidden: phone, email, source, payment, amounts, internal IDs
+// and returns calendar data with PII filtered. Two modes, keyed by which token matched:
+//
+//   'full' (shareCalendarToken)        — housekeeping / co-hosts:
+//     - Shown: first + last name, persons/adults/children, notes, dates
+//     - Hidden: phone, email, source, payment, amounts, internal IDs
+//
+//   'anonymized' (guestCalendarToken)  — previous guests / marketing:
+//     - Shown: ONLY whether each day is booked or available
+//     - Hidden: everything else — names, notes, counts, dates, source, the lot
+//       (booking details are never attached to the response in this mode)
 //
 // Auth is the URL token alone — no user session.
 
@@ -10,7 +17,9 @@ import { getAdminDb, Timestamp } from '@/lib/firebaseAdminSafe';
 import { formatBucharestDate, iterateBucharestStayDays } from '@/lib/dates/property-times';
 import { getDaysInMonth } from 'date-fns';
 
-export type PublicDayStatus = 'available' | 'booked' | 'on-hold' | 'external-block' | 'manual-block';
+export type CalendarMode = 'full' | 'anonymized';
+
+export type PublicDayStatus = 'available' | 'booked' | 'on-hold' | 'external-block' | 'manual-block' | 'unavailable';
 
 export interface PublicDayData {
   day: number;
@@ -68,28 +77,32 @@ function nightsBetween(checkIn: Date, checkOut: Date): number {
 }
 
 /**
- * Resolve a share token to a property doc. Returns null if no property has this token.
+ * Resolve a share token to a property doc, and decide which view it unlocks.
+ * A token matching `shareCalendarToken` → 'full'; one matching `guestCalendarToken`
+ * → 'anonymized'. Returns null if no property has this token.
  */
-export async function resolvePropertyByToken(token: string): Promise<{ propertyId: string; propertyName: string } | null> {
+export async function resolvePropertyByToken(token: string): Promise<{ propertyId: string; propertyName: string; mode: CalendarMode } | null> {
   if (!token) return null;
   const db = await getAdminDb();
-  const snap = await db.collection('properties')
-    .where('shareCalendarToken', '==', token)
-    .limit(1)
-    .get();
-  if (snap.empty) return null;
-  const doc = snap.docs[0];
+  const [fullSnap, guestSnap] = await Promise.all([
+    db.collection('properties').where('shareCalendarToken', '==', token).limit(1).get(),
+    db.collection('properties').where('guestCalendarToken', '==', token).limit(1).get(),
+  ]);
+  const doc = !fullSnap.empty ? fullSnap.docs[0] : (!guestSnap.empty ? guestSnap.docs[0] : null);
+  if (!doc) return null;
+  const mode: CalendarMode = !fullSnap.empty ? 'full' : 'anonymized';
   const data = doc.data();
   return {
     propertyId: doc.id,
     propertyName: typeof data.name === 'string' ? data.name : 'Property',
+    mode,
   };
 }
 
 /**
  * Fetch public calendar data for a property — current month and N months ahead.
  */
-export async function fetchPublicCalendarData(propertyId: string, propertyName: string, monthsAhead: number = 2): Promise<PublicCalendarData> {
+export async function fetchPublicCalendarData(propertyId: string, propertyName: string, monthsAhead: number = 2, mode: CalendarMode = 'full'): Promise<PublicCalendarData> {
   const db = await getAdminDb();
   const now = new Date();
 
@@ -220,11 +233,18 @@ export async function fetchPublicCalendarData(propertyId: string, propertyName: 
         dayData.status = status;
       }
 
-      days[d] = dayData;
+      // Anonymized view: collapse every unavailable reason into a single 'unavailable'
+      // and drop all booking detail so names/notes/dates never reach the response.
+      if (mode === 'anonymized') {
+        days[d] = { day: d, status: dayData.status === 'available' ? 'available' : 'unavailable' };
+      } else {
+        days[d] = dayData;
+      }
     }
 
-    // Booking position (start/middle/end/single) for booked/on-hold cells, plus checkoutBooking tail
-    for (const b of bookings) {
+    // Booking bars (start/middle/end/single + checkout tail) — full view only.
+    // Anonymized days carry no bookingId, so they render as plain filled cells.
+    if (mode === 'full') for (const b of bookings) {
       let lastDayInMonth = 0;
       for (let d = 1; d <= daysInMonth; d++) {
         if (b.stayDays.has(`${mk}:${d}`)) lastDayInMonth = d;

--- a/src/app/calendar/[token]/page.tsx
+++ b/src/app/calendar/[token]/page.tsx
@@ -13,18 +13,20 @@ export default async function PublicCalendarPage({ params }: PageProps) {
   const property = await resolvePropertyByToken(token);
   if (!property) notFound();
 
-  const data = await fetchPublicCalendarData(property.propertyId, property.propertyName, 2);
+  const data = await fetchPublicCalendarData(property.propertyId, property.propertyName, 2, property.mode);
 
   return (
     <main className="min-h-screen bg-slate-50">
       <header className="bg-white border-b sticky top-0 z-10">
         <div className="max-w-md mx-auto px-4 py-3">
           <h1 className="text-base font-semibold text-slate-900">{data.propertyName}</h1>
-          <p className="text-xs text-muted-foreground">Calendar rezervări</p>
+          <p className="text-xs text-muted-foreground">
+            {property.mode === 'anonymized' ? 'Disponibilitate' : 'Calendar rezervări'}
+          </p>
         </div>
       </header>
       <div className="max-w-md mx-auto px-3 py-4">
-        <PublicCalendar months={data.months} />
+        <PublicCalendar months={data.months} mode={property.mode} />
         <p className="text-[10px] text-center text-muted-foreground mt-6 pb-4">
           Datele se actualizează automat. Reîncărcați pagina pentru cea mai recentă versiune.
         </p>


### PR DESCRIPTION
## What

Adds a second, independent tokenized calendar view for sharing with **past guests** (marketing / re-engagement) — e.g. when occupancy is low and you message previous guests on WhatsApp with open dates.

It reuses the existing `/calendar/[token]` route via a `CalendarMode` (`'full' | 'anonymized'`) keyed by which token matched. The two links are fully independent and rotatable separately.

## Privacy

The anonymized view shows **only booked-vs-free** — it never attaches booking detail to the response, so guest names, notes, counts, dates, and source can't leak. Redaction is by omission, not filtering.

## Changes

- `resolvePropertyByToken` checks both `shareCalendarToken` (full, housekeeping) and `guestCalendarToken` (anonymized, guests) in parallel and reports which matched.
- Anonymized mode collapses every unavailable reason into a single `'unavailable'` status; booking-bar computation is skipped.
- `public-calendar` renders clean booked (filled grey) vs free (plain white) cells with a legend, no icons or popovers — screenshot-ready.
- `generateGuestCalendarToken` server action (gated by `requirePropertyAccess`) writes `guestCalendarToken`.
- `ShareCalendarCard` generalized (title/description/icon/action props); admin Calendar Sync tab now shows both links via one component.

## Notes

- Multi-property safe; no hardcoding.
- No migration needed — `guestCalendarToken` is created on demand via the "Generate Guest Link" button.
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)