### PR TITLE
feat: Growth Engine foundation — data model + Execution Gateway seam (dark-launched)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -198,6 +198,19 @@ env:
 # - variable: META_PIXEL_ID
 # - variable: META_CAPI_ACCESS_TOKEN
 
+# Growth Engine (dark-launched) — see plans/growth-engine.md §0.2
+# The engine is INERT unless GROWTH_ENGINE_ENABLED="true"; and even when enabled,
+# NO message is delivered unless GROWTH_ENGINE_SEND_MODE="live" is ALSO set.
+# Two independent switches must be flipped. Uncomment + set to activate.
+# - variable: GROWTH_ENGINE_ENABLED
+#   value: "false"
+#   availability:
+#     - RUNTIME
+# - variable: GROWTH_ENGINE_SEND_MODE
+#   value: "dry-run"
+#   availability:
+#     - RUNTIME
+
 # Grant access to secrets in Cloud Secret Manager.
 # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
 # - variable: MY_SECRET

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -75,6 +75,31 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "messageLog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "guestId", "order": "ASCENDING" },
+        { "fieldPath": "at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messageLog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "campaignId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messageLog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "guestId", "order": "ASCENDING" },
+        { "fieldPath": "campaignId", "order": "ASCENDING" },
+        { "fieldPath": "templateName", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -212,6 +212,31 @@ service cloud.firestore {
     }
 
     // ============================================================================
+    // Growth Engine Collections (dark-launched — see plans/growth-engine.md §5)
+    // Written exclusively via Admin SDK on the Core plane.
+    // ============================================================================
+
+    match /segments/{segmentId} {
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only
+    }
+
+    match /messageLog/{messageId} {
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (audit trail)
+    }
+
+    match /suppressionList/{entryId} {
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only
+    }
+
+    match /campaigns/{campaignId} {
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only
+    }
+
+    // ============================================================================
     // App Config
     // ============================================================================
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -222,12 +222,14 @@ service cloud.firestore {
     }
 
     match /messageLog/{messageId} {
-      allow read: if isSuperAdmin() || isPropertyOwner();
+      // Audit trail carrying guest identifiers — super-admin only (M4).
+      allow read: if isSuperAdmin();
       allow write: if false;  // Admin SDK only (audit trail)
     }
 
     match /suppressionList/{entryId} {
-      allow read: if isSuperAdmin() || isPropertyOwner();
+      // Holds raw phone/email PII — super-admin only (M4).
+      allow read: if isSuperAdmin();
       allow write: if false;  // Admin SDK only
     }
 

--- a/src/config/__tests__/growth-engine.test.ts
+++ b/src/config/__tests__/growth-engine.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+import { isGrowthEngineEnabled, getSendMode, isLiveSendAllowed } from '../growth-engine';
+
+/**
+ * The two-switch safety matrix: NOTHING is live unless BOTH
+ * GROWTH_ENGINE_ENABLED=true and GROWTH_ENGINE_SEND_MODE=live are set, with
+ * strict string equality so any fuzzy value fails toward dry-run.
+ */
+describe('growth-engine flags — two-switch safety matrix', () => {
+  const orig = { ...process.env };
+  afterEach(() => {
+    process.env = { ...orig };
+  });
+
+  it('defaults to dry-run when nothing is set', () => {
+    delete process.env.GROWTH_ENGINE_ENABLED;
+    delete process.env.GROWTH_ENGINE_SEND_MODE;
+    expect(isGrowthEngineEnabled()).toBe(false);
+    expect(getSendMode()).toBe('dry-run');
+    expect(isLiveSendAllowed()).toBe(false);
+  });
+
+  it('ENABLED alone stays dry-run', () => {
+    process.env.GROWTH_ENGINE_ENABLED = 'true';
+    delete process.env.GROWTH_ENGINE_SEND_MODE;
+    expect(isGrowthEngineEnabled()).toBe(true);
+    expect(getSendMode()).toBe('dry-run');
+  });
+
+  it('SEND_MODE=live alone (engine off) stays dry-run', () => {
+    delete process.env.GROWTH_ENGINE_ENABLED;
+    process.env.GROWTH_ENGINE_SEND_MODE = 'live';
+    expect(getSendMode()).toBe('dry-run');
+  });
+
+  it('both switches on → live', () => {
+    process.env.GROWTH_ENGINE_ENABLED = 'true';
+    process.env.GROWTH_ENGINE_SEND_MODE = 'live';
+    expect(getSendMode()).toBe('live');
+    expect(isLiveSendAllowed()).toBe(true);
+  });
+
+  it('fuzzy values fail safe (strict equality)', () => {
+    process.env.GROWTH_ENGINE_ENABLED = 'TRUE';
+    process.env.GROWTH_ENGINE_SEND_MODE = 'live';
+    expect(getSendMode()).toBe('dry-run');
+
+    process.env.GROWTH_ENGINE_ENABLED = 'true';
+    process.env.GROWTH_ENGINE_SEND_MODE = 'LIVE ';
+    expect(getSendMode()).toBe('dry-run');
+
+    process.env.GROWTH_ENGINE_ENABLED = '1';
+    process.env.GROWTH_ENGINE_SEND_MODE = 'live';
+    expect(getSendMode()).toBe('dry-run');
+  });
+});

--- a/src/config/growth-engine.ts
+++ b/src/config/growth-engine.ts
@@ -1,0 +1,45 @@
+/**
+ * Growth Engine runtime configuration & dark-launch flags.
+ *
+ * Everything defaults to OFF / dry-run: the engine is inert in production until
+ * `GROWTH_ENGINE_ENABLED=true` is set at deploy time, and NO real message is
+ * ever delivered until `GROWTH_ENGINE_SEND_MODE=live` is ALSO set. This is the
+ * safety model from plans/growth-engine.md §0.2 — a stray env var alone cannot
+ * message a real guest.
+ *
+ * Plain module (not `'use server'`) so it can export constants and be imported
+ * by both server services and (flag reads only) client code.
+ */
+
+export type SendMode = 'dry-run' | 'live';
+
+/** Master kill switch. Default OFF — requires a deploy-time env var to enable. */
+export function isGrowthEngineEnabled(): boolean {
+  return process.env.GROWTH_ENGINE_ENABLED === 'true';
+}
+
+/**
+ * Effective send mode. Defaults to 'dry-run'. Only resolves to 'live' when BOTH
+ * the engine is enabled AND `GROWTH_ENGINE_SEND_MODE=live` — two independent
+ * switches must be flipped before anything is delivered.
+ */
+export function getSendMode(): SendMode {
+  if (!isGrowthEngineEnabled()) return 'dry-run';
+  return process.env.GROWTH_ENGINE_SEND_MODE === 'live' ? 'live' : 'dry-run';
+}
+
+/** True only when a real message may be delivered. */
+export function isLiveSendAllowed(): boolean {
+  return getSendMode() === 'live';
+}
+
+/** Delivery guardrails used by campaign sends (all overridable via env). */
+export const GROWTH_ENGINE_LIMITS = {
+  /** Max messages delivered per campaign run. */
+  perRunCap: Number(process.env.GROWTH_ENGINE_PER_RUN_CAP) || 50,
+  /** Delay between deliveries (ms) to protect the WhatsApp sender number. */
+  throttleMs: Number(process.env.GROWTH_ENGINE_THROTTLE_MS) || 1500,
+  /** Quiet hours in property-local time (Europe/Bucharest) — no sends inside. */
+  quietHoursStart: 21,
+  quietHoursEnd: 9,
+} as const;

--- a/src/lib/growth/__tests__/date-utils.test.ts
+++ b/src/lib/growth/__tests__/date-utils.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+import { seasonOf, monthsBetween, parseFirestoreDate } from '../date-utils';
+
+describe('growth/date-utils', () => {
+  describe('seasonOf', () => {
+    it('maps Dec/Jan/Feb to winter', () => {
+      expect(seasonOf(new Date(2026, 11, 15))).toBe('winter');
+      expect(seasonOf(new Date(2026, 0, 15))).toBe('winter');
+      expect(seasonOf(new Date(2026, 1, 15))).toBe('winter');
+    });
+    it('maps the other seasons by month', () => {
+      expect(seasonOf(new Date(2026, 2, 1))).toBe('spring');
+      expect(seasonOf(new Date(2026, 4, 30))).toBe('spring');
+      expect(seasonOf(new Date(2026, 5, 1))).toBe('summer');
+      expect(seasonOf(new Date(2026, 7, 31))).toBe('summer');
+      expect(seasonOf(new Date(2026, 8, 1))).toBe('autumn');
+      expect(seasonOf(new Date(2026, 10, 30))).toBe('autumn');
+    });
+  });
+
+  describe('monthsBetween', () => {
+    it('counts whole months', () => {
+      expect(monthsBetween(new Date(2025, 0, 15), new Date(2026, 0, 15))).toBe(12);
+      expect(monthsBetween(new Date(2026, 0, 15), new Date(2026, 3, 15))).toBe(3);
+    });
+    it('does not count a partial final month', () => {
+      expect(monthsBetween(new Date(2026, 0, 15), new Date(2026, 3, 10))).toBe(2);
+    });
+    it('is 0 for the same date', () => {
+      expect(monthsBetween(new Date(2026, 0, 15), new Date(2026, 0, 15))).toBe(0);
+    });
+  });
+
+  describe('parseFirestoreDate', () => {
+    it('parses a serialized {_seconds} object', () => {
+      expect(parseFirestoreDate({ _seconds: 1700000000 })?.getTime()).toBe(1700000000 * 1000);
+    });
+    it('parses a Timestamp-like object via toDate()', () => {
+      const d = new Date(2026, 0, 1);
+      expect(parseFirestoreDate({ toDate: () => d })).toBe(d);
+    });
+    it('parses ISO strings and Date instances', () => {
+      expect(parseFirestoreDate('2026-01-01')?.getFullYear()).toBe(2026);
+      const d = new Date();
+      expect(parseFirestoreDate(d)).toBe(d);
+    });
+    it('returns null for junk', () => {
+      expect(parseFirestoreDate(null)).toBeNull();
+      expect(parseFirestoreDate(undefined)).toBeNull();
+      expect(parseFirestoreDate('not-a-date')).toBeNull();
+      expect(parseFirestoreDate(123 as unknown)).toBeNull();
+    });
+  });
+});

--- a/src/lib/growth/__tests__/date-utils.test.ts
+++ b/src/lib/growth/__tests__/date-utils.test.ts
@@ -2,32 +2,32 @@
 import { seasonOf, monthsBetween, parseFirestoreDate } from '../date-utils';
 
 describe('growth/date-utils', () => {
-  describe('seasonOf', () => {
+  describe('seasonOf (UTC-deterministic)', () => {
     it('maps Dec/Jan/Feb to winter', () => {
-      expect(seasonOf(new Date(2026, 11, 15))).toBe('winter');
-      expect(seasonOf(new Date(2026, 0, 15))).toBe('winter');
-      expect(seasonOf(new Date(2026, 1, 15))).toBe('winter');
+      expect(seasonOf(new Date(Date.UTC(2026, 11, 15)))).toBe('winter');
+      expect(seasonOf(new Date(Date.UTC(2026, 0, 15)))).toBe('winter');
+      expect(seasonOf(new Date(Date.UTC(2026, 1, 15)))).toBe('winter');
     });
     it('maps the other seasons by month', () => {
-      expect(seasonOf(new Date(2026, 2, 1))).toBe('spring');
-      expect(seasonOf(new Date(2026, 4, 30))).toBe('spring');
-      expect(seasonOf(new Date(2026, 5, 1))).toBe('summer');
-      expect(seasonOf(new Date(2026, 7, 31))).toBe('summer');
-      expect(seasonOf(new Date(2026, 8, 1))).toBe('autumn');
-      expect(seasonOf(new Date(2026, 10, 30))).toBe('autumn');
+      expect(seasonOf(new Date(Date.UTC(2026, 2, 1)))).toBe('spring');
+      expect(seasonOf(new Date(Date.UTC(2026, 4, 30)))).toBe('spring');
+      expect(seasonOf(new Date(Date.UTC(2026, 5, 1)))).toBe('summer');
+      expect(seasonOf(new Date(Date.UTC(2026, 7, 31)))).toBe('summer');
+      expect(seasonOf(new Date(Date.UTC(2026, 8, 1)))).toBe('autumn');
+      expect(seasonOf(new Date(Date.UTC(2026, 10, 30)))).toBe('autumn');
     });
   });
 
-  describe('monthsBetween', () => {
+  describe('monthsBetween (UTC-deterministic)', () => {
     it('counts whole months', () => {
-      expect(monthsBetween(new Date(2025, 0, 15), new Date(2026, 0, 15))).toBe(12);
-      expect(monthsBetween(new Date(2026, 0, 15), new Date(2026, 3, 15))).toBe(3);
+      expect(monthsBetween(new Date(Date.UTC(2025, 0, 15)), new Date(Date.UTC(2026, 0, 15)))).toBe(12);
+      expect(monthsBetween(new Date(Date.UTC(2026, 0, 15)), new Date(Date.UTC(2026, 3, 15)))).toBe(3);
     });
     it('does not count a partial final month', () => {
-      expect(monthsBetween(new Date(2026, 0, 15), new Date(2026, 3, 10))).toBe(2);
+      expect(monthsBetween(new Date(Date.UTC(2026, 0, 15)), new Date(Date.UTC(2026, 3, 10)))).toBe(2);
     });
     it('is 0 for the same date', () => {
-      expect(monthsBetween(new Date(2026, 0, 15), new Date(2026, 0, 15))).toBe(0);
+      expect(monthsBetween(new Date(Date.UTC(2026, 0, 15)), new Date(Date.UTC(2026, 0, 15)))).toBe(0);
     });
   });
 
@@ -36,11 +36,11 @@ describe('growth/date-utils', () => {
       expect(parseFirestoreDate({ _seconds: 1700000000 })?.getTime()).toBe(1700000000 * 1000);
     });
     it('parses a Timestamp-like object via toDate()', () => {
-      const d = new Date(2026, 0, 1);
+      const d = new Date(Date.UTC(2026, 0, 1));
       expect(parseFirestoreDate({ toDate: () => d })).toBe(d);
     });
     it('parses ISO strings and Date instances', () => {
-      expect(parseFirestoreDate('2026-01-01')?.getFullYear()).toBe(2026);
+      expect(parseFirestoreDate('2026-01-01')?.getUTCFullYear()).toBe(2026);
       const d = new Date();
       expect(parseFirestoreDate(d)).toBe(d);
     });

--- a/src/lib/growth/date-utils.ts
+++ b/src/lib/growth/date-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Date helpers for the Growth Engine segment logic.
+ *
+ * Dependency-free and pure (duck-types Firestore Timestamps rather than
+ * importing the Admin/Client SDK) so it is unit-testable and safe to import
+ * from either runtime.
+ */
+import type { Season } from '@/types';
+
+/**
+ * Parse a Firestore date field that may be an Admin/Client Timestamp,
+ * a serialized `{_seconds}` object, a Date, or an ISO string.
+ */
+export function parseFirestoreDate(raw: unknown): Date | null {
+  if (!raw) return null;
+  if (raw instanceof Date) return isNaN(raw.getTime()) ? null : raw;
+  if (typeof raw === 'object' && raw !== null) {
+    const o = raw as { toDate?: () => Date; _seconds?: number };
+    if (typeof o.toDate === 'function') {
+      const d = o.toDate();
+      return isNaN(d.getTime()) ? null : d;
+    }
+    if (typeof o._seconds === 'number') return new Date(o._seconds * 1000);
+  }
+  if (typeof raw === 'string') {
+    const d = new Date(raw);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+/** Northern-hemisphere meteorological season of a date (Romania). */
+export function seasonOf(date: Date): Season {
+  const m = date.getMonth(); // 0-11
+  if (m === 11 || m <= 1) return 'winter'; // Dec, Jan, Feb
+  if (m <= 4) return 'spring';             // Mar, Apr, May
+  if (m <= 7) return 'summer';             // Jun, Jul, Aug
+  return 'autumn';                          // Sep, Oct, Nov
+}
+
+/**
+ * Whole calendar months from `from` to `to` (>= 0 when `to` is later).
+ * Not yet a full month if `to`'s day-of-month is before `from`'s.
+ */
+export function monthsBetween(from: Date, to: Date): number {
+  let months =
+    (to.getFullYear() - from.getFullYear()) * 12 + (to.getMonth() - from.getMonth());
+  if (to.getDate() < from.getDate()) months -= 1;
+  return months;
+}

--- a/src/lib/growth/date-utils.ts
+++ b/src/lib/growth/date-utils.ts
@@ -29,9 +29,14 @@ export function parseFirestoreDate(raw: unknown): Date | null {
   return null;
 }
 
-/** Northern-hemisphere meteorological season of a date (Romania). */
+/**
+ * Northern-hemisphere meteorological season of a date (Romania).
+ * Uses UTC getters so classification is deterministic regardless of the host
+ * timezone — matching this project's hard-won lesson that local-time date math
+ * shifts by a day in non-UTC environments (L1).
+ */
 export function seasonOf(date: Date): Season {
-  const m = date.getMonth(); // 0-11
+  const m = date.getUTCMonth(); // 0-11
   if (m === 11 || m <= 1) return 'winter'; // Dec, Jan, Feb
   if (m <= 4) return 'spring';             // Mar, Apr, May
   if (m <= 7) return 'summer';             // Jun, Jul, Aug
@@ -40,11 +45,11 @@ export function seasonOf(date: Date): Season {
 
 /**
  * Whole calendar months from `from` to `to` (>= 0 when `to` is later).
- * Not yet a full month if `to`'s day-of-month is before `from`'s.
+ * Not yet a full month if `to`'s day-of-month is before `from`'s. UTC-based (L1).
  */
 export function monthsBetween(from: Date, to: Date): number {
   let months =
-    (to.getFullYear() - from.getFullYear()) * 12 + (to.getMonth() - from.getMonth());
-  if (to.getDate() < from.getDate()) months -= 1;
+    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+  if (to.getUTCDate() < from.getUTCDate()) months -= 1;
   return months;
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -415,6 +415,10 @@ export const loggers = {
   housekeeping: createLogger('housekeeping'),
   contentData: createLogger('content:data'),
   contentGeneration: createLogger('content:generation'),
+  // Growth Engine (dark-launched)
+  campaign: createLogger('campaign'),
+  segment: createLogger('segment'),
+  executionGateway: createLogger('execution:gateway'),
 };
 
 // Type-safe logger categories

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -1,35 +1,42 @@
 /** @jest-environment node */
 
-// Mock the Admin SDK and guest lookup BEFORE importing the module under test.
+// Mock the Admin SDK, guest lookup, and WhatsApp provider BEFORE importing the SUT.
 jest.mock('@/lib/firebaseAdminSafe', () => ({
   getAdminDb: jest.fn(),
   FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
 }));
 jest.mock('@/services/guestService', () => ({ getGuestById: jest.fn() }));
+jest.mock('@/services/whatsappService', () => ({
+  sendWhatsAppTemplate: jest.fn().mockResolvedValue({ success: true, sid: 'SM-1' }),
+  WHATSAPP_TEMPLATES: { winter_invite: 'HX-test' },
+}));
 
 import { executeSend, isConsentBlocked, maskContact } from '../executionGateway';
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { getGuestById } from '@/services/guestService';
+import { sendWhatsAppTemplate } from '@/services/whatsappService';
 import type { Guest } from '@/types';
 
 const mockGetAdminDb = getAdminDb as jest.Mock;
 const mockGetGuestById = getGuestById as jest.Mock;
+const mockSendWhatsApp = sendWhatsAppTemplate as jest.Mock;
 
-/** Build a chainable Firestore mock; `suppressed` toggles the suppressionList hit. */
-function makeDb({ suppressed = false }: { suppressed?: boolean } = {}) {
+function chainableGet(result: unknown) {
+  const q: Record<string, jest.Mock> = {};
+  q.where = jest.fn(() => q);
+  q.limit = jest.fn(() => q);
+  q.get = jest.fn().mockResolvedValue(result);
+  return q;
+}
+
+/** Chainable Firestore mock; toggles suppressionList hit and prior-delivery dedup. */
+function makeDb({ suppressed = false, priorDelivered = false }: { suppressed?: boolean; priorDelivered?: boolean } = {}) {
   const addMock = jest.fn().mockResolvedValue({ id: 'log-123' });
-  const query: Record<string, jest.Mock> = {
-    where: jest.fn(),
-    limit: jest.fn(),
-    get: jest.fn().mockResolvedValue({ empty: !suppressed }),
-  };
-  query.where.mockReturnValue(query);
-  query.limit.mockReturnValue(query);
+  const suppressionQuery = chainableGet({ empty: !suppressed });
+  const messageLogQuery = chainableGet({ docs: priorDelivered ? [{ data: () => ({ status: 'sent' }) }] : [] });
+  const messageLogCol = { add: addMock, where: messageLogQuery.where };
   const db = {
-    collection: jest.fn((name: string) => {
-      if (name === 'messageLog') return { add: addMock };
-      return query; // suppressionList
-    }),
+    collection: jest.fn((name: string) => (name === 'messageLog' ? messageLogCol : suppressionQuery)),
   };
   return { db, addMock };
 }
@@ -57,9 +64,11 @@ function guest(overrides: Partial<Guest> = {}): Guest {
 }
 
 beforeEach(() => {
-  // Ensure DARK LAUNCH default (both switches off) for every test.
+  // Enforce DARK LAUNCH default (both switches off) for every test unless overridden.
   delete process.env.GROWTH_ENGINE_ENABLED;
   delete process.env.GROWTH_ENGINE_SEND_MODE;
+  mockSendWhatsApp.mockClear();
+  mockSendWhatsApp.mockResolvedValue({ success: true, sid: 'SM-1' });
 });
 
 describe('executionGateway pure helpers', () => {
@@ -67,7 +76,6 @@ describe('executionGateway pure helpers', () => {
     expect(isConsentBlocked({ unsubscribed: true }, 'whatsapp')).toBe(true);
     expect(isConsentBlocked({ unsubscribed: false, channelConsent: { whatsapp: 'opted_out' } }, 'whatsapp')).toBe(true);
     expect(isConsentBlocked({ unsubscribed: false, channelConsent: { whatsapp: 'opted_in' } }, 'whatsapp')).toBe(false);
-    // unknown/absent consent is allowed (owner call §0.2.1)
     expect(isConsentBlocked({ unsubscribed: false }, 'whatsapp')).toBe(false);
     expect(isConsentBlocked({ unsubscribed: false, channelConsent: { email: 'opted_out' } }, 'whatsapp')).toBe(false);
   });
@@ -77,14 +85,15 @@ describe('executionGateway pure helpers', () => {
   });
 });
 
-describe('executeSend — dark-launch safety', () => {
-  it('defaults to dry-run (records intent, delivers nothing)', async () => {
+describe('executeSend — dark-launch safety (default)', () => {
+  it('defaults to dry-run: records intent, delivers nothing', async () => {
     const { db, addMock } = makeDb();
     mockGetAdminDb.mockResolvedValue(db);
     mockGetGuestById.mockResolvedValue(guest());
 
     const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
 
+    expect(mockSendWhatsApp).not.toHaveBeenCalled();
     expect(res.status).toBe('dry-run');
     expect(res.mode).toBe('dry-run');
     expect(addMock).toHaveBeenCalledTimes(1);
@@ -103,7 +112,7 @@ describe('executeSend — dark-launch safety', () => {
   });
 
   it('suppresses guests on the suppression list', async () => {
-    const { db, addMock } = makeDb({ suppressed: true });
+    const { db } = makeDb({ suppressed: true });
     mockGetAdminDb.mockResolvedValue(db);
     mockGetGuestById.mockResolvedValue(guest());
 
@@ -130,5 +139,57 @@ describe('executeSend — dark-launch safety', () => {
     const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
     expect(res.status).toBe('skipped');
     expect(res.reason).toBe('no-contact-for-channel');
+  });
+});
+
+describe('executeSend — live mode (both switches on)', () => {
+  beforeEach(() => {
+    process.env.GROWTH_ENGINE_ENABLED = 'true';
+    process.env.GROWTH_ENGINE_SEND_MODE = 'live';
+  });
+
+  it('delivers via WhatsApp and logs sent', async () => {
+    const { db, addMock } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite', campaignId: 'c1' });
+
+    expect(mockSendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe('sent');
+    expect(res.mode).toBe('live');
+    expect(res.providerId).toBe('SM-1');
+    expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ status: 'sent', providerId: 'SM-1' });
+  });
+
+  it('logs failed (not delivered) when the provider reports failure', async () => {
+    mockSendWhatsApp.mockResolvedValue({ success: false, error: 'twilio boom' });
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('failed');
+    expect(res.reason).toBe('twilio boom');
+  });
+
+  it('dedups an already-delivered campaign template (M1)', async () => {
+    const { db } = makeDb({ priorDelivered: true });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite', campaignId: 'c1' });
+    expect(mockSendWhatsApp).not.toHaveBeenCalled();
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('dedup');
+  });
+
+  it('does NOT dedup when there is no campaignId (lifecycle sends)', async () => {
+    const { db } = makeDb({ priorDelivered: true }); // prior exists but request carries no campaignId
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('sent');
   });
 });

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -1,0 +1,134 @@
+/** @jest-environment node */
+
+// Mock the Admin SDK and guest lookup BEFORE importing the module under test.
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
+}));
+jest.mock('@/services/guestService', () => ({ getGuestById: jest.fn() }));
+
+import { executeSend, isConsentBlocked, maskContact } from '../executionGateway';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { getGuestById } from '@/services/guestService';
+import type { Guest } from '@/types';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockGetGuestById = getGuestById as jest.Mock;
+
+/** Build a chainable Firestore mock; `suppressed` toggles the suppressionList hit. */
+function makeDb({ suppressed = false }: { suppressed?: boolean } = {}) {
+  const addMock = jest.fn().mockResolvedValue({ id: 'log-123' });
+  const query: Record<string, jest.Mock> = {
+    where: jest.fn(),
+    limit: jest.fn(),
+    get: jest.fn().mockResolvedValue({ empty: !suppressed }),
+  };
+  query.where.mockReturnValue(query);
+  query.limit.mockReturnValue(query);
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name === 'messageLog') return { add: addMock };
+      return query; // suppressionList
+    }),
+  };
+  return { db, addMock };
+}
+
+function guest(overrides: Partial<Guest> = {}): Guest {
+  return {
+    id: 'g1',
+    firstName: 'Ana',
+    language: 'en',
+    bookingIds: ['b1'],
+    propertyIds: ['prahova-mountain-chalet'],
+    totalBookings: 1,
+    totalSpent: 1000,
+    currency: 'RON',
+    firstBookingDate: new Date() as unknown as Guest['firstBookingDate'],
+    lastBookingDate: new Date() as unknown as Guest['lastBookingDate'],
+    reviewSubmitted: false,
+    tags: [],
+    unsubscribed: false,
+    normalizedPhone: '+40712345678',
+    createdAt: new Date() as unknown as Guest['createdAt'],
+    updatedAt: new Date() as unknown as Guest['updatedAt'],
+    ...overrides,
+  } as Guest;
+}
+
+beforeEach(() => {
+  // Ensure DARK LAUNCH default (both switches off) for every test.
+  delete process.env.GROWTH_ENGINE_ENABLED;
+  delete process.env.GROWTH_ENGINE_SEND_MODE;
+});
+
+describe('executionGateway pure helpers', () => {
+  it('isConsentBlocked blocks unsubscribed and explicit opt-out only', () => {
+    expect(isConsentBlocked({ unsubscribed: true }, 'whatsapp')).toBe(true);
+    expect(isConsentBlocked({ unsubscribed: false, channelConsent: { whatsapp: 'opted_out' } }, 'whatsapp')).toBe(true);
+    expect(isConsentBlocked({ unsubscribed: false, channelConsent: { whatsapp: 'opted_in' } }, 'whatsapp')).toBe(false);
+    // unknown/absent consent is allowed (owner call §0.2.1)
+    expect(isConsentBlocked({ unsubscribed: false }, 'whatsapp')).toBe(false);
+    expect(isConsentBlocked({ unsubscribed: false, channelConsent: { email: 'opted_out' } }, 'whatsapp')).toBe(false);
+  });
+  it('maskContact never leaks the full contact', () => {
+    expect(maskContact('+40712345678')).toBe('+40712***');
+    expect(maskContact('a@b.co')).toBe('a***');
+  });
+});
+
+describe('executeSend — dark-launch safety', () => {
+  it('defaults to dry-run (records intent, delivers nothing)', async () => {
+    const { db, addMock } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+
+    expect(res.status).toBe('dry-run');
+    expect(res.mode).toBe('dry-run');
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock.mock.calls[0][0]).toMatchObject({ status: 'dry-run', to: '+40712***' });
+  });
+
+  it('suppresses unsubscribed guests', async () => {
+    const { db, addMock } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ unsubscribed: true }));
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('consent-or-unsubscribed');
+    expect(addMock.mock.calls[0][0]).toMatchObject({ status: 'suppressed' });
+  });
+
+  it('suppresses guests on the suppression list', async () => {
+    const { db, addMock } = makeDb({ suppressed: true });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('suppressed');
+    expect(res.reason).toBe('suppression-list');
+  });
+
+  it('skips when the guest is not found', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(null);
+
+    const res = await executeSend({ guestId: 'missing', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('guest-not-found');
+  });
+
+  it('skips when there is no contact for the channel', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ normalizedPhone: undefined, phone: undefined, email: undefined }));
+
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('no-contact-for-channel');
+  });
+});

--- a/src/services/__tests__/segmentService.test.ts
+++ b/src/services/__tests__/segmentService.test.ts
@@ -12,8 +12,8 @@ function guest(overrides: Partial<Guest> = {}): Guest {
     totalBookings: 1,
     totalSpent: 1000,
     currency: 'RON',
-    firstBookingDate: new Date(2024, 0, 1) as unknown as Guest['firstBookingDate'],
-    lastBookingDate: new Date(2025, 0, 1) as unknown as Guest['lastBookingDate'],
+    firstBookingDate: new Date(Date.UTC(2024, 0, 1)) as unknown as Guest['firstBookingDate'],
+    lastBookingDate: new Date(Date.UTC(2025, 0, 1)) as unknown as Guest['lastBookingDate'],
     reviewSubmitted: false,
     tags: [],
     unsubscribed: false,
@@ -23,7 +23,7 @@ function guest(overrides: Partial<Guest> = {}): Guest {
   } as Guest;
 }
 
-const NOW = new Date(2026, 0, 1); // fixed reference
+const NOW = new Date(Date.UTC(2026, 0, 1)); // fixed reference
 
 describe('segmentService.resolveChannel', () => {
   it('prefers WhatsApp when a phone exists', () => {
@@ -39,10 +39,8 @@ describe('segmentService.resolveChannel', () => {
 });
 
 describe('segmentService.matchesDefinition', () => {
-  it('excludes unsubscribed guests by default', () => {
+  it('excludes unsubscribed by default, includes when opted out of exclusion', () => {
     expect(matchesDefinition(guest({ unsubscribed: true }), {}, NOW)).toBe(false);
-  });
-  it('includes unsubscribed when excludeUnsubscribed is false', () => {
     expect(matchesDefinition(guest({ unsubscribed: true }), { excludeUnsubscribed: false }, NOW)).toBe(true);
   });
   it('filters by propertyId', () => {
@@ -54,18 +52,22 @@ describe('segmentService.matchesDefinition', () => {
     expect(matchesDefinition(guest({ totalBookings: 1 }), { minTotalBookings: 2 }, NOW)).toBe(false);
     expect(matchesDefinition(guest({ totalBookings: 3 }), { minTotalBookings: 2 }, NOW)).toBe(true);
   });
-  it('filters by countryIn / countryNotIn', () => {
+  it('filters by countryIn (requires a known country)', () => {
     expect(matchesDefinition(guest({ country: 'RO' }), { countryIn: ['RO'] }, NOW)).toBe(true);
     expect(matchesDefinition(guest({ country: 'IL' }), { countryIn: ['RO'] }, NOW)).toBe(false);
-    expect(matchesDefinition(guest({ country: 'RO' }), { countryNotIn: ['RO'] }, NOW)).toBe(false);
+    expect(matchesDefinition(guest({ country: undefined }), { countryIn: ['RO'] }, NOW)).toBe(false);
+  });
+  it('countryNotIn requires a KNOWN country — unknown is NOT foreign (M3)', () => {
     expect(matchesDefinition(guest({ country: 'IL' }), { countryNotIn: ['RO'] }, NOW)).toBe(true);
+    expect(matchesDefinition(guest({ country: 'RO' }), { countryNotIn: ['RO'] }, NOW)).toBe(false);
+    expect(matchesDefinition(guest({ country: undefined }), { countryNotIn: ['RO'] }, NOW)).toBe(false);
   });
   it('requires a phone for hasChannel whatsapp', () => {
     expect(matchesDefinition(guest({ normalizedPhone: '+40712345678', email: undefined }), { hasChannel: 'whatsapp' }, NOW)).toBe(true);
     expect(matchesDefinition(guest({ normalizedPhone: undefined, phone: undefined, email: 'a@b.com' }), { hasChannel: 'whatsapp' }, NOW)).toBe(false);
   });
   it('filters by lastStaySeason', () => {
-    const winterStay = guest({ lastStayDate: new Date(2025, 0, 15) as unknown as Guest['lastStayDate'] });
+    const winterStay = guest({ lastStayDate: new Date(Date.UTC(2025, 0, 15)) as unknown as Guest['lastStayDate'] });
     expect(matchesDefinition(winterStay, { lastStaySeason: ['winter'] }, NOW)).toBe(true);
     expect(matchesDefinition(winterStay, { lastStaySeason: ['summer'] }, NOW)).toBe(false);
   });
@@ -89,6 +91,7 @@ describe('segmentService.PREDEFINED_SEGMENTS', () => {
   it('builds coherent definitions', () => {
     expect(PREDEFINED_SEGMENTS.repeatGuests('p1')).toEqual({ minTotalBookings: 2, propertyId: 'p1' });
     expect(PREDEFINED_SEGMENTS.romanian()).toEqual({ countryIn: ['RO'], propertyId: undefined });
+    expect(PREDEFINED_SEGMENTS.foreign('p1')).toEqual({ countryNotIn: ['RO'], propertyId: 'p1' });
     expect(PREDEFINED_SEGMENTS.lastStayedInSeason('winter', 'p1')).toEqual({ lastStaySeason: ['winter'], propertyId: 'p1' });
   });
 });

--- a/src/services/__tests__/segmentService.test.ts
+++ b/src/services/__tests__/segmentService.test.ts
@@ -1,0 +1,94 @@
+/** @jest-environment node */
+import { matchesDefinition, resolveChannel, PREDEFINED_SEGMENTS } from '../segmentService';
+import type { Guest } from '@/types';
+
+function guest(overrides: Partial<Guest> = {}): Guest {
+  return {
+    id: 'g1',
+    firstName: 'Test',
+    language: 'en',
+    bookingIds: ['b1'],
+    propertyIds: ['prahova-mountain-chalet'],
+    totalBookings: 1,
+    totalSpent: 1000,
+    currency: 'RON',
+    firstBookingDate: new Date(2024, 0, 1) as unknown as Guest['firstBookingDate'],
+    lastBookingDate: new Date(2025, 0, 1) as unknown as Guest['lastBookingDate'],
+    reviewSubmitted: false,
+    tags: [],
+    unsubscribed: false,
+    createdAt: new Date() as unknown as Guest['createdAt'],
+    updatedAt: new Date() as unknown as Guest['updatedAt'],
+    ...overrides,
+  } as Guest;
+}
+
+const NOW = new Date(2026, 0, 1); // fixed reference
+
+describe('segmentService.resolveChannel', () => {
+  it('prefers WhatsApp when a phone exists', () => {
+    expect(resolveChannel({ normalizedPhone: '+40712345678' })).toBe('whatsapp');
+    expect(resolveChannel({ phone: '0712345678' })).toBe('whatsapp');
+  });
+  it('falls back to email', () => {
+    expect(resolveChannel({ email: 'a@b.com' })).toBe('email');
+  });
+  it('returns null when unreachable', () => {
+    expect(resolveChannel({})).toBeNull();
+  });
+});
+
+describe('segmentService.matchesDefinition', () => {
+  it('excludes unsubscribed guests by default', () => {
+    expect(matchesDefinition(guest({ unsubscribed: true }), {}, NOW)).toBe(false);
+  });
+  it('includes unsubscribed when excludeUnsubscribed is false', () => {
+    expect(matchesDefinition(guest({ unsubscribed: true }), { excludeUnsubscribed: false }, NOW)).toBe(true);
+  });
+  it('filters by propertyId', () => {
+    const def = { propertyId: 'prahova-mountain-chalet' };
+    expect(matchesDefinition(guest(), def, NOW)).toBe(true);
+    expect(matchesDefinition(guest({ propertyIds: ['other'] }), def, NOW)).toBe(false);
+  });
+  it('filters repeat guests by minTotalBookings', () => {
+    expect(matchesDefinition(guest({ totalBookings: 1 }), { minTotalBookings: 2 }, NOW)).toBe(false);
+    expect(matchesDefinition(guest({ totalBookings: 3 }), { minTotalBookings: 2 }, NOW)).toBe(true);
+  });
+  it('filters by countryIn / countryNotIn', () => {
+    expect(matchesDefinition(guest({ country: 'RO' }), { countryIn: ['RO'] }, NOW)).toBe(true);
+    expect(matchesDefinition(guest({ country: 'IL' }), { countryIn: ['RO'] }, NOW)).toBe(false);
+    expect(matchesDefinition(guest({ country: 'RO' }), { countryNotIn: ['RO'] }, NOW)).toBe(false);
+    expect(matchesDefinition(guest({ country: 'IL' }), { countryNotIn: ['RO'] }, NOW)).toBe(true);
+  });
+  it('requires a phone for hasChannel whatsapp', () => {
+    expect(matchesDefinition(guest({ normalizedPhone: '+40712345678', email: undefined }), { hasChannel: 'whatsapp' }, NOW)).toBe(true);
+    expect(matchesDefinition(guest({ normalizedPhone: undefined, phone: undefined, email: 'a@b.com' }), { hasChannel: 'whatsapp' }, NOW)).toBe(false);
+  });
+  it('filters by lastStaySeason', () => {
+    const winterStay = guest({ lastStayDate: new Date(2025, 0, 15) as unknown as Guest['lastStayDate'] });
+    expect(matchesDefinition(winterStay, { lastStaySeason: ['winter'] }, NOW)).toBe(true);
+    expect(matchesDefinition(winterStay, { lastStaySeason: ['summer'] }, NOW)).toBe(false);
+  });
+  it('filters by monthsSinceLastBooking', () => {
+    // lastBookingDate = 2025-01-01, NOW = 2026-01-01 => 12 months
+    expect(matchesDefinition(guest(), { monthsSinceLastBooking: { min: 6 } }, NOW)).toBe(true);
+    expect(matchesDefinition(guest(), { monthsSinceLastBooking: { max: 6 } }, NOW)).toBe(false);
+  });
+  it('filters by tagsInclude', () => {
+    expect(matchesDefinition(guest({ tags: ['vip'] }), { tagsInclude: ['vip'] }, NOW)).toBe(true);
+    expect(matchesDefinition(guest({ tags: [] }), { tagsInclude: ['vip'] }, NOW)).toBe(false);
+  });
+  it('ANDs multiple conditions', () => {
+    const g = guest({ country: 'RO', totalBookings: 2, normalizedPhone: '+40712345678' });
+    expect(matchesDefinition(g, { countryIn: ['RO'], minTotalBookings: 2, hasChannel: 'whatsapp' }, NOW)).toBe(true);
+    expect(matchesDefinition(g, { countryIn: ['RO'], minTotalBookings: 5 }, NOW)).toBe(false);
+  });
+});
+
+describe('segmentService.PREDEFINED_SEGMENTS', () => {
+  it('builds coherent definitions', () => {
+    expect(PREDEFINED_SEGMENTS.repeatGuests('p1')).toEqual({ minTotalBookings: 2, propertyId: 'p1' });
+    expect(PREDEFINED_SEGMENTS.romanian()).toEqual({ countryIn: ['RO'], propertyId: undefined });
+    expect(PREDEFINED_SEGMENTS.lastStayedInSeason('winter', 'p1')).toEqual({ lastStaySeason: ['winter'], propertyId: 'p1' });
+  });
+});

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -1,0 +1,273 @@
+/**
+ * executionGateway — the single choke point through which every outbound
+ * message flows. It enforces consent + suppression, resolves the contact,
+ * writes an auditable `messageLog` entry, and delivers ONLY when the engine is
+ * live. By default (dark launch) it records a `dry-run` entry describing what
+ * *would* have been sent, and delivers nothing.
+ *
+ * This is the portable "action seam" from plans/growth-engine.md §3/§6.9: v1
+ * runs in-app on Core (secrets are here); a later VM implementation can satisfy
+ * the same interface without changing callers.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + pure helpers.
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { Guest, ChannelType, ConsentState, MessageLogStatus } from '@/types';
+import { getSendMode } from '@/config/growth-engine';
+import { getGuestById } from '@/services/guestService';
+import { normalizePhone } from '@/lib/sanitize';
+
+const logger = loggers.executionGateway;
+
+type AdminDb = Awaited<ReturnType<typeof getAdminDb>>;
+
+export interface SendRequest {
+  guestId: string;
+  channel: ChannelType;
+  templateName: string;
+  variables?: Record<string, string>;
+  campaignId?: string;
+}
+
+export interface SendResult {
+  status: MessageLogStatus;
+  reason?: string;
+  providerId?: string;
+  messageLogId?: string;
+  mode: 'dry-run' | 'live';
+}
+
+/**
+ * Pure: is this channel blocked for the guest by explicit signal?
+ * `unsubscribed` or an explicit `opted_out` block; `unknown`/`opted_in` are
+ * allowed — the owner's call (§0.2.1) that known past guests are in scope.
+ */
+export function isConsentBlocked(
+  guest: Pick<Guest, 'channelConsent' | 'unsubscribed'>,
+  channel: ChannelType
+): boolean {
+  if (guest.unsubscribed) return true;
+  const state: ConsentState | undefined = guest.channelConsent?.[channel];
+  return state === 'opted_out';
+}
+
+/** Mask a phone/email for logging (never store full contact in messageLog). */
+export function maskContact(contact: string): string {
+  if (!contact) return '';
+  return contact.length <= 6 ? `${contact[0]}***` : `${contact.slice(0, 6)}***`;
+}
+
+function resolveContact(guest: Guest, channel: ChannelType): string | null {
+  if (channel === 'whatsapp' || channel === 'sms') {
+    return (
+      guest.normalizedPhone ||
+      (guest.phone ? normalizePhone(guest.phone) : null) ||
+      guest.phone ||
+      null
+    );
+  }
+  if (channel === 'email') return guest.email || null;
+  return null;
+}
+
+/** Hard opt-outs recorded in the suppressionList collection (phone/email). */
+async function isSuppressed(db: AdminDb, guest: Guest): Promise<boolean> {
+  const phone =
+    guest.normalizedPhone || (guest.phone ? normalizePhone(guest.phone) : undefined);
+  const checks: Promise<boolean>[] = [];
+  if (phone) {
+    checks.push(
+      db
+        .collection('suppressionList')
+        .where('normalizedPhone', '==', phone)
+        .limit(1)
+        .get()
+        .then((s) => !s.empty)
+    );
+  }
+  if (guest.email) {
+    checks.push(
+      db
+        .collection('suppressionList')
+        .where('email', '==', guest.email.toLowerCase().trim())
+        .limit(1)
+        .get()
+        .then((s) => !s.empty)
+    );
+  }
+  if (checks.length === 0) return false;
+  return (await Promise.all(checks)).some(Boolean);
+}
+
+interface MessageLogInput {
+  guestId: string;
+  channel: ChannelType;
+  campaignId: string | null;
+  templateName: string | null;
+  variables: Record<string, string> | null;
+  status: MessageLogStatus;
+  reason: string | null;
+  to: string | null;
+  providerId: string | null;
+}
+
+async function writeMessageLog(db: AdminDb, entry: MessageLogInput): Promise<string> {
+  const ref = await db.collection('messageLog').add({
+    ...entry,
+    at: FieldValue.serverTimestamp(),
+  });
+  return ref.id;
+}
+
+/**
+ * Execute (or dry-run) a single outbound message. Every path writes exactly one
+ * messageLog entry so the audit trail is complete regardless of outcome.
+ */
+export async function executeSend(req: SendRequest): Promise<SendResult> {
+  const db = await getAdminDb();
+  const mode = getSendMode();
+  const guest = await getGuestById(req.guestId);
+
+  const base = {
+    guestId: req.guestId,
+    channel: req.channel,
+    campaignId: req.campaignId ?? null,
+    templateName: req.templateName ?? null,
+    variables: req.variables ?? null,
+  };
+
+  if (!guest) {
+    logger.warn('executeSend: guest not found', { guestId: req.guestId });
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'skipped',
+      reason: 'guest-not-found',
+      to: null,
+      providerId: null,
+    });
+    return { status: 'skipped', reason: 'guest-not-found', messageLogId: id, mode };
+  }
+
+  // 1) consent / unsubscribe
+  if (isConsentBlocked(guest, req.channel)) {
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'suppressed',
+      reason: 'consent-or-unsubscribed',
+      to: null,
+      providerId: null,
+    });
+    return { status: 'suppressed', reason: 'consent-or-unsubscribed', messageLogId: id, mode };
+  }
+
+  // 2) hard suppression list
+  if (await isSuppressed(db, guest)) {
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'suppressed',
+      reason: 'suppression-list',
+      to: null,
+      providerId: null,
+    });
+    return { status: 'suppressed', reason: 'suppression-list', messageLogId: id, mode };
+  }
+
+  // 3) resolve a contact for the channel
+  const contact = resolveContact(guest, req.channel);
+  if (!contact) {
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'skipped',
+      reason: 'no-contact-for-channel',
+      to: null,
+      providerId: null,
+    });
+    return { status: 'skipped', reason: 'no-contact-for-channel', messageLogId: id, mode };
+  }
+
+  // 4) DARK LAUNCH: default dry-run — record intent, deliver nothing.
+  if (mode !== 'live') {
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'dry-run',
+      reason: null,
+      to: maskContact(contact),
+      providerId: null,
+    });
+    logger.info('Dry-run send recorded (no delivery)', {
+      guestId: req.guestId,
+      channel: req.channel,
+      template: req.templateName,
+      to: maskContact(contact),
+    });
+    return { status: 'dry-run', messageLogId: id, mode: 'dry-run' };
+  }
+
+  // 5) LIVE delivery (only when both flags are flipped)
+  try {
+    const delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {});
+    const status: MessageLogStatus = delivery.success ? 'sent' : 'failed';
+    const id = await writeMessageLog(db, {
+      ...base,
+      status,
+      reason: delivery.error ?? null,
+      to: maskContact(contact),
+      providerId: delivery.providerId ?? null,
+    });
+    return {
+      status,
+      reason: delivery.error,
+      providerId: delivery.providerId,
+      messageLogId: id,
+      mode: 'live',
+    };
+  } catch (error) {
+    logger.error('Live send failed', error as Error, {
+      guestId: req.guestId,
+      channel: req.channel,
+    });
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'failed',
+      reason: (error as Error).message,
+      to: maskContact(contact),
+      providerId: null,
+    });
+    return { status: 'failed', reason: (error as Error).message, messageLogId: id, mode: 'live' };
+  }
+}
+
+/**
+ * Deliver a real message. Only reachable in live mode. WhatsApp is fully wired
+ * to the existing Twilio service; email/SMS campaign delivery is wired in a
+ * later increment (today's emailService is booking-specific).
+ */
+async function deliverLive(
+  channel: ChannelType,
+  contact: string,
+  templateName: string,
+  variables: Record<string, string>
+): Promise<{ success: boolean; providerId?: string; error?: string }> {
+  if (channel === 'whatsapp') {
+    const { sendWhatsAppTemplate, WHATSAPP_TEMPLATES } = await import(
+      '@/services/whatsappService'
+    );
+    if (!(templateName in WHATSAPP_TEMPLATES)) {
+      return { success: false, error: `WhatsApp template not registered: ${templateName}` };
+    }
+    const r = await sendWhatsAppTemplate(
+      contact,
+      templateName as keyof typeof WHATSAPP_TEMPLATES,
+      variables
+    );
+    return { success: r.success, providerId: r.sid, error: r.error };
+  }
+  if (channel === 'email') {
+    return { success: false, error: 'email channel not yet wired for campaigns' };
+  }
+  if (channel === 'sms') {
+    return { success: false, error: 'sms channel not yet wired for campaigns' };
+  }
+  return { success: false, error: `unsupported channel: ${channel}` };
+}

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -60,12 +60,10 @@ export function maskContact(contact: string): string {
 
 function resolveContact(guest: Guest, channel: ChannelType): string | null {
   if (channel === 'whatsapp' || channel === 'sms') {
-    return (
-      guest.normalizedPhone ||
-      (guest.phone ? normalizePhone(guest.phone) : null) ||
-      guest.phone ||
-      null
-    );
+    // Only ever return a properly normalized number — the SAME identity the
+    // suppression check keys on. A phone that fails normalization is treated as
+    // unreachable (no raw fallback), so it cannot slip past suppression (M5).
+    return guest.normalizedPhone || (guest.phone ? normalizePhone(guest.phone) || null : null);
   }
   if (channel === 'email') return guest.email || null;
   return null;
@@ -98,6 +96,25 @@ async function isSuppressed(db: AdminDb, guest: Guest): Promise<boolean> {
   }
   if (checks.length === 0) return false;
   return (await Promise.all(checks)).some(Boolean);
+}
+
+/**
+ * Within a campaign, has this guest already been REALLY delivered this template?
+ * Only real deliveries ('sent'/'delivered') block a resend — dry-run previews
+ * never do, so a campaign can be previewed repeatedly (M1).
+ */
+async function alreadyDelivered(db: AdminDb, req: SendRequest): Promise<boolean> {
+  if (!req.campaignId) return false; // dedup only makes sense inside a campaign
+  const snap = await db
+    .collection('messageLog')
+    .where('guestId', '==', req.guestId)
+    .where('campaignId', '==', req.campaignId)
+    .where('templateName', '==', req.templateName)
+    .get();
+  return snap.docs.some((d) => {
+    const s = (d.data() as { status?: string }).status;
+    return s === 'sent' || s === 'delivered';
+  });
 }
 
 interface MessageLogInput {
@@ -173,6 +190,18 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     return { status: 'suppressed', reason: 'suppression-list', messageLogId: id, mode };
   }
 
+  // 2.5) dedup — never re-deliver the same campaign template to the same guest
+  if (await alreadyDelivered(db, req)) {
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'skipped',
+      reason: 'dedup',
+      to: null,
+      providerId: null,
+    });
+    return { status: 'skipped', reason: 'dedup', messageLogId: id, mode };
+  }
+
   // 3) resolve a contact for the channel
   const contact = resolveContact(guest, req.channel);
   if (!contact) {
@@ -204,38 +233,35 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     return { status: 'dry-run', messageLogId: id, mode: 'dry-run' };
   }
 
-  // 5) LIVE delivery (only when both flags are flipped)
+  // 5) LIVE delivery (only when both flags are flipped). Delivery and the log
+  // write are deliberately separated so a Firestore log-write failure can never
+  // mislabel an already-delivered message as 'failed' and cause a re-send (M2).
+  let delivery: { success: boolean; providerId?: string; error?: string };
   try {
-    const delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {});
-    const status: MessageLogStatus = delivery.success ? 'sent' : 'failed';
-    const id = await writeMessageLog(db, {
-      ...base,
-      status,
-      reason: delivery.error ?? null,
-      to: maskContact(contact),
-      providerId: delivery.providerId ?? null,
-    });
-    return {
-      status,
-      reason: delivery.error,
-      providerId: delivery.providerId,
-      messageLogId: id,
-      mode: 'live',
-    };
+    delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {});
   } catch (error) {
-    logger.error('Live send failed', error as Error, {
+    logger.error('Live send threw', error as Error, {
       guestId: req.guestId,
       channel: req.channel,
     });
-    const id = await writeMessageLog(db, {
-      ...base,
-      status: 'failed',
-      reason: (error as Error).message,
-      to: maskContact(contact),
-      providerId: null,
-    });
-    return { status: 'failed', reason: (error as Error).message, messageLogId: id, mode: 'live' };
+    delivery = { success: false, error: (error as Error).message };
   }
+
+  const status: MessageLogStatus = delivery.success ? 'sent' : 'failed';
+  const id = await writeMessageLog(db, {
+    ...base,
+    status,
+    reason: delivery.error ?? null,
+    to: maskContact(contact),
+    providerId: delivery.providerId ?? null,
+  });
+  return {
+    status,
+    reason: delivery.error,
+    providerId: delivery.providerId,
+    messageLogId: id,
+    mode: 'live',
+  };
 }
 
 /**

--- a/src/services/segmentService.ts
+++ b/src/services/segmentService.ts
@@ -54,7 +54,10 @@ export function matchesDefinition(
     if (!guest.country || !def.countryIn.includes(guest.country)) return false;
   }
   if (def.countryNotIn && def.countryNotIn.length > 0) {
-    if (guest.country && def.countryNotIn.includes(guest.country)) return false;
+    // Symmetric with countryIn: a guest with unknown country is NOT classifiable
+    // as "not in X", so exclude them rather than treating unknown as foreign (M3).
+    if (!guest.country) return false;
+    if (def.countryNotIn.includes(guest.country)) return false;
   }
 
   if (def.tagsInclude && def.tagsInclude.length > 0) {
@@ -115,7 +118,7 @@ export async function evaluateSegment(
 
 export interface AudiencePreview {
   count: number;
-  byChannel: Record<'whatsapp' | 'sms' | 'email' | 'none', number>;
+  byChannel: Record<'whatsapp' | 'email' | 'none', number>;
   sample: Array<{ id: string; name: string; channel: ChannelType | null; country?: string }>;
 }
 
@@ -125,10 +128,13 @@ export async function previewAudience(
   now: Date = new Date()
 ): Promise<AudiencePreview> {
   const guests = await evaluateSegment(def, now);
-  const byChannel = { whatsapp: 0, sms: 0, email: 0, none: 0 };
+  // resolveChannel only ever yields whatsapp | email | null (no sms today).
+  const byChannel = { whatsapp: 0, email: 0, none: 0 };
   for (const g of guests) {
     const ch = resolveChannel(g);
-    byChannel[ch ?? 'none']++;
+    if (ch === 'whatsapp') byChannel.whatsapp++;
+    else if (ch === 'email') byChannel.email++;
+    else byChannel.none++;
   }
   const sample = guests.slice(0, 10).map((g) => ({
     id: g.id,

--- a/src/services/segmentService.ts
+++ b/src/services/segmentService.ts
@@ -1,0 +1,167 @@
+/**
+ * segmentService — evaluate a declarative SegmentDefinition against the
+ * `guests` collection and preview the resulting audience.
+ *
+ * Plain server module (NOT `'use server'`) so it can export pure helpers and
+ * types alongside async functions. The dataset is tiny (~150 guests), so we
+ * narrow by propertyId in Firestore and apply the rest of the predicate
+ * in-memory — no composite indexes required.
+ *
+ * See plans/growth-engine.md §6.2.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { Guest, SegmentDefinition, ChannelType, Season } from '@/types';
+import { parseFirestoreDate, seasonOf, monthsBetween } from '@/lib/growth/date-utils';
+
+const logger = loggers.segment;
+
+/**
+ * The channel a guest is reachable on, WhatsApp-first (phone), then email.
+ * Pure — safe to call anywhere. Reflects the §0.1 reality: phones, not emails.
+ */
+export function resolveChannel(
+  guest: Pick<Guest, 'normalizedPhone' | 'phone' | 'email'>
+): ChannelType | null {
+  if (guest.normalizedPhone || guest.phone) return 'whatsapp';
+  if (guest.email) return 'email';
+  return null;
+}
+
+/**
+ * Pure predicate: does a guest match a segment definition as of `now`?
+ * Kept side-effect-free so it is exhaustively unit-testable without Firestore.
+ */
+export function matchesDefinition(
+  guest: Guest,
+  def: SegmentDefinition,
+  now: Date = new Date()
+): boolean {
+  // Exclude unsubscribed unless explicitly opted out of that exclusion.
+  if (def.excludeUnsubscribed !== false && guest.unsubscribed) return false;
+
+  if (def.propertyId && !(guest.propertyIds || []).includes(def.propertyId)) return false;
+
+  const bookings = guest.totalBookings || 0;
+  if (typeof def.minTotalBookings === 'number' && bookings < def.minTotalBookings) return false;
+  if (typeof def.maxTotalBookings === 'number' && bookings > def.maxTotalBookings) return false;
+
+  if (typeof def.minTotalSpent === 'number' && (guest.totalSpent || 0) < def.minTotalSpent) {
+    return false;
+  }
+
+  if (def.countryIn && def.countryIn.length > 0) {
+    if (!guest.country || !def.countryIn.includes(guest.country)) return false;
+  }
+  if (def.countryNotIn && def.countryNotIn.length > 0) {
+    if (guest.country && def.countryNotIn.includes(guest.country)) return false;
+  }
+
+  if (def.tagsInclude && def.tagsInclude.length > 0) {
+    const tags = guest.tags || [];
+    if (!def.tagsInclude.some((t) => tags.includes(t))) return false;
+  }
+
+  if (def.hasChannel) {
+    const hasPhone = !!(guest.normalizedPhone || guest.phone);
+    if ((def.hasChannel === 'whatsapp' || def.hasChannel === 'sms') && !hasPhone) return false;
+    if (def.hasChannel === 'email' && !guest.email) return false;
+  }
+
+  if (def.lastStaySeason && def.lastStaySeason.length > 0) {
+    const d = parseFirestoreDate(guest.lastStayDate);
+    if (!d || !def.lastStaySeason.includes(seasonOf(d))) return false;
+  }
+
+  if (def.monthsSinceLastBooking) {
+    const d = parseFirestoreDate(guest.lastBookingDate);
+    if (!d) return false;
+    const months = monthsBetween(d, now);
+    const { min, max } = def.monthsSinceLastBooking;
+    if (typeof min === 'number' && months < min) return false;
+    if (typeof max === 'number' && months > max) return false;
+  }
+
+  if (def.monthsSinceLastStay) {
+    const d = parseFirestoreDate(guest.lastStayDate);
+    if (!d) return false;
+    const months = monthsBetween(d, now);
+    const { min, max } = def.monthsSinceLastStay;
+    if (typeof min === 'number' && months < min) return false;
+    if (typeof max === 'number' && months > max) return false;
+  }
+
+  return true;
+}
+
+/** Fetch candidate guests, narrowing by propertyId in Firestore when set. */
+async function fetchCandidates(def: SegmentDefinition): Promise<Guest[]> {
+  const db = await getAdminDb();
+  const base = db.collection('guests');
+  const snap = def.propertyId
+    ? await base.where('propertyIds', 'array-contains', def.propertyId).get()
+    : await base.get();
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() } as Guest));
+}
+
+/** Resolve a segment definition to the matching guest records. */
+export async function evaluateSegment(
+  def: SegmentDefinition,
+  now: Date = new Date()
+): Promise<Guest[]> {
+  const candidates = await fetchCandidates(def);
+  return candidates.filter((g) => matchesDefinition(g, def, now));
+}
+
+export interface AudiencePreview {
+  count: number;
+  byChannel: Record<'whatsapp' | 'sms' | 'email' | 'none', number>;
+  sample: Array<{ id: string; name: string; channel: ChannelType | null; country?: string }>;
+}
+
+/** Count + channel breakdown + a small sample for a segment definition. */
+export async function previewAudience(
+  def: SegmentDefinition,
+  now: Date = new Date()
+): Promise<AudiencePreview> {
+  const guests = await evaluateSegment(def, now);
+  const byChannel = { whatsapp: 0, sms: 0, email: 0, none: 0 };
+  for (const g of guests) {
+    const ch = resolveChannel(g);
+    byChannel[ch ?? 'none']++;
+  }
+  const sample = guests.slice(0, 10).map((g) => ({
+    id: g.id,
+    name: [g.firstName, g.lastName].filter(Boolean).join(' ').trim(),
+    channel: resolveChannel(g),
+    country: g.country,
+  }));
+  logger.info('Previewed audience', { count: guests.length, byChannel });
+  return { count: guests.length, byChannel, sample };
+}
+
+/** Reusable segment builders (the §6.2 catalogue). */
+export const PREDEFINED_SEGMENTS = {
+  lastStayedInSeason: (season: Season, propertyId?: string): SegmentDefinition => ({
+    lastStaySeason: [season],
+    propertyId,
+  }),
+  noBookingInMonths: (min: number, propertyId?: string): SegmentDefinition => ({
+    monthsSinceLastBooking: { min },
+    propertyId,
+  }),
+  repeatGuests: (propertyId?: string): SegmentDefinition => ({
+    minTotalBookings: 2,
+    propertyId,
+  }),
+  romanian: (propertyId?: string): SegmentDefinition => ({ countryIn: ['RO'], propertyId }),
+  foreign: (propertyId?: string): SegmentDefinition => ({ countryNotIn: ['RO'], propertyId }),
+  highValue: (minTotalSpent: number, propertyId?: string): SegmentDefinition => ({
+    minTotalSpent,
+    propertyId,
+  }),
+  whatsappReachable: (propertyId?: string): SegmentDefinition => ({
+    hasChannel: 'whatsapp',
+    propertyId,
+  }),
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -268,8 +268,106 @@ export interface Guest {
   tags: string[];
   unsubscribed: boolean;
   unsubscribedAt?: SerializableTimestamp;
+  // --- Growth Engine (dark-launched — see plans/growth-engine.md §5) ---
+  channelConsent?: ChannelConsent;
+  consentLog?: ConsentLogEntry[];
+  segmentIds?: string[];
+  lastCampaignAt?: SerializableTimestamp;
+  rfm?: GuestRFM;
   createdAt: SerializableTimestamp;
   updatedAt: SerializableTimestamp;
+}
+
+// ============================================================================
+// Growth Engine (dark-launched — see plans/growth-engine.md §5)
+// ============================================================================
+
+export type ChannelType = 'whatsapp' | 'sms' | 'email';
+export type ConsentState = 'opted_in' | 'opted_out' | 'unknown';
+
+export interface ChannelConsent {
+  whatsapp?: ConsentState;
+  sms?: ConsentState;
+  email?: ConsentState;
+}
+
+export interface ConsentLogEntry {
+  channel: ChannelType;
+  state: ConsentState;
+  source: string; // e.g. 'booking', 'stop-keyword', 'admin', 'import'
+  at: SerializableTimestamp;
+}
+
+export interface GuestRFM {
+  recencyDays: number;
+  frequency: number;
+  monetary: number;
+  score: number;
+  segmentTag?: string; // e.g. 'vip', 'at-risk', 'lapsed'
+}
+
+export type Season = 'winter' | 'spring' | 'summer' | 'autumn';
+
+/**
+ * Declarative audience filter evaluated against the `guests` collection.
+ * All conditions are ANDed; range objects are inclusive.
+ */
+export interface SegmentDefinition {
+  propertyId?: string;                          // guests.propertyIds array-contains
+  lastStaySeason?: Season[];                    // season of lastStayDate
+  monthsSinceLastBooking?: { min?: number; max?: number };
+  monthsSinceLastStay?: { min?: number; max?: number };
+  minTotalBookings?: number;                    // >= (repeat guests)
+  maxTotalBookings?: number;                    // <=
+  minTotalSpent?: number;
+  countryIn?: string[];                         // ISO-2 codes
+  countryNotIn?: string[];
+  tagsInclude?: string[];                       // guest.tags intersects
+  hasChannel?: ChannelType;                     // reachable via this channel
+  excludeUnsubscribed?: boolean;                // default true
+}
+
+export interface Segment {
+  id: string;
+  name: string;
+  definition: SegmentDefinition;
+  dynamic: boolean;          // recomputed each use vs snapshot
+  propertyId?: string;
+  cachedCount?: number;
+  createdAt?: SerializableTimestamp;
+  updatedAt?: SerializableTimestamp;
+}
+
+export type MessageLogStatus =
+  | 'dry-run'      // would-send; recorded but NOT delivered (dark launch)
+  | 'sent'         // handed to provider
+  | 'delivered'    // provider delivery confirmation
+  | 'suppressed'   // blocked by suppression / consent / unsubscribe
+  | 'skipped'      // no reachable contact / dedup
+  | 'failed';      // provider error
+
+export interface MessageLog {
+  id: string;
+  guestId: string;
+  channel: ChannelType;
+  campaignId?: string | null;
+  templateName?: string | null;
+  status: MessageLogStatus;
+  reason?: string | null;      // for suppressed / skipped / failed
+  providerId?: string | null;  // e.g. Twilio SID
+  to?: string | null;          // masked contact
+  variables?: Record<string, string> | null;
+  at?: SerializableTimestamp;
+}
+
+export interface SuppressionEntry {
+  id: string;
+  normalizedPhone?: string;
+  email?: string;
+  channel?: ChannelType | 'all';   // default 'all'
+  reason: string;                  // 'stop-keyword' | 'unsubscribe' | 'bounce' | 'manual'
+  source: string;
+  at?: SerializableTimestamp;
 }
 
 export interface Inquiry {


### PR DESCRIPTION
## What this is
Phase 1 **foundation** of the Growth Engine (past-guest reactivation over WhatsApp). It is **dark-launched**: nothing runs or sends in production until two independent env switches are flipped. `executeSend` has no callers yet — this lays the data model + the safety seam that later increments build on.

## Safety model
- **Two-switch kill:** inert unless `GROWTH_ENGINE_ENABLED=true`; even then delivers nothing unless `GROWTH_ENGINE_SEND_MODE=live`. Both use strict equality — any fuzzy value fails to dry-run.
- **Dry-run by default:** the Execution Gateway records what it *would* send to `messageLog` and delivers nothing.
- Adversarially reviewed pre-merge; the reviewer confirmed **no code path can deliver a real message with the flags off**.

## Contents
- `types`: `Guest.channelConsent/consentLog/segmentIds/lastCampaignAt/rfm` + `SegmentDefinition`, `Segment`, `MessageLog`, `SuppressionEntry`, channel/consent enums
- `config/growth-engine.ts`: two-switch dark-launch flags
- `services/executionGateway.ts`: the send seam — consent + suppression gating, dedup, `messageLog` audit, dry-run default; WhatsApp live path wired to the existing Twilio service
- `services/segmentService.ts`: `SegmentDefinition` evaluation + `previewAudience`
- `lib/growth/date-utils.ts`: UTC-deterministic season/months/Firestore-date helpers
- `firestore.rules` + indexes: `segments`/`messageLog`/`suppressionList`/`campaigns` (Admin-SDK-only writes; PII collections super-admin read)
- `apphosting.yaml`: documented flags (commented, default off)

## Validation
- 39 unit tests (segment predicates, consent/suppression gating, live-mode delivery, dedup, two-switch matrix)
- `next build` green; type-clean
- Exercised against **live Firestore**: 146 past guests / 132 WhatsApp-reachable, unsubscribe correctly excluded, segment counts match manual analysis

Firestore rules + indexes already deployed. Merging deploys inert code behind the flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)