### PR TITLE
fix: Meta Pixel + CAPI per-property (multi-property isolation)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -193,20 +193,12 @@ env:
       - BUILD
       - RUNTIME
 
-# Meta Pixel (browser + server) + Conversions API. Pixel ID is public (appears
-# in the browser); the CAPI token is a Secret Manager secret. See
-# docs/meta-ads-infrastructure-2026.md.
-  - variable: NEXT_PUBLIC_META_PIXEL_ID
-    value: "1010060168431159"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: META_PIXEL_ID
-    value: "1010060168431159"
-    availability:
-      - RUNTIME
-  - variable: META_CAPI_ACCESS_TOKEN
-    secret: projects/1061532538391/secrets/META_CAPI_ACCESS_TOKEN/versions/latest
+# Meta Pixel (browser + server) + Conversions API — PER PROPERTY (multi-property).
+# Pixel IDs (public) live in code: src/lib/meta-pixels.ts (resolved by property).
+# CAPI tokens are a per-property JSON-map secret { "<slug>": "<token>" }.
+# See docs/meta-ads-infrastructure-2026.md.
+  - variable: META_CAPI_TOKENS
+    secret: projects/1061532538391/secrets/META_CAPI_TOKENS/versions/latest
     availability:
       - RUNTIME
 # Meta Marketing API (Growth Engine Phase 2 — Custom Audiences + ad insights).

--- a/src/app/actions/booking-actions.ts
+++ b/src/app/actions/booking-actions.ts
@@ -197,6 +197,7 @@ export async function createPendingBookingAction(
     // Fire Meta CAPI InitiateCheckout event (non-blocking)
     const eventId = crypto.randomUUID();
     sendMetaEvent({
+      propertyId,
       eventName: 'InitiateCheckout',
       eventId,
       userData: {

--- a/src/app/actions/createInquiryAction.ts
+++ b/src/app/actions/createInquiryAction.ts
@@ -113,6 +113,7 @@ export async function createInquiryAction(
 
     // Fire Meta CAPI Lead event (non-blocking)
     sendMetaEvent({
+      propertyId: propertySlug,
       eventName: 'Lead',
       eventId: crypto.randomUUID(),
       userData: {

--- a/src/app/booking/success/actions.ts
+++ b/src/app/booking/success/actions.ts
@@ -241,6 +241,7 @@ export async function verifyAndUpdateBooking(
     // Fire Meta CAPI Purchase event (non-blocking)
     if (updatedBooking) {
       sendMetaEvent({
+        propertyId: updatedBooking.propertyId,
         eventName: 'Purchase',
         // Deterministic id: dedupes with the browser Pixel Purchase AND prevents
         // double-counting when the success page is refreshed (this action re-runs).

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { ErrorBoundary } from '@/components/error-boundary'; // Import ErrorBoun
 import { LanguageProvider } from '@/lib/language-system'; // Import unified language system
 import { GoogleTagManager, GoogleTagManagerNoscript } from '@/components/tracking/gtm';
 import { MetaPixel } from '@/components/tracking/meta-pixel';
+import { getPixelIdForProperty } from '@/lib/meta-pixels';
 import { CookieConsent } from '@/components/cookie-consent';
 import { UTMCapture } from '@/components/tracking/utm-capture';
 import { LanguageHtmlUpdater } from '@/components/language-html-updater';
@@ -32,16 +33,18 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Read language from middleware-set header for correct SSR lang attribute
+  // Read language + resolved property from middleware-set headers
   const headersList = await headers();
   const detectedLang = headersList.get('x-language') || DEFAULT_LANGUAGE;
+  // Per-property Meta pixel: only the current property's pixel loads (multi-property).
+  const metaPixelId = getPixelIdForProperty(headersList.get('x-property-slug'));
 
   return (
     <html lang={detectedLang}>
       <head>
         <link rel="preconnect" href="https://firebasestorage.googleapis.com" />
         <GoogleTagManager />
-        <MetaPixel />
+        <MetaPixel pixelId={metaPixelId} />
       </head>
       {/* Apply font variable to body */}
       <body className={`${inter.variable} font-sans antialiased`}>

--- a/src/components/tracking/meta-pixel.tsx
+++ b/src/components/tracking/meta-pixel.tsx
@@ -13,9 +13,10 @@ import { useEffect, useRef, useState } from 'react';
  * event. Pairs with the server-side Conversions API (`meta-capi.ts`), which
  * sends the authoritative Purchase/Lead/InitiateCheckout events.
  *
- * Inert unless NEXT_PUBLIC_META_PIXEL_ID is set (mirrors the GTM component).
+ * Receives the pixel id for the CURRENT property (resolved server-side in the
+ * root layout from the middleware's x-property-slug). Renders nothing when a
+ * property has no pixel — so one property never fires to another's pixel.
  */
-const PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID;
 const COOKIE_NAME = 'cookie_consent';
 
 function hasMarketingConsent(): boolean {
@@ -30,14 +31,14 @@ function hasMarketingConsent(): boolean {
   }
 }
 
-export function MetaPixel() {
+export function MetaPixel({ pixelId }: { pixelId?: string }) {
   const pathname = usePathname();
   const [consented, setConsented] = useState(false);
   const skipFirstPageView = useRef(true);
 
   // Determine consent on mount and whenever the banner updates it.
   useEffect(() => {
-    if (!PIXEL_ID) return;
+    if (!pixelId) return;
     setConsented(hasMarketingConsent());
     const onUpdate = (e: Event) => {
       const detail = (e as CustomEvent).detail as { marketing?: boolean } | undefined;
@@ -45,21 +46,21 @@ export function MetaPixel() {
     };
     window.addEventListener('consent-updated', onUpdate);
     return () => window.removeEventListener('consent-updated', onUpdate);
-  }, []);
+  }, [pixelId]);
 
   // Fire PageView on client-side route changes. The base snippet already fires
   // the first PageView, so skip the initial run to avoid a double count.
   useEffect(() => {
-    if (!PIXEL_ID || !consented) return;
+    if (!pixelId || !consented) return;
     if (skipFirstPageView.current) {
       skipFirstPageView.current = false;
       return;
     }
     const fbq = (window as unknown as { fbq?: (...args: unknown[]) => void }).fbq;
     if (typeof fbq === 'function') fbq('track', 'PageView');
-  }, [pathname, consented]);
+  }, [pathname, consented, pixelId]);
 
-  if (!PIXEL_ID || !consented) return null;
+  if (!pixelId || !consented) return null;
 
   return (
     <Script
@@ -72,7 +73,7 @@ export function MetaPixel() {
           n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
           t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script',
           'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', '${PIXEL_ID}');
+          fbq('init', '${pixelId}');
           fbq('track', 'PageView');
         `,
       }}

--- a/src/lib/__tests__/meta-capi.test.ts
+++ b/src/lib/__tests__/meta-capi.test.ts
@@ -1,0 +1,39 @@
+/** @jest-environment node */
+import { sendMetaEvent } from '../meta-capi';
+import { getPixelIdForProperty } from '../meta-pixels';
+
+describe('getPixelIdForProperty (per-property pixel resolution)', () => {
+  it('resolves a configured property and nothing else', () => {
+    expect(getPixelIdForProperty('prahova-mountain-chalet')).toBe('1010060168431159');
+    expect(getPixelIdForProperty('coltei-apartment-bucharest')).toBeUndefined();
+    expect(getPixelIdForProperty(null)).toBeUndefined();
+    expect(getPixelIdForProperty(undefined)).toBeUndefined();
+  });
+});
+
+describe('sendMetaEvent — multi-property isolation', () => {
+  const origTokens = process.env.META_CAPI_TOKENS;
+  beforeAll(() => {
+    process.env.META_CAPI_TOKENS = JSON.stringify({ 'prahova-mountain-chalet': 'tok-prahova' });
+  });
+  afterAll(() => {
+    process.env.META_CAPI_TOKENS = origTokens;
+  });
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockReset();
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, text: async () => 'ok' });
+  });
+
+  it('fires to the PROPERTY-SPECIFIC pixel + token when configured', async () => {
+    await sendMetaEvent({ propertyId: 'prahova-mountain-chalet', eventName: 'Purchase', eventId: 'e1' });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('/1010060168431159/events'); // Prahova's pixel
+    expect(JSON.parse((opts as { body: string }).body).access_token).toBe('tok-prahova');
+  });
+
+  it('does NOT fire for a property with no pixel/token (no cross-property pollution)', async () => {
+    await sendMetaEvent({ propertyId: 'coltei-apartment-bucharest', eventName: 'Purchase', eventId: 'e2' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/meta-capi.ts
+++ b/src/lib/meta-capi.ts
@@ -5,12 +5,29 @@
 
 import { createHash } from 'crypto';
 import { loggers } from '@/lib/logger';
+import { getPixelIdForProperty } from '@/lib/meta-pixels';
 
 const logger = loggers.tracking;
 
-const META_PIXEL_ID = process.env.META_PIXEL_ID;
-const META_CAPI_ACCESS_TOKEN = process.env.META_CAPI_ACCESS_TOKEN;
 const GRAPH_API_VERSION = 'v21.0';
+
+/**
+ * Per-property CAPI access tokens, from the META_CAPI_TOKENS secret — a JSON map
+ * { "<property-slug>": "<token>" }. Parsed once. A property with no token here
+ * sends no server events (multi-property isolation).
+ */
+let capiTokens: Record<string, string> | null = null;
+function getCapiToken(slug: string): string | undefined {
+  if (capiTokens === null) {
+    try {
+      capiTokens = process.env.META_CAPI_TOKENS ? JSON.parse(process.env.META_CAPI_TOKENS) : {};
+    } catch {
+      logger.warn('Meta CAPI: META_CAPI_TOKENS is not valid JSON');
+      capiTokens = {};
+    }
+  }
+  return (capiTokens ?? {})[slug];
+}
 
 interface UserData {
   email?: string;
@@ -33,6 +50,8 @@ interface CustomData {
 }
 
 interface MetaEventParams {
+  /** REQUIRED: the property this event belongs to — selects the pixel + token. */
+  propertyId: string;
   eventName: string;
   eventId: string;
   eventSourceUrl?: string;
@@ -74,12 +93,17 @@ function buildUserData(userData?: UserData) {
  * No-ops gracefully if env vars are not set.
  */
 export async function sendMetaEvent(params: MetaEventParams): Promise<void> {
-  if (!META_PIXEL_ID || !META_CAPI_ACCESS_TOKEN) {
-    logger.debug('Meta CAPI: skipping (env vars not set)');
+  const { propertyId, eventName, eventId, eventSourceUrl, userData, customData } = params;
+
+  // Resolve the pixel + token FOR THIS PROPERTY. If either is missing, this
+  // property isn't configured for Meta tracking — skip (never fire to another
+  // property's pixel).
+  const pixelId = getPixelIdForProperty(propertyId);
+  const accessToken = propertyId ? getCapiToken(propertyId) : undefined;
+  if (!pixelId || !accessToken) {
+    logger.debug('Meta CAPI: skipping (no pixel/token for property)', { propertyId, eventName });
     return;
   }
-
-  const { eventName, eventId, eventSourceUrl, userData, customData } = params;
 
   const eventData: Record<string, unknown> = {
     event_name: eventName,
@@ -103,7 +127,7 @@ export async function sendMetaEvent(params: MetaEventParams): Promise<void> {
     eventData.custom_data = cd;
   }
 
-  const url = `https://graph.facebook.com/${GRAPH_API_VERSION}/${META_PIXEL_ID}/events`;
+  const url = `https://graph.facebook.com/${GRAPH_API_VERSION}/${pixelId}/events`;
 
   try {
     const response = await fetch(url, {
@@ -111,7 +135,7 @@ export async function sendMetaEvent(params: MetaEventParams): Promise<void> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         data: [eventData],
-        access_token: META_CAPI_ACCESS_TOKEN,
+        access_token: accessToken,
       }),
     });
 

--- a/src/lib/meta-pixels.ts
+++ b/src/lib/meta-pixels.ts
@@ -1,0 +1,21 @@
+/**
+ * Per-property Meta Pixel / dataset IDs (PUBLIC — they appear in the browser).
+ *
+ * MULTI-PROPERTY FIRST: each property fires to ITS OWN pixel. A property with no
+ * entry here has NO Meta tracking — its traffic/conversions must never pollute
+ * another property's pixel. CAPI access tokens are per-property secrets and live
+ * in Secret Manager (see meta-capi.ts / META_CAPI_TOKENS) — NEVER here.
+ *
+ * To onboard a property: create its own dataset in that property's Meta Business,
+ * add its id below, and add its token to the META_CAPI_TOKENS secret map.
+ */
+export const PROPERTY_META_PIXELS: Record<string, string> = {
+  'prahova-mountain-chalet': '1010060168431159',
+  // 'coltei-apartment-bucharest': '<create its own dataset, then add its id here>',
+};
+
+/** Resolve the Meta pixel id for a property slug (undefined if not configured). */
+export function getPixelIdForProperty(slug?: string | null): string | undefined {
+  if (!slug) return undefined;
+  return PROPERTY_META_PIXELS[slug];
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -127,9 +127,11 @@ export async function middleware(request: NextRequest) {
   const rewriteUrl = new URL(rewritePath, request.url);
   rewriteUrl.search = url.search; // preserve original query parameters
 
-  // Pass detected language as request header for SSR lang attribute
+  // Pass detected language + resolved property slug as request headers, so SSR
+  // (e.g. the root layout) can resolve per-property config like the Meta pixel.
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-language', language);
+  requestHeaders.set('x-property-slug', propertySlug);
 
   const response = NextResponse.rewrite(rewriteUrl, {
     request: { headers: requestHeaders },


### PR DESCRIPTION
The pixel/CAPI was wired globally — every property fired to Prahova's pixel, polluting its data. Now each property resolves its own pixel (code map) + CAPI token (per-property JSON secret); a property with none has no Meta tracking. Pixel resolved per request via middleware x-property-slug → layout → MetaPixel prop; server sendMetaEvent takes propertyId. 8 tests (incl. no-cross-property-pollution). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)