### PR TITLE
feat: Growth Engine Phase 2 foundation — Meta Custom Audiences + ad insights (dark/inert)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -197,6 +197,16 @@ env:
 # - variable: NEXT_PUBLIC_META_PIXEL_ID
 # - variable: META_PIXEL_ID
 # - variable: META_CAPI_ACCESS_TOKEN
+# Meta Marketing API (Growth Engine Phase 2 — Custom Audiences + ad insights).
+# Inert until BOTH are set. Requires a Meta Business account + system-user token.
+# - variable: META_SYSTEM_USER_TOKEN
+#   secret: projects/1061532538391/secrets/META_SYSTEM_USER_TOKEN/versions/latest
+#   availability:
+#     - RUNTIME
+# - variable: META_AD_ACCOUNT_ID
+#   secret: projects/1061532538391/secrets/META_AD_ACCOUNT_ID/versions/latest
+#   availability:
+#     - RUNTIME
 
 # Growth Engine (dark-launched) — see plans/growth-engine.md §0.2
 # The engine is INERT unless GROWTH_ENGINE_ENABLED="true"; and even when enabled,

--- a/src/lib/meta-capi.ts
+++ b/src/lib/meta-capi.ts
@@ -42,8 +42,9 @@ interface MetaEventParams {
 
 /**
  * SHA-256 hash after lowercase + trim (Meta's requirement for PII).
+ * Exported for reuse by the Growth Engine Custom Audience builder (§6.5).
  */
-function hashForMeta(value: string): string {
+export function hashForMeta(value: string): string {
   return createHash('sha256')
     .update(value.trim().toLowerCase())
     .digest('hex');

--- a/src/services/__tests__/metaAudienceService.test.ts
+++ b/src/services/__tests__/metaAudienceService.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+jest.mock('@/services/segmentService', () => ({ evaluateSegment: jest.fn() }));
+
+import { formatPhoneForMeta, buildCustomAudiencePayload, isMetaAudienceConfigured } from '../metaAudienceService';
+import { evaluateSegment } from '@/services/segmentService';
+import { hashForMeta } from '@/lib/meta-capi';
+
+const mockEvaluateSegment = evaluateSegment as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('formatPhoneForMeta', () => {
+  it('strips + and non-digits', () => {
+    expect(formatPhoneForMeta('+40 712 345 678')).toBe('40712345678');
+    expect(formatPhoneForMeta('+40712345678')).toBe('40712345678');
+  });
+});
+
+describe('buildCustomAudiencePayload', () => {
+  it('hashes phone (digits-only) and email, skipping unreachable guests', async () => {
+    mockEvaluateSegment.mockResolvedValue([
+      { id: 'g1', normalizedPhone: '+40712345678', email: 'a@b.com' },
+      { id: 'g2', normalizedPhone: '+40733111222' }, // phone only
+      { id: 'g3' }, // neither -> skipped
+    ]);
+
+    const payload = await buildCustomAudiencePayload({ propertyId: 'p' });
+
+    expect(payload.schema).toEqual(['PHONE', 'EMAIL']);
+    expect(payload.data).toHaveLength(2); // g3 skipped
+    // g1: both hashed with the SAME algorithm meta-capi uses
+    expect(payload.data[0][0]).toBe(hashForMeta('40712345678'));
+    expect(payload.data[0][1]).toBe(hashForMeta('a@b.com'));
+    // g2: phone hashed, email slot empty
+    expect(payload.data[1][0]).toBe(hashForMeta('40733111222'));
+    expect(payload.data[1][1]).toBe('');
+    // hashes are 64-hex sha256, never raw PII
+    expect(payload.data[0][0]).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('returns an empty member list for an empty segment', async () => {
+    mockEvaluateSegment.mockResolvedValue([]);
+    const payload = await buildCustomAudiencePayload({ propertyId: 'p' });
+    expect(payload.data).toEqual([]);
+  });
+});
+
+describe('isMetaAudienceConfigured', () => {
+  it('is false without the Meta env vars (dark launch default)', () => {
+    delete process.env.META_SYSTEM_USER_TOKEN;
+    delete process.env.META_AD_ACCOUNT_ID;
+    expect(isMetaAudienceConfigured()).toBe(false);
+  });
+});

--- a/src/services/metaAdsService.ts
+++ b/src/services/metaAdsService.ts
@@ -1,0 +1,54 @@
+/**
+ * metaAdsService — thin Meta Marketing API wrapper for reading ad insights (the
+ * spend half of the ROAS loop, §12). PHASE 2, DARK: inert until
+ * META_SYSTEM_USER_TOKEN + META_AD_ACCOUNT_ID are provisioned. Campaign/ad
+ * creation is intentionally NOT built yet — it needs a live Meta account to be
+ * validated at all, so it belongs to the finalization step, not dark code.
+ */
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.tracking;
+const GRAPH_API_VERSION = 'v21.0';
+const META_SYSTEM_USER_TOKEN = process.env.META_SYSTEM_USER_TOKEN;
+const META_AD_ACCOUNT_ID = process.env.META_AD_ACCOUNT_ID;
+
+export function isMetaAdsConfigured(): boolean {
+  return !!META_SYSTEM_USER_TOKEN && !!META_AD_ACCOUNT_ID;
+}
+
+export interface AdInsights {
+  spend: number;
+  impressions: number;
+  clicks: number;
+}
+
+/** Read insights for a Meta campaign. Inert (returns not-configured) without creds. */
+export async function getCampaignInsights(
+  metaCampaignId: string
+): Promise<{ success: boolean; insights?: AdInsights; error?: string }> {
+  if (!isMetaAdsConfigured()) {
+    return { success: false, error: 'Meta Ads not configured' };
+  }
+  try {
+    const url = `https://graph.facebook.com/${GRAPH_API_VERSION}/${metaCampaignId}/insights?fields=spend,impressions,clicks&access_token=${META_SYSTEM_USER_TOKEN}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      const text = await res.text();
+      logger.error('getCampaignInsights failed', new Error(text), { metaCampaignId });
+      return { success: false, error: text };
+    }
+    const json = await res.json();
+    const row = json?.data?.[0] || {};
+    return {
+      success: true,
+      insights: {
+        spend: Number(row.spend || 0),
+        impressions: Number(row.impressions || 0),
+        clicks: Number(row.clicks || 0),
+      },
+    };
+  } catch (error) {
+    logger.error('getCampaignInsights error', error as Error, { metaCampaignId });
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/src/services/metaAudienceService.ts
+++ b/src/services/metaAudienceService.ts
@@ -1,0 +1,83 @@
+/**
+ * metaAudienceService — build & refresh Meta Custom Audiences from a segment,
+ * using hashed phone/email (reuses hashForMeta from meta-capi). PHASE 2, DARK:
+ * fully inert until META_SYSTEM_USER_TOKEN + META_AD_ACCOUNT_ID are provisioned;
+ * the payload builder is pure/testable and runs regardless.
+ *
+ * See plans/growth-engine.md §6.5/§10. NOTE (finalization): verify the exact
+ * Meta normalization/hashing rules against current Marketing API docs before
+ * going live (their spec moves faster than any cached knowledge).
+ */
+import { loggers } from '@/lib/logger';
+import type { SegmentDefinition } from '@/types';
+import { evaluateSegment } from '@/services/segmentService';
+import { hashForMeta } from '@/lib/meta-capi';
+
+const logger = loggers.tracking;
+const GRAPH_API_VERSION = 'v21.0';
+const META_SYSTEM_USER_TOKEN = process.env.META_SYSTEM_USER_TOKEN;
+const META_AD_ACCOUNT_ID = process.env.META_AD_ACCOUNT_ID;
+
+export interface CustomAudiencePayload {
+  schema: string[]; // e.g. ['PHONE', 'EMAIL']
+  data: string[][]; // hashed rows aligned to schema
+}
+
+export function isMetaAudienceConfigured(): boolean {
+  return !!META_SYSTEM_USER_TOKEN && !!META_AD_ACCOUNT_ID;
+}
+
+/** Format a phone for Meta hashing: digits only (E.164 without '+'/spaces). */
+export function formatPhoneForMeta(phone: string): string {
+  return phone.replace(/[^0-9]/g, '');
+}
+
+/**
+ * Build the hashed Custom Audience payload for a segment. Pure transform over
+ * the segment's guests — no secrets, no network — so it is unit-testable and
+ * safe to run in the dark launch.
+ */
+export async function buildCustomAudiencePayload(
+  def: SegmentDefinition
+): Promise<CustomAudiencePayload> {
+  const guests = await evaluateSegment(def);
+  const schema = ['PHONE', 'EMAIL'];
+  const data: string[][] = [];
+  for (const g of guests) {
+    const phone = g.normalizedPhone || g.phone;
+    const phoneHash = phone ? hashForMeta(formatPhoneForMeta(phone)) : '';
+    const emailHash = g.email ? hashForMeta(g.email) : '';
+    if (phoneHash || emailHash) data.push([phoneHash, emailHash]);
+  }
+  logger.info('Built Custom Audience payload', { members: data.length });
+  return { schema, data };
+}
+
+/** Upload/refresh a Meta Custom Audience from a segment. Inert without creds. */
+export async function syncCustomAudience(
+  audienceId: string,
+  def: SegmentDefinition
+): Promise<{ success: boolean; uploaded?: number; error?: string }> {
+  if (!isMetaAudienceConfigured()) {
+    logger.warn('syncCustomAudience skipped — Meta not configured');
+    return { success: false, error: 'Meta not configured (missing system-user token / ad account)' };
+  }
+  const payload = await buildCustomAudiencePayload(def);
+  try {
+    const url = `https://graph.facebook.com/${GRAPH_API_VERSION}/${audienceId}/users`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload, access_token: META_SYSTEM_USER_TOKEN }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      logger.error('syncCustomAudience failed', new Error(text), { audienceId });
+      return { success: false, error: text };
+    }
+    return { success: true, uploaded: payload.data.length };
+  } catch (error) {
+    logger.error('syncCustomAudience error', error as Error, { audienceId });
+    return { success: false, error: (error as Error).message };
+  }
+}


### PR DESCRIPTION
## Increment 5 of the Growth Engine Core (Phase 2 foundation)

**Fully inert** until `META_SYSTEM_USER_TOKEN` + `META_AD_ACCOUNT_ID` are provisioned — this is dark Phase-2 scaffolding, not an active integration.

- **`meta-capi.ts`** — `hashForMeta` exported (was private) for reuse.
- **`metaAudienceService.ts`** — `buildCustomAudiencePayload` turns a segment into hashed PHONE/EMAIL rows (pure, unit-tested, never emits raw PII); `syncCustomAudience` uploads to a Meta Custom Audience (inert without creds).
- **`metaAdsService.ts`** — `getCampaignInsights` (the spend side of the ROAS loop; inert without creds).
- **apphosting.yaml** — documented Meta Marketing API env vars.

**Deliberately deferred to finalization** (needs a live Meta account to validate at all): programmatic campaign/ad creation, and the `admin/ads` ROAS dashboard (meaningless without real spend data). Building unvalidatable inert code for those would be churn — they belong with the Meta-creds step.

Tests: 4 pass. Build green, type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)