### PR TITLE
feat: per-property config + property branding + frequency cap + composer polish

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -238,6 +238,11 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only
     }
 
+    match /growthConfig/{propertyId} {
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (per-property reactivation config)
+    }
+
     // ============================================================================
     // App Config
     // ============================================================================

--- a/src/app/admin/campaigns/_components/campaign-composer.tsx
+++ b/src/app/admin/campaigns/_components/campaign-composer.tsx
@@ -16,7 +16,13 @@ export function CampaignComposer({ propertyId }: { propertyId: string }) {
   const [name, setName] = useState('');
   const [segmentKey, setSegmentKey] = useState(SEGMENT_CATALOG[0].key);
   const [templateName, setTemplateName] = useState(TEMPLATE_CATALOG[0].key);
-  const [preview, setPreview] = useState<{ count: number; whatsapp: number } | null>(null);
+  const [preview, setPreview] = useState<{
+    count: number;
+    reachable: number;
+    suppressed: number;
+    ro: number;
+    en: number;
+  } | null>(null);
   const [previewing, startPreview] = useTransition();
   const [creating, startCreate] = useTransition();
 
@@ -24,7 +30,14 @@ export function CampaignComposer({ propertyId }: { propertyId: string }) {
     setPreview(null);
     startPreview(async () => {
       const res = await previewSegmentAction(key, propertyId);
-      if (res.success) setPreview({ count: res.count ?? 0, whatsapp: res.whatsapp ?? 0 });
+      if (res.success)
+        setPreview({
+          count: res.count ?? 0,
+          reachable: res.reachable ?? 0,
+          suppressed: res.suppressed ?? 0,
+          ro: res.ro ?? 0,
+          en: res.en ?? 0,
+        });
       else toast({ title: 'Preview failed', description: res.error, variant: 'destructive' });
     });
   };
@@ -87,9 +100,14 @@ export function CampaignComposer({ propertyId }: { propertyId: string }) {
               </>
             ) : preview ? (
               <>
-                <Users className="h-4 w-4 text-muted-foreground" />
+                <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
                 <span>
-                  <strong>{preview.count}</strong> guests · <strong>{preview.whatsapp}</strong> reachable on WhatsApp
+                  <strong>{preview.reachable}</strong> reachable
+                  {preview.suppressed > 0 ? ` (${preview.suppressed} opted out)` : ''}
+                  {' · '}
+                  <strong>{preview.ro}</strong> RO / <strong>{preview.en}</strong> EN
+                  {' · '}
+                  <span className="text-muted-foreground">{preview.count} total</span>
                 </span>
               </>
             ) : (

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -48,7 +48,15 @@ export async function fetchCampaigns(propertyId: string): Promise<Campaign[]> {
 export async function previewSegmentAction(
   segmentKey: string,
   propertyId: string
-): Promise<{ success: boolean; count?: number; whatsapp?: number; error?: string }> {
+): Promise<{
+  success: boolean;
+  count?: number;
+  reachable?: number;
+  suppressed?: number;
+  ro?: number;
+  en?: number;
+  error?: string;
+}> {
   try {
     await requireSuperAdmin();
   } catch (error) {
@@ -57,7 +65,14 @@ export async function previewSegmentAction(
   }
   try {
     const preview = await previewAudience(buildSegmentDefinition(segmentKey, propertyId));
-    return { success: true, count: preview.count, whatsapp: preview.byChannel.whatsapp };
+    return {
+      success: true,
+      count: preview.count,
+      reachable: preview.reachable,
+      suppressed: preview.suppressed,
+      ro: preview.byLanguage.ro,
+      en: preview.byLanguage.en,
+    };
   } catch (error) {
     logger.error('previewSegmentAction failed', error as Error);
     return { success: false, error: 'Failed to preview audience' };

--- a/src/config/growth-engine.ts
+++ b/src/config/growth-engine.ts
@@ -42,4 +42,6 @@ export const GROWTH_ENGINE_LIMITS = {
   /** Quiet hours in property-local time (Europe/Bucharest) — no sends inside. */
   quietHoursStart: 21,
   quietHoursEnd: 9,
+  /** Min days between marketing touches to a guest, across all campaigns (H4). */
+  frequencyCapDays: Number(process.env.GROWTH_ENGINE_FREQUENCY_CAP_DAYS) || 14,
 } as const;

--- a/src/lib/growth/language.ts
+++ b/src/lib/growth/language.ts
@@ -1,0 +1,19 @@
+import type { Guest, LanguageCode } from '@/types';
+import { normalizeCountryCode } from '@/lib/country-utils';
+
+/**
+ * Effective message language for a guest. For this RO-first business, the
+ * guest's country is a better predictor than the `language` field, which
+ * defaults to 'en' for imported/phone-only guests (the exact reactivation
+ * base) — so a RO/MD guest gets Romanian even when `language` was never
+ * captured. An explicit 'ro' always wins. (H2)
+ *
+ * Pure + dependency-light so both the send path and the audience preview can
+ * use one source of truth.
+ */
+export function resolveGuestLanguage(guest: Pick<Guest, 'language' | 'country'>): LanguageCode {
+  if (guest.language === 'ro') return 'ro';
+  const code = guest.country ? normalizeCountryCode(guest.country) : undefined;
+  if (code === 'RO' || code === 'MD') return 'ro';
+  return guest.language || 'en';
+}

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -32,15 +32,25 @@ function chainableGet(result: unknown) {
 }
 
 /** Chainable Firestore mock; toggles suppressionList hit and prior-delivery dedup. */
-function makeDb({ suppressed = false, priorDelivered = false }: { suppressed?: boolean; priorDelivered?: boolean } = {}) {
+function makeDb({ suppressed = false, priorDelivered = false, propertyName = 'Prahova Mountain Chalet' }: { suppressed?: boolean; priorDelivered?: boolean; propertyName?: string } = {}) {
   const addMock = jest.fn().mockResolvedValue({ id: 'log-123' });
+  const guestUpdateMock = jest.fn().mockResolvedValue(undefined);
   const suppressionQuery = chainableGet({ empty: !suppressed });
   const messageLogQuery = chainableGet({ docs: priorDelivered ? [{ data: () => ({ status: 'sent' }) }] : [] });
   const messageLogCol = { add: addMock, where: messageLogQuery.where };
+  const propertiesDoc = { get: jest.fn().mockResolvedValue({ exists: true, data: () => ({ name: propertyName }) }) };
+  const overridesDoc = { get: jest.fn().mockResolvedValue({ exists: false, data: () => ({}) }) };
+  const guestsDoc = { update: guestUpdateMock };
   const db = {
-    collection: jest.fn((name: string) => (name === 'messageLog' ? messageLogCol : suppressionQuery)),
+    collection: jest.fn((name: string) => {
+      if (name === 'messageLog') return messageLogCol;
+      if (name === 'properties') return { doc: jest.fn(() => propertiesDoc) };
+      if (name === 'propertyOverrides') return { doc: jest.fn(() => overridesDoc) };
+      if (name === 'guests') return { doc: jest.fn(() => guestsDoc) };
+      return suppressionQuery; // suppressionList
+    }),
   };
-  return { db, addMock };
+  return { db, addMock, guestUpdateMock };
 }
 
 function guest(overrides: Partial<Guest> = {}): Guest {
@@ -118,6 +128,23 @@ describe('executeSend — dark-launch safety (default)', () => {
     expect(addMock.mock.calls[0][0]).toMatchObject({ status: 'dry-run', to: '+40712***', propertyId: 'prahova-mountain-chalet' });
   });
 
+  it('skips a guest within the frequency-cap window (H4)', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ lastCampaignAt: { _seconds: Math.floor(Date.now() / 1000) - 2 * 86400 } as unknown as Guest['lastCampaignAt'] }));
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('frequency-cap');
+  });
+
+  it('does not cap a guest whose last touch predates the window (H4)', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ lastCampaignAt: { _seconds: Math.floor(Date.now() / 1000) - 30 * 86400 } as unknown as Guest['lastCampaignAt'] }));
+    const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('dry-run');
+  });
+
   it('suppresses unsubscribed guests', async () => {
     const { db, addMock } = makeDb();
     mockGetAdminDb.mockResolvedValue(db);
@@ -179,6 +206,14 @@ describe('executeSend — live mode (both switches on)', () => {
     expect(res.mode).toBe('live');
     expect(res.providerId).toBe('SM-1');
     expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ status: 'sent', providerId: 'SM-1' });
+  });
+
+  it('property-brands the live message with the property name (H1)', async () => {
+    const { db } = makeDb({ propertyName: 'Prahova Mountain Chalet' });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+    await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(mockSendWhatsApp).toHaveBeenCalledWith('+40712345678', 'HX-en', expect.objectContaining({ property: 'Prahova Mountain Chalet' }));
   });
 
   it('sends the RO template to a RO-country guest whose language defaulted to en (H2)', async () => {

--- a/src/services/__tests__/growthConfigService.test.ts
+++ b/src/services/__tests__/growthConfigService.test.ts
@@ -1,0 +1,59 @@
+/** @jest-environment node */
+jest.mock('@/lib/firebaseAdminSafe', () => ({ getAdminDb: jest.fn() }));
+
+import {
+  getGrowthPropertyConfig,
+  clearGrowthConfigCache,
+  DEFAULT_GROWTH_PROPERTY_CONFIG,
+} from '../growthConfigService';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb(configDoc: Record<string, unknown> | null) {
+  const db = {
+    collection: jest.fn(() => ({
+      doc: jest.fn(() => ({
+        get: jest.fn().mockResolvedValue({ exists: !!configDoc, data: () => configDoc }),
+      })),
+    })),
+  };
+  return db;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearGrowthConfigCache();
+});
+
+describe('getGrowthPropertyConfig', () => {
+  it('returns the SAFE default (reactivation OFF) for an unconfigured property', async () => {
+    mockGetAdminDb.mockResolvedValue(makeDb(null));
+    const config = await getGrowthPropertyConfig('some-property');
+    expect(config).toEqual(DEFAULT_GROWTH_PROPERTY_CONFIG);
+    expect(config.reactivationEnabled).toBe(false);
+  });
+
+  it('merges a stored config over the defaults', async () => {
+    mockGetAdminDb.mockResolvedValue(makeDb({ reactivationEnabled: true, reactivationCohort: 'all' }));
+    const config = await getGrowthPropertyConfig('coltei-apartment-bucharest');
+    expect(config.reactivationEnabled).toBe(true);
+    expect(config.reactivationCohort).toBe('all');
+    // unspecified field falls back to default
+    expect(config.reactivationTemplate).toBe(DEFAULT_GROWTH_PROPERTY_CONFIG.reactivationTemplate);
+  });
+
+  it('caches per property (one Firestore read)', async () => {
+    const db = makeDb({ reactivationEnabled: true });
+    mockGetAdminDb.mockResolvedValue(db);
+    await getGrowthPropertyConfig('p1');
+    await getGrowthPropertyConfig('p1');
+    expect(db.collection).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to defaults if the read throws', async () => {
+    mockGetAdminDb.mockRejectedValue(new Error('firestore down'));
+    const config = await getGrowthPropertyConfig('p2');
+    expect(config).toEqual(DEFAULT_GROWTH_PROPERTY_CONFIG);
+  });
+});

--- a/src/services/__tests__/guestLifecycleService.test.ts
+++ b/src/services/__tests__/guestLifecycleService.test.ts
@@ -6,11 +6,15 @@ jest.mock('@/lib/firebaseAdminSafe', () => ({
 }));
 jest.mock('@/services/guestService', () => ({ findGuestByPhone: jest.fn() }));
 jest.mock('@/services/executionGateway', () => ({ executeSend: jest.fn() }));
+jest.mock('@/services/growthConfigService', () => ({ getGrowthPropertyConfig: jest.fn() }));
 
 import { runChannelAwareReactivation } from '../guestLifecycleService';
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { findGuestByPhone } from '@/services/guestService';
 import { executeSend } from '@/services/executionGateway';
+import { getGrowthPropertyConfig } from '@/services/growthConfigService';
+
+const mockGetConfig = getGrowthPropertyConfig as jest.Mock;
 
 const mockGetAdminDb = getAdminDb as jest.Mock;
 const mockFindGuestByPhone = findGuestByPhone as jest.Mock;
@@ -38,6 +42,11 @@ beforeEach(() => {
   delete process.env.GROWTH_ENGINE_SEND_MODE;
   jest.clearAllMocks();
   mockFindGuestByPhone.mockResolvedValue({ id: 'g1', firstName: 'Ana', normalizedPhone: '+40712345678' });
+  mockGetConfig.mockResolvedValue({
+    reactivationEnabled: true,
+    reactivationCohort: 'locals',
+    reactivationTemplate: 'seasonal_availability',
+  });
 });
 
 describe('runChannelAwareReactivation — audience filtering', () => {
@@ -78,6 +87,28 @@ describe('runChannelAwareReactivation — audience filtering', () => {
     expect(stats).toMatchObject({ attempted: 1, sent: 1 });
     expect(eligible._update).toHaveBeenCalledTimes(1);
     expect(eligible._update.mock.calls[0][0]).toHaveProperty('seasonalReactivationSentAt');
+  });
+
+  it('does nothing for a property whose reactivation is disabled (M1)', async () => {
+    const eligible = bookingDoc({ propertyId: 'coltei-apartment-bucharest', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
+    const { db } = makeDb([eligible]);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetConfig.mockResolvedValue({ reactivationEnabled: false, reactivationCohort: 'locals', reactivationTemplate: 'seasonal_availability' });
+    const stats = await runChannelAwareReactivation(NOW);
+    expect(mockExecuteSend).not.toHaveBeenCalled();
+    expect(stats.attempted).toBe(0);
+  });
+
+  it("cohort 'all' reaches foreign guests too, and uses the property's template (M1)", async () => {
+    const eligible = bookingDoc({ propertyId: 'coltei-apartment-bucharest', guestInfo: { phone: '+40712345678' }, checkOutDate: secondsFor(90) });
+    const { db } = makeDb([eligible]);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockFindGuestByPhone.mockResolvedValue({ id: 'g1', firstName: 'John', country: 'US' });
+    mockGetConfig.mockResolvedValue({ reactivationEnabled: true, reactivationCohort: 'all', reactivationTemplate: 'city_comeback' });
+    mockExecuteSend.mockResolvedValue({ status: 'dry-run', mode: 'dry-run' });
+    await runChannelAwareReactivation(NOW);
+    expect(mockExecuteSend).toHaveBeenCalledTimes(1);
+    expect(mockExecuteSend.mock.calls[0][0]).toMatchObject({ templateName: 'city_comeback' });
   });
 
   it('records propertyId and reaches unknown-country guests (#1/#3)', async () => {

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -14,10 +14,11 @@
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
 import type { Guest, ChannelType, ConsentState, MessageLogStatus, LanguageCode } from '@/types';
-import { getSendMode } from '@/config/growth-engine';
+import { getSendMode, GROWTH_ENGINE_LIMITS } from '@/config/growth-engine';
 import { getGuestById } from '@/services/guestService';
 import { normalizePhone } from '@/lib/sanitize';
-import { normalizeCountryCode } from '@/lib/country-utils';
+import { resolveGuestLanguage } from '@/lib/growth/language';
+import { parseFirestoreDate } from '@/lib/growth/date-utils';
 
 const logger = loggers.executionGateway;
 
@@ -54,19 +55,9 @@ export function isConsentBlocked(
   return state === 'opted_out';
 }
 
-/**
- * Effective message language for a guest. For this RO-first business, the guest's
- * country is a better predictor than the `language` field, which defaults to 'en'
- * for imported/phone-only guests (the exact reactivation base) — so a RO/MD guest
- * gets Romanian even when `language` was never captured (H2). An explicit 'ro'
- * always wins.
- */
-export function resolveGuestLanguage(guest: Pick<Guest, 'language' | 'country'>): LanguageCode {
-  if (guest.language === 'ro') return 'ro';
-  const code = guest.country ? normalizeCountryCode(guest.country) : undefined;
-  if (code === 'RO' || code === 'MD') return 'ro';
-  return guest.language || 'en';
-}
+// resolveGuestLanguage lives in @/lib/growth/language (shared with the audience
+// preview); re-exported here for existing callers/tests. (H2)
+export { resolveGuestLanguage };
 
 /** Mask a phone/email for logging (never store full contact in messageLog). */
 export function maskContact(contact: string): string {
@@ -155,6 +146,29 @@ async function writeMessageLog(db: AdminDb, entry: MessageLogInput): Promise<str
 }
 
 /**
+ * Resolve a property's display name (for property-branding the message, H1).
+ * Cached per process; falls back to the id so a lookup miss never blocks a send.
+ */
+const propertyNameCache = new Map<string, string>();
+async function getPropertyName(db: AdminDb, propertyId: string): Promise<string> {
+  const cached = propertyNameCache.get(propertyId);
+  if (cached) return cached;
+  let name = propertyId;
+  try {
+    const prop = await db.collection('properties').doc(propertyId).get();
+    name = (prop.data()?.name as string) || name;
+    if (name === propertyId) {
+      const ov = await db.collection('propertyOverrides').doc(propertyId).get();
+      name = (ov.data()?.propertyMeta?.name as string) || name;
+    }
+  } catch {
+    logger.warn('getPropertyName failed; using id', { propertyId });
+  }
+  propertyNameCache.set(propertyId, name);
+  return name;
+}
+
+/**
  * Execute (or dry-run) a single outbound message. Every path writes exactly one
  * messageLog entry so the audit trail is complete regardless of outcome.
  */
@@ -220,6 +234,24 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     return { status: 'skipped', reason: 'dedup', messageLogId: id, mode };
   }
 
+  // 2.6) frequency cap — don't message a guest more than once per window across
+  // ALL campaigns + reactivation (H4). Only real deliveries set lastCampaignAt,
+  // so dry-run previews never trip this and can be re-run freely.
+  const lastCampaignAt = parseFirestoreDate(guest.lastCampaignAt);
+  if (lastCampaignAt) {
+    const daysSince = (new Date().getTime() - lastCampaignAt.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSince < GROWTH_ENGINE_LIMITS.frequencyCapDays) {
+      const id = await writeMessageLog(db, {
+        ...base,
+        status: 'skipped',
+        reason: 'frequency-cap',
+        to: null,
+        providerId: null,
+      });
+      return { status: 'skipped', reason: 'frequency-cap', messageLogId: id, mode };
+    }
+  }
+
   // 3) resolve a contact for the channel
   const contact = resolveContact(guest, req.channel);
   if (!contact) {
@@ -254,9 +286,17 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
   // 5) LIVE delivery (only when both flags are flipped). Delivery and the log
   // write are deliberately separated so a Firestore log-write failure can never
   // mislabel an already-delivered message as 'failed' and cause a re-send (M2).
+  // Property-brand the message: inject the property name as a `property`
+  // template variable so the guest knows which property is reaching out (H1).
+  // The approved marketing template must reference {{property}}.
+  const propertyName = req.propertyId ? await getPropertyName(db, req.propertyId) : undefined;
+  const liveVars = propertyName
+    ? { ...(req.variables || {}), property: propertyName }
+    : req.variables || {};
+
   let delivery: { success: boolean; providerId?: string; error?: string };
   try {
-    delivery = await deliverLive(req.channel, contact, req.templateName, req.variables || {}, resolveGuestLanguage(guest));
+    delivery = await deliverLive(req.channel, contact, req.templateName, liveVars, resolveGuestLanguage(guest));
   } catch (error) {
     logger.error('Live send threw', error as Error, {
       guestId: req.guestId,
@@ -273,6 +313,19 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     to: maskContact(contact),
     providerId: delivery.providerId ?? null,
   });
+
+  // Record the touch on the GUEST (not just the booking) so the frequency cap
+  // and cross-campaign dedup work across properties (H4). Best-effort.
+  if (delivery.success) {
+    try {
+      await db.collection('guests').doc(req.guestId).update({
+        lastCampaignAt: FieldValue.serverTimestamp(),
+      });
+    } catch (error) {
+      logger.warn('Failed to update lastCampaignAt', { guestId: req.guestId });
+    }
+  }
+
   return {
     status,
     reason: delivery.error,

--- a/src/services/growthConfigService.ts
+++ b/src/services/growthConfigService.ts
@@ -1,0 +1,49 @@
+/**
+ * growthConfigService — PER-PROPERTY Growth Engine configuration (M1).
+ *
+ * The automatic reactivation strategy is NOT one-size-fits-all: the mountain
+ * chalet wants locals + a seasonal message; a city apartment may want returning
+ * foreign travelers + a different template, or no auto-nudge at all. This reads
+ * a per-property config doc (`growthConfig/{propertyId}`) with a SAFE default
+ * (reactivation OFF until a property is explicitly configured).
+ *
+ * Plain server module. Cached per process; call clearGrowthConfigCache() in
+ * tests/scripts after mutating.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { GrowthPropertyConfig } from '@/types';
+
+const logger = loggers.campaign;
+
+/** Safe default: a property is NOT auto-reactivated until explicitly configured. */
+export const DEFAULT_GROWTH_PROPERTY_CONFIG: GrowthPropertyConfig = {
+  reactivationEnabled: false,
+  reactivationCohort: 'locals', // 'locals' = RO/MD + unknown; 'all' = everyone
+  reactivationTemplate: 'seasonal_availability',
+};
+
+const cache = new Map<string, GrowthPropertyConfig>();
+
+export async function getGrowthPropertyConfig(propertyId: string): Promise<GrowthPropertyConfig> {
+  const cached = cache.get(propertyId);
+  if (cached) return cached;
+
+  let config: GrowthPropertyConfig = { ...DEFAULT_GROWTH_PROPERTY_CONFIG };
+  try {
+    const db = await getAdminDb();
+    const doc = await db.collection('growthConfig').doc(propertyId).get();
+    if (doc.exists) {
+      config = { ...config, ...(doc.data() as Partial<GrowthPropertyConfig>) };
+    }
+  } catch (error) {
+    logger.error('getGrowthPropertyConfig failed; using safe defaults', error as Error, { propertyId });
+  }
+  cache.set(propertyId, config);
+  return config;
+}
+
+/** Clear the in-process cache (tests / after writing a config doc). */
+export function clearGrowthConfigCache(): void {
+  cache.clear();
+}

--- a/src/services/guestLifecycleService.ts
+++ b/src/services/guestLifecycleService.ts
@@ -17,6 +17,7 @@ import { executeSend } from '@/services/executionGateway';
 import { findGuestByPhone } from '@/services/guestService';
 import { parseFirestoreDate } from '@/lib/growth/date-utils';
 import { normalizeCountryCode } from '@/lib/country-utils';
+import { getGrowthPropertyConfig } from '@/services/growthConfigService';
 
 const logger = loggers.campaign;
 const DAY_MS = 1000 * 60 * 60 * 24;
@@ -54,6 +55,11 @@ export async function runChannelAwareReactivation(now: Date = new Date()): Promi
       // Day-90 seasonal reactivation window, once per booking.
       if (days < 89.5 || days > 91.5 || data.seasonalReactivationSentAt) continue;
 
+      // Per-property config (M1): does this property auto-reactivate, and how?
+      // Safe default is OFF, so a property only runs once explicitly configured.
+      const config = await getGrowthPropertyConfig(data.propertyId);
+      if (!config.reactivationEnabled) continue;
+
       const guest = await findGuestByPhone(phone);
       if (!guest) {
         stats.skipped++;
@@ -68,27 +74,28 @@ export async function runChannelAwareReactivation(now: Date = new Date()): Promi
         continue;
       }
 
-      // Cohort strategy: automatic reactivation targets LOCALS — RO/MD or
-      // unknown-country guests, who can realistically return. Known-foreign
-      // guests (unlikely to travel back) are skipped here; reach them
-      // deliberately via a targeted campaign instead, not this auto-nudge.
-      // Normalize first so "Romania"/"ro" aren't mistaken for foreign (H3);
-      // unrecognized/undefined => treated as unknown => reached (safe direction).
-      const countryCode = guest.country ? normalizeCountryCode(guest.country) : undefined;
-      if (countryCode && countryCode !== 'RO' && countryCode !== 'MD') {
-        stats.skipped++;
-        continue;
+      // Cohort per property config (M1): 'locals' targets RO/MD + unknown and
+      // skips known-foreign (the mountain-chalet default); 'all' keeps everyone
+      // (fits a city apartment whose repeat base includes returning foreign
+      // travelers). Normalize country first so "Romania"/"ro" aren't mistaken
+      // for foreign (H3); unrecognized/undefined => unknown => reached.
+      if (config.reactivationCohort === 'locals') {
+        const countryCode = guest.country ? normalizeCountryCode(guest.country) : undefined;
+        if (countryCode && countryCode !== 'RO' && countryCode !== 'MD') {
+          stats.skipped++;
+          continue;
+        }
       }
 
       stats.attempted++;
 
-      // executeSend auto-selects the WhatsApp template variant by guest.language
-      // and records data.propertyId on the messageLog audit entry.
+      // executeSend auto-selects the WhatsApp template variant by guest.language,
+      // property-brands the message, and records propertyId on the audit entry.
       const result = await executeSend({
         guestId: guest.id,
         propertyId: data.propertyId,
         channel: 'whatsapp',
-        templateName: 'seasonal_availability',
+        templateName: config.reactivationTemplate,
         variables: { '1': guest.firstName || '' },
       });
 

--- a/src/services/segmentService.ts
+++ b/src/services/segmentService.ts
@@ -14,6 +14,8 @@ import { loggers } from '@/lib/logger';
 import type { Guest, SegmentDefinition, ChannelType, Season } from '@/types';
 import { parseFirestoreDate, seasonOf, monthsBetween } from '@/lib/growth/date-utils';
 import { normalizeCountryCode } from '@/lib/country-utils';
+import { normalizePhone } from '@/lib/sanitize';
+import { resolveGuestLanguage } from '@/lib/growth/language';
 
 const logger = loggers.segment;
 
@@ -122,9 +124,33 @@ export async function evaluateSegment(
 }
 
 export interface AudiencePreview {
-  count: number;
+  count: number;                            // total guests matching the segment
+  reachable: number;                        // reachable by a channel AND not suppressed
+  suppressed: number;                       // matched + reachable but on the suppression list
   byChannel: Record<'whatsapp' | 'email' | 'none', number>;
+  byLanguage: { ro: number; en: number };   // among reachable guests
   sample: Array<{ id: string; name: string; channel: ChannelType | null; country?: string }>;
+}
+
+/** Load the suppression list once into sets for an honest preview (small collection). */
+async function loadSuppressionSet(): Promise<{ phones: Set<string>; emails: Set<string> }> {
+  const db = await getAdminDb();
+  const snap = await db.collection('suppressionList').get();
+  const phones = new Set<string>();
+  const emails = new Set<string>();
+  snap.docs.forEach((d) => {
+    const x = d.data() as { normalizedPhone?: string; email?: string };
+    if (x.normalizedPhone) phones.add(x.normalizedPhone);
+    if (x.email) emails.add(String(x.email).toLowerCase().trim());
+  });
+  return { phones, emails };
+}
+
+function isGuestSuppressed(guest: Guest, sets: { phones: Set<string>; emails: Set<string> }): boolean {
+  const phone = guest.normalizedPhone || (guest.phone ? normalizePhone(guest.phone) : undefined);
+  if (phone && sets.phones.has(phone)) return true;
+  if (guest.email && sets.emails.has(guest.email.toLowerCase().trim())) return true;
+  return false;
 }
 
 /** Count + channel breakdown + a small sample for a segment definition. */
@@ -133,13 +159,28 @@ export async function previewAudience(
   now: Date = new Date()
 ): Promise<AudiencePreview> {
   const guests = await evaluateSegment(def, now);
+  const suppression = await loadSuppressionSet();
   // resolveChannel only ever yields whatsapp | email | null (no sms today).
   const byChannel = { whatsapp: 0, email: 0, none: 0 };
+  const byLanguage = { ro: 0, en: 0 };
+  let reachable = 0;
+  let suppressed = 0;
   for (const g of guests) {
     const ch = resolveChannel(g);
     if (ch === 'whatsapp') byChannel.whatsapp++;
     else if (ch === 'email') byChannel.email++;
     else byChannel.none++;
+    if (ch) {
+      // Among channel-reachable guests, subtract the suppressed and split the
+      // rest by effective language — an honest "who will actually get this" (M2/M3).
+      if (isGuestSuppressed(g, suppression)) {
+        suppressed++;
+      } else {
+        reachable++;
+        if (resolveGuestLanguage(g) === 'ro') byLanguage.ro++;
+        else byLanguage.en++;
+      }
+    }
   }
   const sample = guests.slice(0, 10).map((g) => ({
     id: g.id,
@@ -147,8 +188,8 @@ export async function previewAudience(
     channel: resolveChannel(g),
     country: g.country,
   }));
-  logger.info('Previewed audience', { count: guests.length, byChannel });
-  return { count: guests.length, byChannel, sample };
+  logger.info('Previewed audience', { count: guests.length, reachable, suppressed, byChannel, byLanguage });
+  return { count: guests.length, reachable, suppressed, byChannel, byLanguage, sample };
 }
 
 /** Reusable segment builders (the §6.2 catalogue). */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -371,6 +371,13 @@ export interface SuppressionEntry {
   at?: SerializableTimestamp;
 }
 
+/** Per-property Growth Engine configuration (M1). Stored at growthConfig/{propertyId}. */
+export interface GrowthPropertyConfig {
+  reactivationEnabled: boolean;              // does auto-reactivation run for this property?
+  reactivationCohort: 'locals' | 'all';      // 'locals' = RO/MD + unknown; 'all' = everyone
+  reactivationTemplate: string;              // marketing template name for the Day-90 touch
+}
+
 export type CampaignStatus =
   | 'draft'
   | 'scheduled'


### PR DESCRIPTION
Addresses the domain-completeness findings from the review (the ones you chose to build now).

- **M1 — per-property config** (`growthConfig/{propertyId}`): `reactivationEnabled` (safe default **off**), `reactivationCohort` (`locals`|`all`), `reactivationTemplate`. Coltei city apartment → `all` + city template; chalet → `locals` + seasonal. No hardcoded per-property logic.
- **H1 — property branding**: `executeSend` injects a `property` template variable so guests know which property is reaching out (approved template references `{{property}}`).
- **H4 — frequency cap**: guest-level `lastCampaignAt` (written on real sends, checked before any send; default 14 days). Stops a both-properties guest getting 2+ messages across campaigns + reactivation.
- **M2/M3 — honest preview**: `previewAudience` returns reachable-minus-suppressed + an EN/RO split; composer shows it.

**Validated live:** 132 reachable, **RO 93 / EN 39** (vs the old blanket English) — H2 language inference working on real data. 108 tests pass; build green. Domain-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)