### PR TITLE
feat: Meta browser ViewContent + Purchase dedup (deterministic event_id)

### DIFF
--- a/src/app/booking/success/actions.ts
+++ b/src/app/booking/success/actions.ts
@@ -242,7 +242,9 @@ export async function verifyAndUpdateBooking(
     if (updatedBooking) {
       sendMetaEvent({
         eventName: 'Purchase',
-        eventId: crypto.randomUUID(),
+        // Deterministic id: dedupes with the browser Pixel Purchase AND prevents
+        // double-counting when the success page is refreshed (this action re-runs).
+        eventId: `purchase_${bookingId}`,
         userData: {
           email: updatedBooking.guestInfo?.email,
           phone: updatedBooking.guestInfo?.phone,

--- a/src/components/tracking/track-page-view.tsx
+++ b/src/components/tracking/track-page-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { trackViewItem } from '@/lib/tracking';
+import { trackMetaViewContent } from '@/lib/meta-tracking';
 import type { Property } from '@/types';
 
 interface TrackViewItemProps {
@@ -10,7 +11,8 @@ interface TrackViewItemProps {
 
 export function TrackViewItem({ property }: TrackViewItemProps) {
   useEffect(() => {
-    trackViewItem(property);
+    trackViewItem(property);            // GA4 view_item (GTM dataLayer)
+    trackMetaViewContent(property);     // Meta Pixel ViewContent (no-op without consent)
   }, [property]);
 
   return null;

--- a/src/components/tracking/track-purchase.tsx
+++ b/src/components/tracking/track-purchase.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { trackPurchase } from '@/lib/tracking';
+import { trackMetaPurchase } from '@/lib/meta-tracking';
 import type { Booking, Property } from '@/types';
 
 interface TrackPurchaseProps {
@@ -19,7 +20,8 @@ export function TrackPurchase({ booking, property }: TrackPurchaseProps) {
     if (firedRef.current === booking.id) return;
 
     firedRef.current = booking.id;
-    trackPurchase(booking, property);
+    trackPurchase(booking, property);          // GA4 purchase (GTM dataLayer)
+    trackMetaPurchase(booking, property);      // Meta Pixel Purchase, deduped w/ server CAPI
   }, [booking, property]);
 
   return null;

--- a/src/lib/__tests__/meta-tracking.test.ts
+++ b/src/lib/__tests__/meta-tracking.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import { purchaseEventId, trackMetaViewContent, trackMetaPurchase } from '../meta-tracking';
+import type { Booking, Property } from '@/types';
+
+const property = { slug: 'prahova-mountain-chalet', pricePerNight: 450, baseCurrency: 'RON' } as unknown as Property;
+const booking = { id: 'bk123', propertyId: 'prahova-mountain-chalet', pricing: { total: 1350, currency: 'RON' } } as unknown as Booking;
+
+afterEach(() => {
+  delete (window as unknown as { fbq?: unknown }).fbq;
+});
+
+describe('purchaseEventId', () => {
+  it('derives a deterministic id from the booking id (shared with server CAPI)', () => {
+    expect(purchaseEventId('bk123')).toBe('purchase_bk123');
+  });
+});
+
+describe('trackMetaViewContent', () => {
+  it('fires fbq ViewContent with content + value when fbq is present', () => {
+    const fbq = jest.fn();
+    (window as unknown as { fbq: unknown }).fbq = fbq;
+    trackMetaViewContent(property);
+    expect(fbq).toHaveBeenCalledWith('track', 'ViewContent', {
+      content_ids: ['prahova-mountain-chalet'],
+      content_type: 'product',
+      value: 450,
+      currency: 'RON',
+    });
+  });
+  it('is a no-op without consent (fbq undefined)', () => {
+    expect(() => trackMetaViewContent(property)).not.toThrow();
+  });
+});
+
+describe('trackMetaPurchase', () => {
+  it('fires fbq Purchase with the deterministic eventID for dedup', () => {
+    const fbq = jest.fn();
+    (window as unknown as { fbq: unknown }).fbq = fbq;
+    trackMetaPurchase(booking, property);
+    expect(fbq).toHaveBeenCalledWith(
+      'track',
+      'Purchase',
+      { value: 1350, currency: 'RON', content_ids: ['prahova-mountain-chalet'], content_type: 'product' },
+      { eventID: 'purchase_bk123' }
+    );
+  });
+  it('is a no-op without consent (fbq undefined)', () => {
+    expect(() => trackMetaPurchase(booking, property)).not.toThrow();
+  });
+});

--- a/src/lib/meta-tracking.ts
+++ b/src/lib/meta-tracking.ts
@@ -1,0 +1,65 @@
+/**
+ * Client-side Meta Pixel (fbq) event helpers.
+ *
+ * These are NO-OPS unless `window.fbq` exists — and fbq is only loaded after the
+ * visitor grants *marketing* consent (see components/tracking/meta-pixel.tsx).
+ * So calling these without consent silently does nothing (GDPR-safe).
+ *
+ * Deduplication: browser events that also fire server-side via the Conversions
+ * API (Purchase) use a DETERMINISTIC eventID derived from the stable business
+ * key (bookingId). The server CAPI uses the exact same id, so Meta counts the
+ * action once regardless of which arrives first. See src/lib/meta-capi.ts.
+ */
+import type { Booking, Property } from '@/types';
+
+type Fbq = (...args: unknown[]) => void;
+
+function getFbq(): Fbq | null {
+  if (typeof window === 'undefined') return null;
+  const fbq = (window as unknown as { fbq?: Fbq }).fbq;
+  return typeof fbq === 'function' ? fbq : null;
+}
+
+/** Deterministic Purchase eventID shared by browser + server for dedup. */
+export function purchaseEventId(bookingId: string): string {
+  return `purchase_${bookingId}`;
+}
+
+/**
+ * Browser ViewContent for a property page — the key retargeting-audience signal
+ * ("people who viewed a property"). Browser-only; no server equivalent, so no
+ * dedup needed.
+ */
+export function trackMetaViewContent(property: Property): void {
+  const fbq = getFbq();
+  if (!fbq || !property?.slug) return;
+  const data: Record<string, unknown> = {
+    content_ids: [property.slug],
+    content_type: 'product',
+  };
+  if (typeof property.pricePerNight === 'number') {
+    data.value = property.pricePerNight;
+    data.currency = property.baseCurrency || 'RON';
+  }
+  fbq('track', 'ViewContent', data);
+}
+
+/**
+ * Browser Purchase on the booking-success page — deduped against the server-side
+ * CAPI Purchase via the deterministic eventID.
+ */
+export function trackMetaPurchase(booking: Booking, property?: Property): void {
+  const fbq = getFbq();
+  if (!fbq || !booking?.id) return;
+  fbq(
+    'track',
+    'Purchase',
+    {
+      value: booking.pricing?.total ?? 0,
+      currency: booking.pricing?.currency ?? property?.baseCurrency ?? 'RON',
+      content_ids: [booking.propertyId],
+      content_type: 'product',
+    },
+    { eventID: purchaseEventId(booking.id) }
+  );
+}


### PR DESCRIPTION
Completes the dual browser+server Meta tracking: browser **ViewContent** on property pages (retargeting audience) and browser **Purchase** on the success page, deduped with the server CAPI via a deterministic `purchase_${bookingId}` event_id. Also fixes a pre-existing bug where the server Purchase re-fired with a random id on success-page refresh (double-counting). GA4 tracking untouched. 5 tests, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)