### PR TITLE
feat: Growth Engine campaign engine — campaignService + marketing WhatsApp templates (dark)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -210,6 +210,20 @@ env:
 #   value: "dry-run"
 #   availability:
 #     - RUNTIME
+# Marketing WhatsApp template content SIDs (from Twilio, after Meta approval).
+# Until set, the live WhatsApp path for these templates stays inert.
+# - variable: WHATSAPP_TPL_WINTER_INVITE
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WINTER_INVITE/versions/latest
+#   availability:
+#     - RUNTIME
+# - variable: WHATSAPP_TPL_WE_MISS_YOU
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WE_MISS_YOU/versions/latest
+#   availability:
+#     - RUNTIME
+# - variable: WHATSAPP_TPL_SEASONAL_AVAILABILITY
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_SEASONAL_AVAILABILITY/versions/latest
+#   availability:
+#     - RUNTIME
 
 # Grant access to secrets in Cloud Secret Manager.
 # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters

--- a/src/services/__tests__/campaignService.test.ts
+++ b/src/services/__tests__/campaignService.test.ts
@@ -1,0 +1,110 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'ts') },
+  Timestamp: { fromDate: jest.fn((d: Date) => d) },
+}));
+jest.mock('@/services/segmentService', () => ({
+  evaluateSegment: jest.fn(),
+  previewAudience: jest.fn(),
+}));
+jest.mock('@/services/executionGateway', () => ({ executeSend: jest.fn() }));
+
+import { sendCampaign } from '../campaignService';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { evaluateSegment } from '@/services/segmentService';
+import { executeSend } from '@/services/executionGateway';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockEvaluateSegment = evaluateSegment as jest.Mock;
+const mockExecuteSend = executeSend as jest.Mock;
+
+function campaignDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'c1',
+    name: 'Winter reactivation',
+    propertyId: 'prahova-mountain-chalet',
+    channel: 'whatsapp',
+    templateName: 'winter_invite',
+    variables: {},
+    segmentDefinition: { propertyId: 'prahova-mountain-chalet' },
+    status: 'draft',
+    sentAt: null,
+    ...overrides,
+  };
+}
+
+function makeDb(campaign: Record<string, unknown> | null) {
+  const updateMock = jest.fn().mockResolvedValue(undefined);
+  const docRef = {
+    get: jest.fn().mockResolvedValue({
+      exists: !!campaign,
+      id: campaign?.id,
+      data: () => campaign,
+    }),
+    update: updateMock,
+  };
+  const db = { collection: jest.fn(() => ({ doc: jest.fn(() => docRef) })) };
+  return { db, updateMock };
+}
+
+beforeEach(() => {
+  delete process.env.GROWTH_ENGINE_ENABLED; // dark-launch default => dry-run
+  delete process.env.GROWTH_ENGINE_SEND_MODE;
+  jest.clearAllMocks();
+});
+
+describe('campaignService.sendCampaign (dry-run by default)', () => {
+  it('iterates the whole audience and tallies dry-run stats', async () => {
+    const { db } = makeDb(campaignDoc());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockEvaluateSegment.mockResolvedValue([{ id: 'g1' }, { id: 'g2' }, { id: 'g3' }]);
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+
+    const res = await sendCampaign('c1');
+
+    expect(mockExecuteSend).toHaveBeenCalledTimes(3);
+    expect(mockExecuteSend.mock.calls[0][0]).toMatchObject({
+      guestId: 'g1',
+      campaignId: 'c1',
+      channel: 'whatsapp',
+      templateName: 'winter_invite',
+    });
+    expect(res.mode).toBe('dry-run');
+    expect(res.capped).toBe(false);
+    expect(res.stats).toMatchObject({ audienceSize: 3, attempted: 3, dryRun: 3, sent: 0 });
+  });
+
+  it('respects the per-run cap and reports capped', async () => {
+    const { db } = makeDb(campaignDoc());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockEvaluateSegment.mockResolvedValue(Array.from({ length: 10 }, (_, i) => ({ id: `g${i}` })));
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+
+    const res = await sendCampaign('c1', { cap: 4 });
+
+    expect(mockExecuteSend).toHaveBeenCalledTimes(4);
+    expect(res.capped).toBe(true);
+    expect(res.stats.attempted).toBe(4);
+  });
+
+  it('tallies mixed gateway outcomes', async () => {
+    const { db } = makeDb(campaignDoc());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockEvaluateSegment.mockResolvedValue([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    mockExecuteSend
+      .mockResolvedValueOnce({ status: 'dry-run', mode: 'dry-run' })
+      .mockResolvedValueOnce({ status: 'suppressed', mode: 'dry-run' })
+      .mockResolvedValueOnce({ status: 'skipped', mode: 'dry-run' });
+
+    const res = await sendCampaign('c1');
+    expect(res.stats).toMatchObject({ dryRun: 1, suppressed: 1, skipped: 1, sent: 0, failed: 0 });
+  });
+
+  it('throws for a missing campaign', async () => {
+    const { db } = makeDb(null);
+    mockGetAdminDb.mockResolvedValue(db);
+    await expect(sendCampaign('missing')).rejects.toThrow(/not found/i);
+  });
+});

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -7,19 +7,19 @@ jest.mock('@/lib/firebaseAdminSafe', () => ({
 }));
 jest.mock('@/services/guestService', () => ({ getGuestById: jest.fn() }));
 jest.mock('@/services/whatsappService', () => ({
-  sendWhatsAppTemplate: jest.fn().mockResolvedValue({ success: true, sid: 'SM-1' }),
-  WHATSAPP_TEMPLATES: { winter_invite: 'HX-test' },
+  resolveWhatsAppTemplateSid: jest.fn((name: string) => (name === 'winter_invite' ? 'HX-test' : undefined)),
+  sendWhatsAppTemplateBySid: jest.fn().mockResolvedValue({ success: true, sid: 'SM-1' }),
 }));
 
 import { executeSend, isConsentBlocked, maskContact } from '../executionGateway';
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { getGuestById } from '@/services/guestService';
-import { sendWhatsAppTemplate } from '@/services/whatsappService';
+import { sendWhatsAppTemplateBySid } from '@/services/whatsappService';
 import type { Guest } from '@/types';
 
 const mockGetAdminDb = getAdminDb as jest.Mock;
 const mockGetGuestById = getGuestById as jest.Mock;
-const mockSendWhatsApp = sendWhatsAppTemplate as jest.Mock;
+const mockSendWhatsApp = sendWhatsAppTemplateBySid as jest.Mock;
 
 function chainableGet(result: unknown) {
   const q: Record<string, jest.Mock> = {};

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -1,0 +1,218 @@
+/**
+ * campaignService — create, preview, and run past-guest campaigns.
+ *
+ * A campaign snapshots a SegmentDefinition + a template, and `sendCampaign`
+ * drives the resulting audience through the Execution Gateway ONE guest at a
+ * time. Because every send routes through `executeSend`, campaigns inherit the
+ * dark-launch guarantee for free: by default this records dry-run intent and
+ * delivers nothing. Dedup, consent, and suppression are all enforced in the
+ * gateway. See plans/growth-engine.md §6.1.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + helpers.
+ */
+import { getAdminDb, FieldValue, Timestamp } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { Campaign, CampaignStats, CampaignStatus, SegmentDefinition, ChannelType } from '@/types';
+import { evaluateSegment, previewAudience, type AudiencePreview } from '@/services/segmentService';
+import { executeSend } from '@/services/executionGateway';
+import { getSendMode, GROWTH_ENGINE_LIMITS } from '@/config/growth-engine';
+
+const logger = loggers.campaign;
+
+function emptyStats(): CampaignStats {
+  return { audienceSize: 0, attempted: 0, sent: 0, dryRun: 0, suppressed: 0, skipped: 0, failed: 0 };
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Current hour in property-local time (Europe/Bucharest), 0-23. */
+function bucharestHour(now: Date): number {
+  return Number(
+    new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'Europe/Bucharest',
+      hour: '2-digit',
+      hour12: false,
+    }).format(now)
+  );
+}
+
+/** Quiet hours wrap midnight: [quietHoursStart, 24) ∪ [0, quietHoursEnd). */
+function isQuietHours(now: Date = new Date()): boolean {
+  const hour = bucharestHour(now);
+  const { quietHoursStart, quietHoursEnd } = GROWTH_ENGINE_LIMITS;
+  return hour >= quietHoursStart || hour < quietHoursEnd;
+}
+
+export interface CreateCampaignInput {
+  name: string;
+  propertyId: string;
+  channel: ChannelType;
+  templateName: string;
+  variables?: Record<string, string>;
+  segmentDefinition: SegmentDefinition;
+  segmentId?: string;
+  scheduleAt?: Date | null;
+}
+
+export async function createCampaign(input: CreateCampaignInput): Promise<string> {
+  const db = await getAdminDb();
+  const status: CampaignStatus = input.scheduleAt ? 'scheduled' : 'draft';
+  const ref = await db.collection('campaigns').add({
+    name: input.name,
+    propertyId: input.propertyId,
+    channel: input.channel,
+    templateName: input.templateName,
+    variables: input.variables ?? {},
+    segmentDefinition: input.segmentDefinition,
+    segmentId: input.segmentId ?? null,
+    scheduleAt: input.scheduleAt ? Timestamp.fromDate(input.scheduleAt) : null,
+    status,
+    stats: emptyStats(),
+    approvedBy: null,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    sentAt: null,
+  });
+  logger.info('Campaign created', { campaignId: ref.id, name: input.name, status });
+  return ref.id;
+}
+
+export async function getCampaign(id: string): Promise<Campaign | null> {
+  const db = await getAdminDb();
+  const doc = await db.collection('campaigns').doc(id).get();
+  if (!doc.exists) return null;
+  return { id: doc.id, ...doc.data() } as Campaign;
+}
+
+export async function listCampaigns(propertyId?: string): Promise<Campaign[]> {
+  const db = await getAdminDb();
+  const { convertTimestampsToISOStrings } = await import('@/lib/utils');
+  const base = db.collection('campaigns');
+  const snap = propertyId ? await base.where('propertyId', '==', propertyId).get() : await base.get();
+  return snap.docs.map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as Campaign);
+}
+
+/** Live audience count + channel breakdown for a saved campaign's segment. */
+export async function previewCampaignAudience(id: string): Promise<AudiencePreview | null> {
+  const campaign = await getCampaign(id);
+  if (!campaign) return null;
+  return previewAudience(campaign.segmentDefinition);
+}
+
+export async function approveCampaign(id: string, approvedBy: string): Promise<void> {
+  const db = await getAdminDb();
+  await db.collection('campaigns').doc(id).update({
+    approvedBy,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  logger.info('Campaign approved', { campaignId: id, approvedBy });
+}
+
+export interface SendCampaignResult {
+  campaignId: string;
+  mode: 'dry-run' | 'live';
+  stats: CampaignStats;
+  capped: boolean;
+  deferred?: boolean;
+}
+
+/**
+ * Run a campaign: evaluate the audience and route each guest through the
+ * Execution Gateway. Respects the per-run cap and, in LIVE mode only, quiet
+ * hours + throttling (dry-run previews run anytime, unthrottled).
+ */
+export async function sendCampaign(
+  id: string,
+  options?: { cap?: number }
+): Promise<SendCampaignResult> {
+  const db = await getAdminDb();
+  const campaign = await getCampaign(id);
+  if (!campaign) throw new Error(`Campaign not found: ${id}`);
+
+  const mode = getSendMode();
+  const cap = options?.cap ?? GROWTH_ENGINE_LIMITS.perRunCap;
+
+  // In LIVE mode, hold off during quiet hours so we don't message at night.
+  if (mode === 'live' && isQuietHours()) {
+    logger.warn('sendCampaign deferred — quiet hours', { campaignId: id });
+    await db.collection('campaigns').doc(id).update({
+      status: 'scheduled',
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return { campaignId: id, mode, stats: emptyStats(), capped: false, deferred: true };
+  }
+
+  logger.info('sendCampaign start', {
+    campaignId: id,
+    mode,
+    channel: campaign.channel,
+    template: campaign.templateName,
+    cap,
+  });
+
+  await db.collection('campaigns').doc(id).update({
+    status: 'sending',
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  const audience = await evaluateSegment(campaign.segmentDefinition);
+  const stats = emptyStats();
+  stats.audienceSize = audience.length;
+
+  let capped = false;
+  for (const guest of audience) {
+    if (stats.attempted >= cap) {
+      capped = true;
+      break;
+    }
+    stats.attempted++;
+
+    const result = await executeSend({
+      guestId: guest.id,
+      channel: campaign.channel,
+      templateName: campaign.templateName,
+      variables: campaign.variables,
+      campaignId: id,
+    });
+
+    switch (result.status) {
+      case 'sent':
+      case 'delivered':
+        stats.sent++;
+        break;
+      case 'dry-run':
+        stats.dryRun++;
+        break;
+      case 'suppressed':
+        stats.suppressed++;
+        break;
+      case 'skipped':
+        stats.skipped++;
+        break;
+      case 'failed':
+        stats.failed++;
+        break;
+    }
+
+    // Throttle only real deliveries — protects the WhatsApp sender number.
+    if (mode === 'live' && result.status === 'sent') {
+      await sleep(GROWTH_ENGINE_LIMITS.throttleMs);
+    }
+  }
+
+  const finalStatus: CampaignStatus = capped
+    ? 'scheduled' // more to send on the next run
+    : stats.failed > 0 && stats.sent === 0 && stats.dryRun === 0
+      ? 'failed'
+      : 'sent';
+
+  await db.collection('campaigns').doc(id).update({
+    status: finalStatus,
+    stats,
+    sentAt: mode === 'live' && !capped ? FieldValue.serverTimestamp() : (campaign.sentAt ?? null),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  logger.info('sendCampaign done', { campaignId: id, mode, stats, capped });
+  return { campaignId: id, mode, stats, capped };
+}

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -276,17 +276,18 @@ async function deliverLive(
   variables: Record<string, string>
 ): Promise<{ success: boolean; providerId?: string; error?: string }> {
   if (channel === 'whatsapp') {
-    const { sendWhatsAppTemplate, WHATSAPP_TEMPLATES } = await import(
+    const { resolveWhatsAppTemplateSid, sendWhatsAppTemplateBySid } = await import(
       '@/services/whatsappService'
     );
-    if (!(templateName in WHATSAPP_TEMPLATES)) {
-      return { success: false, error: `WhatsApp template not registered: ${templateName}` };
+    const sid = resolveWhatsAppTemplateSid(templateName);
+    if (!sid) {
+      // Unknown name, or a marketing template whose SID isn't approved/set yet.
+      return {
+        success: false,
+        error: `WhatsApp template not registered or not yet approved: ${templateName}`,
+      };
     }
-    const r = await sendWhatsAppTemplate(
-      contact,
-      templateName as keyof typeof WHATSAPP_TEMPLATES,
-      variables
-    );
+    const r = await sendWhatsAppTemplateBySid(contact, sid, variables);
     return { success: r.success, providerId: r.sid, error: r.error };
   }
   if (channel === 'email') {

--- a/src/services/whatsappService.ts
+++ b/src/services/whatsappService.ts
@@ -39,6 +39,32 @@ export const WHATSAPP_TEMPLATES = {
 
 export type WhatsAppTemplateName = keyof typeof WHATSAPP_TEMPLATES;
 
+/**
+ * Marketing-category templates (Growth Engine) — SEPARATE from the operational
+ * curatenie_ and program_ templates. Content SIDs come from env and are EMPTY
+ * until the templates are approved in Twilio/Meta, so the live send path stays
+ * inert until finalization. See plans/growth-engine.md section 6.6 / 10.
+ */
+export const WHATSAPP_MARKETING_TEMPLATES = {
+  winter_invite: process.env.WHATSAPP_TPL_WINTER_INVITE || '',
+  we_miss_you: process.env.WHATSAPP_TPL_WE_MISS_YOU || '',
+  seasonal_availability: process.env.WHATSAPP_TPL_SEASONAL_AVAILABILITY || '',
+} as const;
+
+export type WhatsAppMarketingTemplateName = keyof typeof WHATSAPP_MARKETING_TEMPLATES;
+
+/**
+ * Resolve a Twilio content SID from either the ops or the marketing registry.
+ * Returns undefined for unknown names OR marketing templates whose SID env var
+ * isn't set yet (unapproved) — callers treat that as "not deliverable".
+ */
+export function resolveWhatsAppTemplateSid(name: string): string | undefined {
+  const sid =
+    (WHATSAPP_TEMPLATES as Record<string, string>)[name] ??
+    (WHATSAPP_MARKETING_TEMPLATES as Record<string, string>)[name];
+  return sid || undefined;
+}
+
 // ============================================================================
 // Send freeform message (for sandbox / fallback)
 // ============================================================================
@@ -87,6 +113,24 @@ export async function sendWhatsAppTemplate(
   templateName: WhatsAppTemplateName,
   variables: Record<string, string>
 ): Promise<{ success: boolean; sid?: string; error?: string; messageBody?: string }> {
+  const contentSid = WHATSAPP_TEMPLATES[templateName];
+  if (!contentSid) {
+    logger.error('Unknown WhatsApp template', new Error(`Template not found: ${templateName}`));
+    return { success: false, error: `Unknown template: ${templateName}` };
+  }
+  return sendWhatsAppTemplateBySid(to, contentSid, variables);
+}
+
+/**
+ * Send a template by its Twilio content SID directly. Used by the Growth Engine
+ * Execution Gateway, which resolves SIDs across both the ops and marketing
+ * registries via resolveWhatsAppTemplateSid().
+ */
+export async function sendWhatsAppTemplateBySid(
+  to: string,
+  contentSid: string,
+  variables: Record<string, string>
+): Promise<{ success: boolean; sid?: string; error?: string; messageBody?: string }> {
   const whatsappNumber = process.env.TWILIO_WHATSAPP_NUMBER;
 
   if (!whatsappNumber) {
@@ -100,17 +144,13 @@ export async function sendWhatsAppTemplate(
     return { success: false, error: 'WhatsApp not configured' };
   }
 
-  const contentSid = WHATSAPP_TEMPLATES[templateName];
   if (!contentSid) {
-    logger.error('Unknown WhatsApp template', new Error(`Template not found: ${templateName}`));
-    return { success: false, error: `Unknown template: ${templateName}` };
+    logger.error('Missing WhatsApp content SID', new Error('Empty content SID'));
+    return { success: false, error: 'Missing content SID' };
   }
 
   try {
-    logger.info('Sending WhatsApp template', {
-      to: to.slice(0, 6) + '***',
-      template: templateName,
-    });
+    logger.info('Sending WhatsApp template', { to: to.slice(0, 6) + '***', contentSid });
 
     const message = await client.messages.create({
       from: `whatsapp:${whatsappNumber}`,
@@ -119,17 +159,14 @@ export async function sendWhatsAppTemplate(
       contentVariables: JSON.stringify(variables),
     });
 
-    logger.info('WhatsApp template sent', { sid: message.sid, template: templateName });
-
-    // Build a human-readable version for logging
-    const messageBody = `[template:${templateName}] vars: ${JSON.stringify(variables)}`;
-
+    logger.info('WhatsApp template sent', { sid: message.sid, contentSid });
+    const messageBody = `[sid:${contentSid}] vars: ${JSON.stringify(variables)}`;
     return { success: true, sid: message.sid, messageBody };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error('Failed to send WhatsApp template', error as Error, {
       to: to.slice(0, 6) + '***',
-      template: templateName,
+      contentSid,
     });
     return { success: false, error: errorMessage };
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -370,6 +370,42 @@ export interface SuppressionEntry {
   at?: SerializableTimestamp;
 }
 
+export type CampaignStatus =
+  | 'draft'
+  | 'scheduled'
+  | 'sending'
+  | 'sent'
+  | 'failed'
+  | 'cancelled';
+
+export interface CampaignStats {
+  audienceSize: number;
+  attempted: number;
+  sent: number;
+  dryRun: number;
+  suppressed: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface Campaign {
+  id: string;
+  name: string;
+  propertyId: string;
+  channel: ChannelType;
+  templateName: string;
+  variables?: Record<string, string>;   // default template variables
+  segmentId?: string;                    // reference to a saved segment (optional)
+  segmentDefinition: SegmentDefinition;  // inline snapshot always present
+  scheduleAt?: SerializableTimestamp | null;
+  status: CampaignStatus;
+  stats?: CampaignStats;
+  approvedBy?: string | null;
+  createdAt?: SerializableTimestamp;
+  updatedAt?: SerializableTimestamp;
+  sentAt?: SerializableTimestamp | null;
+}
+
 export interface Inquiry {
   id: string; // Document ID from Firestore
   propertySlug: string;


### PR DESCRIPTION
## Increment 2 of the Growth Engine Core (still dark-launched)
Builds the campaign layer on top of the merged foundation seam. Every send routes through `executeSend`, so campaigns inherit the dry-run guarantee — nothing is delivered until both flags are flipped.

- **`campaignService.ts`** — `createCampaign` / `getCampaign` / `listCampaigns` / `previewCampaignAudience` / `approveCampaign` + `sendCampaign`. The runner evaluates the segment, routes each guest through the Execution Gateway (dedup keyed on `campaignId`), respects the per-run cap, and — in LIVE mode only — quiet hours + throttle. Accumulates stats onto the campaign doc.
- **`whatsappService.ts`** — `WHATSAPP_MARKETING_TEMPLATES` registry (SIDs from env, empty until Twilio/Meta approval) + `sendWhatsAppTemplateBySid` + `resolveWhatsAppTemplateSid`; `sendWhatsAppTemplate` refactored to delegate (ops behavior unchanged).
- **`executionGateway.ts`** — WhatsApp live path resolves the SID across both registries; inert for unapproved marketing templates.
- **types** — `Campaign` / `CampaignStatus` / `CampaignStats`; **apphosting.yaml** — documented marketing-template SID env vars.

## Validation
- 43 unit tests (added campaign runner: audience iteration, per-run cap, mixed gateway outcomes, missing-campaign)
- `next build` green, type-clean
- **Live dry-run integration test** against real Firestore: 16-guest repeat segment, cap 3 → 2 dry-run + 1 skipped (unreachable guest), 0 sent, masked contacts logged; test data self-cleaned (collections verified empty after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)