### PR TITLE
feat: property-scope + language-aware + local-cohort + country/language correctness

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -222,16 +222,29 @@ env:
 #     - RUNTIME
 # Marketing WhatsApp template content SIDs (from Twilio, after Meta approval).
 # Until set, the live WhatsApp path for these templates stays inert.
-# - variable: WHATSAPP_TPL_WINTER_INVITE
-#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WINTER_INVITE/versions/latest
+# Per-language content SIDs — executeSend selects by guest.language (falls back to EN).
+# - variable: WHATSAPP_TPL_WINTER_INVITE_EN
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WINTER_INVITE_EN/versions/latest
 #   availability:
 #     - RUNTIME
-# - variable: WHATSAPP_TPL_WE_MISS_YOU
-#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WE_MISS_YOU/versions/latest
+# - variable: WHATSAPP_TPL_WINTER_INVITE_RO
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WINTER_INVITE_RO/versions/latest
 #   availability:
 #     - RUNTIME
-# - variable: WHATSAPP_TPL_SEASONAL_AVAILABILITY
-#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_SEASONAL_AVAILABILITY/versions/latest
+# - variable: WHATSAPP_TPL_WE_MISS_YOU_EN
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WE_MISS_YOU_EN/versions/latest
+#   availability:
+#     - RUNTIME
+# - variable: WHATSAPP_TPL_WE_MISS_YOU_RO
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_WE_MISS_YOU_RO/versions/latest
+#   availability:
+#     - RUNTIME
+# - variable: WHATSAPP_TPL_SEASONAL_AVAILABILITY_EN
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_SEASONAL_AVAILABILITY_EN/versions/latest
+#   availability:
+#     - RUNTIME
+# - variable: WHATSAPP_TPL_SEASONAL_AVAILABILITY_RO
+#   secret: projects/1061532538391/secrets/WHATSAPP_TPL_SEASONAL_AVAILABILITY_RO/versions/latest
 #   availability:
 #     - RUNTIME
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -100,6 +100,14 @@
         { "fieldPath": "campaignId", "order": "ASCENDING" },
         { "fieldPath": "templateName", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "messageLog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "at", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -12,7 +12,7 @@ jest.mock('@/services/whatsappService', () => ({
   sendWhatsAppTemplateBySid: jest.fn().mockResolvedValue({ success: true, sid: 'SM-1' }),
 }));
 
-import { executeSend, isConsentBlocked, maskContact } from '../executionGateway';
+import { executeSend, isConsentBlocked, maskContact, resolveGuestLanguage } from '../executionGateway';
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { getGuestById } from '@/services/guestService';
 import { sendWhatsAppTemplateBySid, resolveWhatsAppTemplateSid } from '@/services/whatsappService';
@@ -84,6 +84,21 @@ describe('executionGateway pure helpers', () => {
   it('maskContact never leaks the full contact', () => {
     expect(maskContact('+40712345678')).toBe('+40712***');
     expect(maskContact('a@b.co')).toBe('a***');
+  });
+});
+
+describe('resolveGuestLanguage (H2 — country beats the en default)', () => {
+  it('explicit ro wins', () => {
+    expect(resolveGuestLanguage({ language: 'ro' })).toBe('ro');
+  });
+  it('RO/MD country => ro even when language is en or absent', () => {
+    expect(resolveGuestLanguage({ language: 'en', country: 'RO' })).toBe('ro');
+    expect(resolveGuestLanguage({ country: 'Romania' } as Parameters<typeof resolveGuestLanguage>[0])).toBe('ro');
+    expect(resolveGuestLanguage({ country: 'MD' } as Parameters<typeof resolveGuestLanguage>[0])).toBe('ro');
+  });
+  it('foreign/unknown => the language field or en', () => {
+    expect(resolveGuestLanguage({ language: 'en', country: 'US' })).toBe('en');
+    expect(resolveGuestLanguage({} as Parameters<typeof resolveGuestLanguage>[0])).toBe('en');
   });
 });
 
@@ -164,6 +179,14 @@ describe('executeSend — live mode (both switches on)', () => {
     expect(res.mode).toBe('live');
     expect(res.providerId).toBe('SM-1');
     expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ status: 'sent', providerId: 'SM-1' });
+  });
+
+  it('sends the RO template to a RO-country guest whose language defaulted to en (H2)', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ language: 'en', country: 'RO' }));
+    await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(mockResolve).toHaveBeenCalledWith('winter_invite', 'ro');
   });
 
   it('selects the RO template variant for a RO-language guest (#2)', async () => {

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -7,19 +7,21 @@ jest.mock('@/lib/firebaseAdminSafe', () => ({
 }));
 jest.mock('@/services/guestService', () => ({ getGuestById: jest.fn() }));
 jest.mock('@/services/whatsappService', () => ({
-  resolveWhatsAppTemplateSid: jest.fn((name: string) => (name === 'winter_invite' ? 'HX-test' : undefined)),
+  // 2-arg (name, language) so we can assert language-variant selection
+  resolveWhatsAppTemplateSid: jest.fn((name: string, lang: string) => (name === 'winter_invite' ? `HX-${lang}` : undefined)),
   sendWhatsAppTemplateBySid: jest.fn().mockResolvedValue({ success: true, sid: 'SM-1' }),
 }));
 
 import { executeSend, isConsentBlocked, maskContact } from '../executionGateway';
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { getGuestById } from '@/services/guestService';
-import { sendWhatsAppTemplateBySid } from '@/services/whatsappService';
+import { sendWhatsAppTemplateBySid, resolveWhatsAppTemplateSid } from '@/services/whatsappService';
 import type { Guest } from '@/types';
 
 const mockGetAdminDb = getAdminDb as jest.Mock;
 const mockGetGuestById = getGuestById as jest.Mock;
 const mockSendWhatsApp = sendWhatsAppTemplateBySid as jest.Mock;
+const mockResolve = resolveWhatsAppTemplateSid as jest.Mock;
 
 function chainableGet(result: unknown) {
   const q: Record<string, jest.Mock> = {};
@@ -91,13 +93,14 @@ describe('executeSend — dark-launch safety (default)', () => {
     mockGetAdminDb.mockResolvedValue(db);
     mockGetGuestById.mockResolvedValue(guest());
 
-    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite' });
 
     expect(mockSendWhatsApp).not.toHaveBeenCalled();
     expect(res.status).toBe('dry-run');
     expect(res.mode).toBe('dry-run');
     expect(addMock).toHaveBeenCalledTimes(1);
-    expect(addMock.mock.calls[0][0]).toMatchObject({ status: 'dry-run', to: '+40712***' });
+    // messageLog records the property for per-property audit/reporting (#1)
+    expect(addMock.mock.calls[0][0]).toMatchObject({ status: 'dry-run', to: '+40712***', propertyId: 'prahova-mountain-chalet' });
   });
 
   it('suppresses unsubscribed guests', async () => {
@@ -148,18 +151,30 @@ describe('executeSend — live mode (both switches on)', () => {
     process.env.GROWTH_ENGINE_SEND_MODE = 'live';
   });
 
-  it('delivers via WhatsApp and logs sent', async () => {
+  it('delivers via WhatsApp and logs sent, selecting the guest-language template (#2)', async () => {
     const { db, addMock } = makeDb();
     mockGetAdminDb.mockResolvedValue(db);
-    mockGetGuestById.mockResolvedValue(guest());
+    mockGetGuestById.mockResolvedValue(guest()); // language 'en'
 
     const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite', campaignId: 'c1' });
 
-    expect(mockSendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(mockResolve).toHaveBeenCalledWith('winter_invite', 'en');
+    expect(mockSendWhatsApp).toHaveBeenCalledWith('+40712345678', 'HX-en', expect.any(Object));
     expect(res.status).toBe('sent');
     expect(res.mode).toBe('live');
     expect(res.providerId).toBe('SM-1');
     expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ status: 'sent', providerId: 'SM-1' });
+  });
+
+  it('selects the RO template variant for a RO-language guest (#2)', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ language: 'ro' }));
+
+    await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+
+    expect(mockResolve).toHaveBeenCalledWith('winter_invite', 'ro');
+    expect(mockSendWhatsApp).toHaveBeenCalledWith('+40712345678', 'HX-ro', expect.any(Object));
   });
 
   it('logs failed (not delivered) when the provider reports failure', async () => {

--- a/src/services/__tests__/guestLifecycleService.test.ts
+++ b/src/services/__tests__/guestLifecycleService.test.ts
@@ -80,6 +80,43 @@ describe('runChannelAwareReactivation — audience filtering', () => {
     expect(eligible._update.mock.calls[0][0]).toHaveProperty('seasonalReactivationSentAt');
   });
 
+  it('records propertyId and reaches unknown-country guests (#1/#3)', async () => {
+    const eligible = bookingDoc({ propertyId: 'prahova-mountain-chalet', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
+    const { db } = makeDb([eligible]);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockFindGuestByPhone.mockResolvedValue({ id: 'g1', firstName: 'Ana' }); // no country => unknown => reached
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+    await runChannelAwareReactivation(NOW);
+    expect(mockExecuteSend).toHaveBeenCalledTimes(1);
+    expect(mockExecuteSend.mock.calls[0][0]).toMatchObject({
+      propertyId: 'prahova-mountain-chalet',
+      channel: 'whatsapp',
+      templateName: 'seasonal_availability',
+    });
+  });
+
+  it('skips known-foreign guests — cohort strategy targets locals (#3)', async () => {
+    const eligible = bookingDoc({ propertyId: 'p', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
+    const { db } = makeDb([eligible]);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockFindGuestByPhone.mockResolvedValue({ id: 'g1', firstName: 'John', country: 'US' });
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+    const stats = await runChannelAwareReactivation(NOW);
+    expect(mockExecuteSend).not.toHaveBeenCalled();
+    expect(stats).toMatchObject({ attempted: 0, skipped: 1 });
+  });
+
+  it('reaches RO guests (#3)', async () => {
+    const eligible = bookingDoc({ propertyId: 'p', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
+    const { db } = makeDb([eligible]);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockFindGuestByPhone.mockResolvedValue({ id: 'g1', firstName: 'Ana', country: 'RO' });
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+    const stats = await runChannelAwareReactivation(NOW);
+    expect(mockExecuteSend).toHaveBeenCalledTimes(1);
+    expect(stats.attempted).toBe(1);
+  });
+
   it('skips guests who already re-booked since the stay', async () => {
     const eligible = bookingDoc({ guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
     const { db } = makeDb([eligible]);

--- a/src/services/__tests__/guestLifecycleService.test.ts
+++ b/src/services/__tests__/guestLifecycleService.test.ts
@@ -106,6 +106,17 @@ describe('runChannelAwareReactivation — audience filtering', () => {
     expect(stats).toMatchObject({ attempted: 0, skipped: 1 });
   });
 
+  it('normalizes country — a "Romania" guest is reached, not skipped (H3)', async () => {
+    const eligible = bookingDoc({ propertyId: 'p', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
+    const { db } = makeDb([eligible]);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockFindGuestByPhone.mockResolvedValue({ id: 'g1', firstName: 'Ana', country: 'Romania' });
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+    const stats = await runChannelAwareReactivation(NOW);
+    expect(mockExecuteSend).toHaveBeenCalledTimes(1);
+    expect(stats.attempted).toBe(1);
+  });
+
   it('reaches RO guests (#3)', async () => {
     const eligible = bookingDoc({ propertyId: 'p', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
     const { db } = makeDb([eligible]);

--- a/src/services/__tests__/segmentService.test.ts
+++ b/src/services/__tests__/segmentService.test.ts
@@ -57,6 +57,10 @@ describe('segmentService.matchesDefinition', () => {
     expect(matchesDefinition(guest({ country: 'IL' }), { countryIn: ['RO'] }, NOW)).toBe(false);
     expect(matchesDefinition(guest({ country: undefined }), { countryIn: ['RO'] }, NOW)).toBe(false);
   });
+  it('normalizes country names/aliases before matching (H3)', () => {
+    expect(matchesDefinition(guest({ country: 'Romania' }), { countryIn: ['RO'] }, NOW)).toBe(true);
+    expect(matchesDefinition(guest({ country: 'Romania' }), { countryNotIn: ['RO'] }, NOW)).toBe(false);
+  });
   it('countryNotIn requires a KNOWN country — unknown is NOT foreign (M3)', () => {
     expect(matchesDefinition(guest({ country: 'IL' }), { countryNotIn: ['RO'] }, NOW)).toBe(true);
     expect(matchesDefinition(guest({ country: 'RO' }), { countryNotIn: ['RO'] }, NOW)).toBe(false);

--- a/src/services/__tests__/whatsappService.test.ts
+++ b/src/services/__tests__/whatsappService.test.ts
@@ -1,0 +1,46 @@
+/** @jest-environment node */
+
+/**
+ * Language-aware template resolution (#2). The marketing registry reads env at
+ * module load, so each case sets env then re-requires the module.
+ */
+describe('resolveWhatsAppTemplateSid — language selection', () => {
+  const orig = { ...process.env };
+  afterEach(() => {
+    process.env = { ...orig };
+    jest.resetModules();
+  });
+
+  it('selects the requested language variant', () => {
+    process.env.WHATSAPP_TPL_WINTER_INVITE_EN = 'HX-en';
+    process.env.WHATSAPP_TPL_WINTER_INVITE_RO = 'HX-ro';
+    jest.resetModules();
+    const { resolveWhatsAppTemplateSid } = require('../whatsappService');
+    expect(resolveWhatsAppTemplateSid('winter_invite', 'ro')).toBe('HX-ro');
+    expect(resolveWhatsAppTemplateSid('winter_invite', 'en')).toBe('HX-en');
+  });
+
+  it('falls back to EN when the language variant is unset', () => {
+    process.env.WHATSAPP_TPL_WINTER_INVITE_EN = 'HX-en';
+    delete process.env.WHATSAPP_TPL_WINTER_INVITE_RO;
+    jest.resetModules();
+    const { resolveWhatsAppTemplateSid } = require('../whatsappService');
+    expect(resolveWhatsAppTemplateSid('winter_invite', 'ro')).toBe('HX-en');
+  });
+
+  it('returns undefined for an unapproved template (no env set = inert)', () => {
+    delete process.env.WHATSAPP_TPL_WINTER_INVITE_EN;
+    delete process.env.WHATSAPP_TPL_WINTER_INVITE_RO;
+    jest.resetModules();
+    const { resolveWhatsAppTemplateSid } = require('../whatsappService');
+    expect(resolveWhatsAppTemplateSid('winter_invite', 'en')).toBeUndefined();
+    expect(resolveWhatsAppTemplateSid('unknown_template', 'en')).toBeUndefined();
+  });
+
+  it('resolves ops templates regardless of language (single SID)', () => {
+    jest.resetModules();
+    const { resolveWhatsAppTemplateSid } = require('../whatsappService');
+    // curatenie_test is a real ops template SID in the registry
+    expect(resolveWhatsAppTemplateSid('curatenie_test', 'ro')).toBeDefined();
+  });
+});

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -169,6 +169,7 @@ export async function sendCampaign(
 
     const result = await executeSend({
       guestId: guest.id,
+      propertyId: campaign.propertyId,
       channel: campaign.channel,
       templateName: campaign.templateName,
       variables: campaign.variables,

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -13,7 +13,7 @@
  */
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
-import type { Guest, ChannelType, ConsentState, MessageLogStatus } from '@/types';
+import type { Guest, ChannelType, ConsentState, MessageLogStatus, LanguageCode } from '@/types';
 import { getSendMode } from '@/config/growth-engine';
 import { getGuestById } from '@/services/guestService';
 import { normalizePhone } from '@/lib/sanitize';
@@ -24,6 +24,7 @@ type AdminDb = Awaited<ReturnType<typeof getAdminDb>>;
 
 export interface SendRequest {
   guestId: string;
+  propertyId?: string; // which property this send is for (recorded on messageLog)
   channel: ChannelType;
   templateName: string;
   variables?: Record<string, string>;
@@ -119,6 +120,7 @@ async function alreadyDelivered(db: AdminDb, req: SendRequest): Promise<boolean>
 
 interface MessageLogInput {
   guestId: string;
+  propertyId: string | null;
   channel: ChannelType;
   campaignId: string | null;
   templateName: string | null;
@@ -148,6 +150,7 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
 
   const base = {
     guestId: req.guestId,
+    propertyId: req.propertyId ?? null,
     channel: req.channel,
     campaignId: req.campaignId ?? null,
     templateName: req.templateName ?? null,
@@ -238,7 +241,7 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
   // mislabel an already-delivered message as 'failed' and cause a re-send (M2).
   let delivery: { success: boolean; providerId?: string; error?: string };
   try {
-    delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {});
+    delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {}, guest.language || 'en');
   } catch (error) {
     logger.error('Live send threw', error as Error, {
       guestId: req.guestId,
@@ -273,13 +276,14 @@ async function deliverLive(
   channel: ChannelType,
   contact: string,
   templateName: string,
-  variables: Record<string, string>
+  variables: Record<string, string>,
+  language: LanguageCode
 ): Promise<{ success: boolean; providerId?: string; error?: string }> {
   if (channel === 'whatsapp') {
     const { resolveWhatsAppTemplateSid, sendWhatsAppTemplateBySid } = await import(
       '@/services/whatsappService'
     );
-    const sid = resolveWhatsAppTemplateSid(templateName);
+    const sid = resolveWhatsAppTemplateSid(templateName, language);
     if (!sid) {
       // Unknown name, or a marketing template whose SID isn't approved/set yet.
       return {

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -17,6 +17,7 @@ import type { Guest, ChannelType, ConsentState, MessageLogStatus, LanguageCode }
 import { getSendMode } from '@/config/growth-engine';
 import { getGuestById } from '@/services/guestService';
 import { normalizePhone } from '@/lib/sanitize';
+import { normalizeCountryCode } from '@/lib/country-utils';
 
 const logger = loggers.executionGateway;
 
@@ -51,6 +52,20 @@ export function isConsentBlocked(
   if (guest.unsubscribed) return true;
   const state: ConsentState | undefined = guest.channelConsent?.[channel];
   return state === 'opted_out';
+}
+
+/**
+ * Effective message language for a guest. For this RO-first business, the guest's
+ * country is a better predictor than the `language` field, which defaults to 'en'
+ * for imported/phone-only guests (the exact reactivation base) — so a RO/MD guest
+ * gets Romanian even when `language` was never captured (H2). An explicit 'ro'
+ * always wins.
+ */
+export function resolveGuestLanguage(guest: Pick<Guest, 'language' | 'country'>): LanguageCode {
+  if (guest.language === 'ro') return 'ro';
+  const code = guest.country ? normalizeCountryCode(guest.country) : undefined;
+  if (code === 'RO' || code === 'MD') return 'ro';
+  return guest.language || 'en';
 }
 
 /** Mask a phone/email for logging (never store full contact in messageLog). */
@@ -241,7 +256,7 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
   // mislabel an already-delivered message as 'failed' and cause a re-send (M2).
   let delivery: { success: boolean; providerId?: string; error?: string };
   try {
-    delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {}, guest.language || 'en');
+    delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {}, resolveGuestLanguage(guest));
   } catch (error) {
     logger.error('Live send threw', error as Error, {
       guestId: req.guestId,

--- a/src/services/guestLifecycleService.ts
+++ b/src/services/guestLifecycleService.ts
@@ -67,10 +67,22 @@ export async function runChannelAwareReactivation(now: Date = new Date()): Promi
         continue;
       }
 
+      // Cohort strategy: automatic reactivation targets LOCALS — RO or
+      // unknown-country guests, who can realistically return. Known-foreign
+      // guests (unlikely to travel back) are skipped here; reach them
+      // deliberately via a targeted campaign instead, not this auto-nudge.
+      if (guest.country && guest.country !== 'RO') {
+        stats.skipped++;
+        continue;
+      }
+
       stats.attempted++;
 
+      // executeSend auto-selects the WhatsApp template variant by guest.language
+      // and records data.propertyId on the messageLog audit entry.
       const result = await executeSend({
         guestId: guest.id,
+        propertyId: data.propertyId,
         channel: 'whatsapp',
         templateName: 'seasonal_availability',
         variables: { '1': guest.firstName || '' },

--- a/src/services/guestLifecycleService.ts
+++ b/src/services/guestLifecycleService.ts
@@ -16,6 +16,7 @@ import { loggers } from '@/lib/logger';
 import { executeSend } from '@/services/executionGateway';
 import { findGuestByPhone } from '@/services/guestService';
 import { parseFirestoreDate } from '@/lib/growth/date-utils';
+import { normalizeCountryCode } from '@/lib/country-utils';
 
 const logger = loggers.campaign;
 const DAY_MS = 1000 * 60 * 60 * 24;
@@ -67,11 +68,14 @@ export async function runChannelAwareReactivation(now: Date = new Date()): Promi
         continue;
       }
 
-      // Cohort strategy: automatic reactivation targets LOCALS — RO or
+      // Cohort strategy: automatic reactivation targets LOCALS — RO/MD or
       // unknown-country guests, who can realistically return. Known-foreign
       // guests (unlikely to travel back) are skipped here; reach them
       // deliberately via a targeted campaign instead, not this auto-nudge.
-      if (guest.country && guest.country !== 'RO') {
+      // Normalize first so "Romania"/"ro" aren't mistaken for foreign (H3);
+      // unrecognized/undefined => treated as unknown => reached (safe direction).
+      const countryCode = guest.country ? normalizeCountryCode(guest.country) : undefined;
+      if (countryCode && countryCode !== 'RO' && countryCode !== 'MD') {
         stats.skipped++;
         continue;
       }

--- a/src/services/segmentService.ts
+++ b/src/services/segmentService.ts
@@ -13,6 +13,7 @@ import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
 import type { Guest, SegmentDefinition, ChannelType, Season } from '@/types';
 import { parseFirestoreDate, seasonOf, monthsBetween } from '@/lib/growth/date-utils';
+import { normalizeCountryCode } from '@/lib/country-utils';
 
 const logger = loggers.segment;
 
@@ -50,14 +51,18 @@ export function matchesDefinition(
     return false;
   }
 
+  // Normalize the stored country (may be an ISO code, a name like "Romania", or
+  // un-normalized) to an ISO code before comparing — otherwise "Romania" wouldn't
+  // match countryIn:['RO'] and the RO/foreign axis silently breaks (H3).
+  const countryCode = guest.country ? normalizeCountryCode(guest.country) : undefined;
   if (def.countryIn && def.countryIn.length > 0) {
-    if (!guest.country || !def.countryIn.includes(guest.country)) return false;
+    if (!countryCode || !def.countryIn.includes(countryCode)) return false;
   }
   if (def.countryNotIn && def.countryNotIn.length > 0) {
-    // Symmetric with countryIn: a guest with unknown country is NOT classifiable
-    // as "not in X", so exclude them rather than treating unknown as foreign (M3).
-    if (!guest.country) return false;
-    if (def.countryNotIn.includes(guest.country)) return false;
+    // Unknown country isn't classifiable as "not in X" — exclude, don't treat
+    // unknown as foreign (M3).
+    if (!countryCode) return false;
+    if (def.countryNotIn.includes(countryCode)) return false;
   }
 
   if (def.tagsInclude && def.tagsInclude.length > 0) {

--- a/src/services/whatsappService.ts
+++ b/src/services/whatsappService.ts
@@ -1,4 +1,5 @@
 import { loggers } from '@/lib/logger';
+import type { LanguageCode } from '@/types';
 
 const logger = loggers.whatsapp;
 
@@ -45,24 +46,36 @@ export type WhatsAppTemplateName = keyof typeof WHATSAPP_TEMPLATES;
  * until the templates are approved in Twilio/Meta, so the live send path stays
  * inert until finalization. See plans/growth-engine.md section 6.6 / 10.
  */
-export const WHATSAPP_MARKETING_TEMPLATES = {
-  winter_invite: process.env.WHATSAPP_TPL_WINTER_INVITE || '',
-  we_miss_you: process.env.WHATSAPP_TPL_WE_MISS_YOU || '',
-  seasonal_availability: process.env.WHATSAPP_TPL_SEASONAL_AVAILABILITY || '',
-} as const;
+export const WHATSAPP_MARKETING_TEMPLATES: Record<string, Partial<Record<LanguageCode, string>>> = {
+  winter_invite: {
+    en: process.env.WHATSAPP_TPL_WINTER_INVITE_EN || '',
+    ro: process.env.WHATSAPP_TPL_WINTER_INVITE_RO || '',
+  },
+  we_miss_you: {
+    en: process.env.WHATSAPP_TPL_WE_MISS_YOU_EN || '',
+    ro: process.env.WHATSAPP_TPL_WE_MISS_YOU_RO || '',
+  },
+  seasonal_availability: {
+    en: process.env.WHATSAPP_TPL_SEASONAL_AVAILABILITY_EN || '',
+    ro: process.env.WHATSAPP_TPL_SEASONAL_AVAILABILITY_RO || '',
+  },
+};
 
 export type WhatsAppMarketingTemplateName = keyof typeof WHATSAPP_MARKETING_TEMPLATES;
 
 /**
- * Resolve a Twilio content SID from either the ops or the marketing registry.
- * Returns undefined for unknown names OR marketing templates whose SID env var
- * isn't set yet (unapproved) — callers treat that as "not deliverable".
+ * Resolve a Twilio content SID from the ops registry (single SID) or the
+ * marketing registry (per-language). For marketing templates, selects the
+ * guest's language, falling back to EN. Returns undefined for unknown names OR
+ * marketing templates whose SID env var isn't set yet (unapproved) — callers
+ * treat that as "not deliverable".
  */
-export function resolveWhatsAppTemplateSid(name: string): string | undefined {
-  const sid =
-    (WHATSAPP_TEMPLATES as Record<string, string>)[name] ??
-    (WHATSAPP_MARKETING_TEMPLATES as Record<string, string>)[name];
-  return sid || undefined;
+export function resolveWhatsAppTemplateSid(name: string, language: LanguageCode = 'en'): string | undefined {
+  const ops = (WHATSAPP_TEMPLATES as Record<string, string>)[name];
+  if (ops) return ops || undefined;
+  const variants = WHATSAPP_MARKETING_TEMPLATES[name];
+  if (!variants) return undefined;
+  return variants[language] || variants.en || undefined;
 }
 
 // ============================================================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -349,6 +349,7 @@ export type MessageLogStatus =
 export interface MessageLog {
   id: string;
   guestId: string;
+  propertyId?: string | null; // which property this message was for (audit/reporting)
   channel: ChannelType;
   campaignId?: string | null;
   templateName?: string | null;


### PR DESCRIPTION
Closes the domain-completeness gaps a multi-property, bilingual operator would hit.

**#1 Property-aware execution** — `propertyId` threads `SendRequest` → `messageLog` (per-property audit) + index; campaign & reactivation pass it.
**#2 Language-aware sends** — per-language template SIDs (`_EN`/`_RO`); `executeSend` selects `guest.language`, falls back to EN.
**#3 Local-cohort reactivation** — targets RO/MD + unknown-country; known-foreign skipped.
**H2** — `resolveGuestLanguage`: RO/MD country ⇒ Romanian even when `language` defaulted to `'en'` (the imported base).
**H3** — normalize `country` (ISO or name) before RO/foreign comparisons in segments + cohort; unrecognized ⇒ unknown ⇒ reached.

Reviewed by a **domain-completeness** pass (not just safety). Remaining findings (H1 property *branding* in content, H4 frequency cap, M1 Coltei city-apartment strategy, M2/M3 composer UX) are surfaced as explicit decisions — several are business calls, not bugs. 99 service tests pass; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)