### PR TITLE
feat: Growth Engine admin/campaigns UI (dark)

### DIFF
--- a/src/app/admin/campaigns/_components/campaign-composer.tsx
+++ b/src/app/admin/campaigns/_components/campaign-composer.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Users } from 'lucide-react';
+import { SEGMENT_CATALOG, TEMPLATE_CATALOG } from '@/lib/growth/catalog';
+import { previewSegmentAction, createCampaignAction } from '../actions';
+
+export function CampaignComposer({ propertyId }: { propertyId: string }) {
+  const { toast } = useToast();
+  const [name, setName] = useState('');
+  const [segmentKey, setSegmentKey] = useState(SEGMENT_CATALOG[0].key);
+  const [templateName, setTemplateName] = useState(TEMPLATE_CATALOG[0].key);
+  const [preview, setPreview] = useState<{ count: number; whatsapp: number } | null>(null);
+  const [previewing, startPreview] = useTransition();
+  const [creating, startCreate] = useTransition();
+
+  const runPreview = (key: string) => {
+    setPreview(null);
+    startPreview(async () => {
+      const res = await previewSegmentAction(key, propertyId);
+      if (res.success) setPreview({ count: res.count ?? 0, whatsapp: res.whatsapp ?? 0 });
+      else toast({ title: 'Preview failed', description: res.error, variant: 'destructive' });
+    });
+  };
+
+  // Preview the default segment on mount.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { runPreview(segmentKey); }, [propertyId]);
+
+  const onSegmentChange = (key: string) => {
+    setSegmentKey(key);
+    runPreview(key);
+  };
+
+  const create = () =>
+    startCreate(async () => {
+      const res = await createCampaignAction({ name, propertyId, segmentKey, templateName });
+      if (res.success) {
+        toast({ title: 'Campaign created', description: 'Saved as draft. Approve, then run (dry-run).' });
+        setName('');
+      } else {
+        toast({ title: 'Create failed', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  return (
+    <Card className="h-fit">
+      <CardHeader>
+        <CardTitle>New campaign</CardTitle>
+        <CardDescription>Pick an audience and a message. Nothing sends — dry-run only.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="campaign-name">Name</Label>
+          <Input
+            id="campaign-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Winter reactivation"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Audience</Label>
+          <Select value={segmentKey} onValueChange={onSegmentChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SEGMENT_CATALOG.map((s) => (
+                <SelectItem key={s.key} value={s.key}>
+                  {s.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex min-h-[46px] items-center gap-2 rounded-md border bg-muted/40 p-3 text-sm">
+            {previewing ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Counting…
+              </>
+            ) : preview ? (
+              <>
+                <Users className="h-4 w-4 text-muted-foreground" />
+                <span>
+                  <strong>{preview.count}</strong> guests · <strong>{preview.whatsapp}</strong> reachable on WhatsApp
+                </span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">Select an audience to preview the count.</span>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Message template</Label>
+          <Select value={templateName} onValueChange={setTemplateName}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TEMPLATE_CATALOG.map((t) => (
+                <SelectItem key={t.key} value={t.key}>
+                  {t.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button onClick={create} disabled={creating || !name.trim()} className="w-full">
+          {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Create campaign
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/admin/campaigns/_components/campaign-table.tsx
+++ b/src/app/admin/campaigns/_components/campaign-table.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useTransition } from 'react';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Play, Check } from 'lucide-react';
+import type { Campaign } from '@/types';
+import { approveCampaignAction, runCampaignAction } from '../actions';
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  draft: 'outline',
+  scheduled: 'secondary',
+  sending: 'secondary',
+  sent: 'default',
+  failed: 'destructive',
+  cancelled: 'outline',
+};
+
+export function CampaignTable({ campaigns }: { campaigns: Campaign[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Template</TableHead>
+          <TableHead className="text-right">Reached</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {campaigns.map((c) => (
+          <CampaignRow key={c.id} campaign={c} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function CampaignRow({ campaign: c }: { campaign: Campaign }) {
+  const { toast } = useToast();
+  const [approving, startApprove] = useTransition();
+  const [running, startRun] = useTransition();
+
+  const approve = () =>
+    startApprove(async () => {
+      const res = await approveCampaignAction(c.id);
+      toast(res.success ? { title: 'Approved' } : { title: 'Failed', description: res.error, variant: 'destructive' });
+    });
+
+  const run = () =>
+    startRun(async () => {
+      const res = await runCampaignAction(c.id);
+      if (res.success && res.stats) {
+        const s = res.stats;
+        toast({
+          title: `Run complete (${res.mode})`,
+          description: `${s.audienceSize} in audience · ${s.dryRun} dry-run · ${s.sent} sent · ${s.suppressed} suppressed · ${s.skipped} skipped`,
+        });
+      } else {
+        toast({ title: 'Run failed', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  const stats = c.stats;
+  const reached = stats && stats.attempted > 0 ? `${stats.dryRun + stats.sent}/${stats.audienceSize}` : '—';
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{c.name}</TableCell>
+      <TableCell>
+        <Badge variant={STATUS_VARIANT[c.status] || 'outline'}>{c.status}</Badge>
+      </TableCell>
+      <TableCell className="text-muted-foreground">{c.templateName}</TableCell>
+      <TableCell className="text-right text-sm text-muted-foreground">{reached}</TableCell>
+      <TableCell className="space-x-2 whitespace-nowrap text-right">
+        {!c.approvedBy && (
+          <Button size="sm" variant="outline" onClick={approve} disabled={approving}>
+            {approving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            <span className="ml-1">Approve</span>
+          </Button>
+        )}
+        <Button size="sm" onClick={run} disabled={running}>
+          {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+          <span className="ml-1">Run (dry-run)</span>
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -1,0 +1,133 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { loggers } from '@/lib/logger';
+import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
+import type { Campaign, SegmentDefinition } from '@/types';
+import { PREDEFINED_SEGMENTS, previewAudience } from '@/services/segmentService';
+import { listCampaigns, createCampaign, approveCampaign, sendCampaign } from '@/services/campaignService';
+
+const logger = loggers.campaign;
+
+// Map a UI segment key to a SegmentDefinition. Not exported (this file is
+// `'use server'` — only async functions may be exported).
+function buildSegmentDefinition(key: string, propertyId: string): SegmentDefinition {
+  switch (key) {
+    case 'whatsapp_reachable':
+      return PREDEFINED_SEGMENTS.whatsappReachable(propertyId);
+    case 'repeat':
+      return PREDEFINED_SEGMENTS.repeatGuests(propertyId);
+    case 'lapsed_12m':
+      return PREDEFINED_SEGMENTS.noBookingInMonths(12, propertyId);
+    case 'winter_stayers':
+      return PREDEFINED_SEGMENTS.lastStayedInSeason('winter', propertyId);
+    case 'romanian':
+      return PREDEFINED_SEGMENTS.romanian(propertyId);
+    case 'foreign':
+      return PREDEFINED_SEGMENTS.foreign(propertyId);
+    default:
+      return { propertyId };
+  }
+}
+
+export async function fetchCampaigns(propertyId: string): Promise<Campaign[]> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return [];
+    throw error;
+  }
+  try {
+    return await listCampaigns(propertyId);
+  } catch (error) {
+    logger.error('fetchCampaigns failed', error as Error);
+    return [];
+  }
+}
+
+export async function previewSegmentAction(
+  segmentKey: string,
+  propertyId: string
+): Promise<{ success: boolean; count?: number; whatsapp?: number; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const preview = await previewAudience(buildSegmentDefinition(segmentKey, propertyId));
+    return { success: true, count: preview.count, whatsapp: preview.byChannel.whatsapp };
+  } catch (error) {
+    logger.error('previewSegmentAction failed', error as Error);
+    return { success: false, error: 'Failed to preview audience' };
+  }
+}
+
+export async function createCampaignAction(input: {
+  name: string;
+  propertyId: string;
+  segmentKey: string;
+  templateName: string;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  if (!input.name?.trim()) return { success: false, error: 'Campaign name is required' };
+  try {
+    const id = await createCampaign({
+      name: input.name.trim(),
+      propertyId: input.propertyId,
+      channel: 'whatsapp',
+      templateName: input.templateName,
+      segmentDefinition: buildSegmentDefinition(input.segmentKey, input.propertyId),
+    });
+    revalidatePath('/admin/campaigns');
+    return { success: true, id };
+  } catch (error) {
+    logger.error('createCampaignAction failed', error as Error);
+    return { success: false, error: 'Failed to create campaign' };
+  }
+}
+
+export async function approveCampaignAction(id: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    await approveCampaign(id, 'super-admin');
+    revalidatePath('/admin/campaigns');
+    return { success: true };
+  } catch (error) {
+    logger.error('approveCampaignAction failed', error as Error);
+    return { success: false, error: 'Failed to approve campaign' };
+  }
+}
+
+export async function runCampaignAction(id: string): Promise<{
+  success: boolean;
+  mode?: 'dry-run' | 'live';
+  stats?: { audienceSize: number; attempted: number; dryRun: number; sent: number; suppressed: number; skipped: number; failed: number };
+  error?: string;
+}> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const result = await sendCampaign(id);
+    revalidatePath('/admin/campaigns');
+    return { success: true, mode: result.mode, stats: result.stats };
+  } catch (error) {
+    logger.error('runCampaignAction failed', error as Error);
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/src/app/admin/campaigns/page.tsx
+++ b/src/app/admin/campaigns/page.tsx
@@ -1,0 +1,50 @@
+import { AdminPage, EmptyState } from '@/components/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { Megaphone } from 'lucide-react';
+import { fetchCampaigns } from './actions';
+import { CampaignTable } from './_components/campaign-table';
+import { CampaignComposer } from './_components/campaign-composer';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function CampaignsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const campaigns = await fetchCampaigns(property);
+
+  return (
+    <AdminPage
+      title="Campaigns"
+      description="Reactivate past guests over WhatsApp. Dark-launched — every run is a dry-run (records intent, sends nothing) until the engine is switched on."
+    >
+      <PropertyUrlSync />
+      <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Your campaigns</CardTitle>
+            <CardDescription>Create, preview the audience, approve, then run (dry-run).</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {campaigns.length > 0 ? (
+              <CampaignTable campaigns={campaigns} />
+            ) : (
+              <EmptyState
+                icon={Megaphone}
+                title="No campaigns yet"
+                description="Compose your first reactivation campaign on the right."
+              />
+            )}
+          </CardContent>
+        </Card>
+        <CampaignComposer propertyId={property} />
+      </div>
+    </AdminPage>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Building2,
   CalendarCheck,
   Ticket,
+  Megaphone,
   MessageSquare,
   Sliders,
   RefreshCw,
@@ -85,6 +86,7 @@ const navigationGroups = [
       { title: 'Revenue', href: '/admin/revenue', icon: DollarSign },
       { title: 'Attribution', href: '/admin/attribution', icon: BarChart3 },
       { title: 'Coupons', href: '/admin/coupons', icon: Ticket },
+      { title: 'Campaigns', href: '/admin/campaigns', icon: Megaphone },
     ],
   },
 ];

--- a/src/lib/growth/catalog.ts
+++ b/src/lib/growth/catalog.ts
@@ -1,0 +1,32 @@
+/**
+ * Client-safe catalogs for the campaigns admin UI: audience segments and
+ * message templates. Pure data (no server imports) so it can be imported by
+ * client components. The server side (actions.ts) maps a segment key to a
+ * SegmentDefinition via PREDEFINED_SEGMENTS.
+ */
+export interface SegmentOption {
+  key: string;
+  label: string;
+  description: string;
+}
+
+export const SEGMENT_CATALOG: SegmentOption[] = [
+  { key: 'whatsapp_reachable', label: 'All WhatsApp-reachable', description: 'Every past guest with a phone number' },
+  { key: 'repeat', label: 'Repeat guests (2+ stays)', description: 'Your most loyal guests' },
+  { key: 'lapsed_12m', label: 'Lapsed 12+ months', description: 'No booking in over a year — win-back' },
+  { key: 'winter_stayers', label: 'Winter stayers', description: 'Last stayed in winter' },
+  { key: 'romanian', label: 'Romanian guests', description: 'Country = RO' },
+  { key: 'foreign', label: 'Foreign guests', description: 'Known non-RO country' },
+];
+
+export interface TemplateOption {
+  key: string;
+  label: string;
+  description: string;
+}
+
+export const TEMPLATE_CATALOG: TemplateOption[] = [
+  { key: 'winter_invite', label: 'Winter invite', description: 'Invite past guests back for winter' },
+  { key: 'we_miss_you', label: 'We miss you (+ offer)', description: 'Re-engagement with a return incentive' },
+  { key: 'seasonal_availability', label: 'Seasonal availability', description: 'Highlight open dates this season' },
+];


### PR DESCRIPTION
## Increment 4 of the Growth Engine Core

The admin surface for past-guest campaigns at **`/admin/campaigns`** (under Analytics in the sidebar).

- **Composer** — pick an audience (WhatsApp-reachable, repeat, lapsed 12mo+, winter-stayers, RO, foreign) → **live count + WhatsApp-reachable preview** → pick a message template → create (saved as draft).
- **Table** — status badge, reach, **Approve**, and **Run (dry-run)** with a toast summary of the run stats.
- **Server actions** — all `requireSuperAdmin()`, delegate to `campaignService` / `segmentService`; property-scoped (no hardcoded property data in components).

Dark by design: every run is a dry-run (records intent to `messageLog`, sends nothing) until the engine is enabled. Build green, type-clean. The underlying create→run→`executeSend` path was already live-validated against real Firestore in increment 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)