### PR TITLE
feat: activate Meta Pixel + Conversions API (conversion tracking)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -193,10 +193,22 @@ env:
       - BUILD
       - RUNTIME
 
-# Meta Pixel + CAPI secrets: add these after creating secrets in Secret Manager
-# - variable: NEXT_PUBLIC_META_PIXEL_ID
-# - variable: META_PIXEL_ID
-# - variable: META_CAPI_ACCESS_TOKEN
+# Meta Pixel (browser + server) + Conversions API. Pixel ID is public (appears
+# in the browser); the CAPI token is a Secret Manager secret. See
+# docs/meta-ads-infrastructure-2026.md.
+  - variable: NEXT_PUBLIC_META_PIXEL_ID
+    value: "1010060168431159"
+    availability:
+      - BUILD
+      - RUNTIME
+  - variable: META_PIXEL_ID
+    value: "1010060168431159"
+    availability:
+      - RUNTIME
+  - variable: META_CAPI_ACCESS_TOKEN
+    secret: projects/1061532538391/secrets/META_CAPI_ACCESS_TOKEN/versions/latest
+    availability:
+      - RUNTIME
 # Meta Marketing API (Growth Engine Phase 2 — Custom Audiences + ad insights).
 # Inert until BOTH are set. Requires a Meta Business account + system-user token.
 # - variable: META_SYSTEM_USER_TOKEN

--- a/src/app/booking/success/actions.ts
+++ b/src/app/booking/success/actions.ts
@@ -224,7 +224,7 @@ export async function verifyAndUpdateBooking(
     };
 
     // Get currency from metadata or booking
-    const paymentCurrency = session.metadata?.holdCurrency || session.metadata?.currency || booking.pricing?.currency || 'EUR';
+    const paymentCurrency = session.metadata?.holdCurrency || session.metadata?.currency || booking.pricing?.currency || 'RON';
 
     // Update the booking using the same function the webhook would use
     await updateBookingPaymentInfo(
@@ -251,7 +251,7 @@ export async function verifyAndUpdateBooking(
         },
         customData: {
           value: updatedBooking.pricing?.total ?? 0,
-          currency: updatedBooking.pricing?.currency ?? 'EUR',
+          currency: updatedBooking.pricing?.currency ?? 'RON',
           contentIds: [updatedBooking.propertyId],
           contentType: 'product',
           orderId: bookingId,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@/contexts/ThemeContext'; // Import ThemeProvider
 import { ErrorBoundary } from '@/components/error-boundary'; // Import ErrorBoundary
 import { LanguageProvider } from '@/lib/language-system'; // Import unified language system
 import { GoogleTagManager, GoogleTagManagerNoscript } from '@/components/tracking/gtm';
+import { MetaPixel } from '@/components/tracking/meta-pixel';
 import { CookieConsent } from '@/components/cookie-consent';
 import { UTMCapture } from '@/components/tracking/utm-capture';
 import { LanguageHtmlUpdater } from '@/components/language-html-updater';
@@ -40,6 +41,7 @@ export default async function RootLayout({
       <head>
         <link rel="preconnect" href="https://firebasestorage.googleapis.com" />
         <GoogleTagManager />
+        <MetaPixel />
       </head>
       {/* Apply font variable to body */}
       <body className={`${inter.variable} font-sans antialiased`}>

--- a/src/components/tracking/meta-pixel.tsx
+++ b/src/components/tracking/meta-pixel.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Meta (Facebook/Instagram) browser Pixel.
+ *
+ * GDPR-aware: fires ONLY after the visitor grants *marketing* consent via the
+ * cookie-consent banner (fbp is a marketing cookie). It reads the same
+ * `cookie_consent` cookie the banner writes and reacts to its `consent-updated`
+ * event. Pairs with the server-side Conversions API (`meta-capi.ts`), which
+ * sends the authoritative Purchase/Lead/InitiateCheckout events.
+ *
+ * Inert unless NEXT_PUBLIC_META_PIXEL_ID is set (mirrors the GTM component).
+ */
+const PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+const COOKIE_NAME = 'cookie_consent';
+
+function hasMarketingConsent(): boolean {
+  if (typeof document === 'undefined') return false;
+  const match = document.cookie.split('; ').find((row) => row.startsWith(`${COOKIE_NAME}=`));
+  if (!match) return false;
+  try {
+    const prefs = JSON.parse(decodeURIComponent(match.split('=')[1]));
+    return prefs?.marketing === true;
+  } catch {
+    return false;
+  }
+}
+
+export function MetaPixel() {
+  const pathname = usePathname();
+  const [consented, setConsented] = useState(false);
+  const skipFirstPageView = useRef(true);
+
+  // Determine consent on mount and whenever the banner updates it.
+  useEffect(() => {
+    if (!PIXEL_ID) return;
+    setConsented(hasMarketingConsent());
+    const onUpdate = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { marketing?: boolean } | undefined;
+      setConsented(detail?.marketing === true);
+    };
+    window.addEventListener('consent-updated', onUpdate);
+    return () => window.removeEventListener('consent-updated', onUpdate);
+  }, []);
+
+  // Fire PageView on client-side route changes. The base snippet already fires
+  // the first PageView, so skip the initial run to avoid a double count.
+  useEffect(() => {
+    if (!PIXEL_ID || !consented) return;
+    if (skipFirstPageView.current) {
+      skipFirstPageView.current = false;
+      return;
+    }
+    const fbq = (window as unknown as { fbq?: (...args: unknown[]) => void }).fbq;
+    if (typeof fbq === 'function') fbq('track', 'PageView');
+  }, [pathname, consented]);
+
+  if (!PIXEL_ID || !consented) return null;
+
+  return (
+    <Script
+      id="meta-pixel"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
+          !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+          n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '${PIXEL_ID}');
+          fbq('track', 'PageView');
+        `,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
Turns on conversion tracking so FB/IG ad spend becomes measurable. Sets the Pixel ID (public) + CAPI token (Secret Manager), activating the already-wired server CAPI (Purchase/Lead/InitiateCheckout), adds a GDPR/consent-gated browser Pixel, and fixes the EUR→RON currency fallback. Dataset 1010060168431159. Build green, type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)