### PR TITLE
fix: Meta pixel per-property config (admin UI) + domain-agnostic

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -194,9 +194,9 @@ env:
       - RUNTIME
 
 # Meta Pixel (browser + server) + Conversions API — PER PROPERTY (multi-property).
-# Pixel IDs (public) live in code: src/lib/meta-pixels.ts (resolved by property).
-# CAPI tokens are a per-property JSON-map secret { "<slug>": "<token>" }.
-# See docs/meta-ads-infrastructure-2026.md.
+# Pixel IDs (public) are per-property CONFIG: property.analytics.metaPixelId,
+# edited in /admin/website/settings. CAPI tokens are a per-property JSON-map
+# secret { "<slug>": "<token>" }. See docs/meta-ads-infrastructure-2026.md.
   - variable: META_CAPI_TOKENS
     secret: projects/1061532538391/secrets/META_CAPI_TOKENS/versions/latest
     availability:

--- a/src/app/admin/website/_components/website-settings-form.tsx
+++ b/src/app/admin/website/_components/website-settings-form.tsx
@@ -129,6 +129,23 @@ export function WebsiteSettingsForm({ propertyId, initialSettings }: WebsiteSett
               className="max-w-sm"
             />
           </div>
+          <div className="space-y-2">
+            <Label>Meta Pixel / Dataset ID</Label>
+            <p className="text-sm text-muted-foreground">
+              Facebook &amp; Instagram Pixel for this property (from Meta Events Manager). Leave empty to disable Meta tracking for this property.
+            </p>
+            <Input
+              placeholder="e.g., 1010060168431159"
+              value={settings.analytics?.metaPixelId || ''}
+              onChange={(e) =>
+                setSettings((s) => ({
+                  ...s,
+                  analytics: { ...s.analytics, enabled: s.analytics?.enabled || false, metaPixelId: e.target.value },
+                }))
+              }
+              className="max-w-sm"
+            />
+          </div>
           <Separator />
           <div className="space-y-2">
             <Label>Google Place ID</Label>

--- a/src/app/admin/website/actions.ts
+++ b/src/app/admin/website/actions.ts
@@ -20,6 +20,7 @@ export interface WebsiteSettings {
   analytics?: {
     enabled: boolean;
     googleAnalyticsId?: string;
+    metaPixelId?: string;
   };
   googlePlaceId?: string;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default async function RootLayout({
   const headersList = await headers();
   const detectedLang = headersList.get('x-language') || DEFAULT_LANGUAGE;
   // Per-property Meta pixel: only the current property's pixel loads (multi-property).
-  const metaPixelId = getPixelIdForProperty(headersList.get('x-property-slug'));
+  const metaPixelId = await getPixelIdForProperty(headersList.get('x-property-slug'));
 
   return (
     <html lang={detectedLang}>

--- a/src/lib/__tests__/meta-capi.test.ts
+++ b/src/lib/__tests__/meta-capi.test.ts
@@ -1,15 +1,11 @@
 /** @jest-environment node */
-import { sendMetaEvent } from '../meta-capi';
-import { getPixelIdForProperty } from '../meta-pixels';
+jest.mock('@/lib/meta-pixels', () => ({
+  getPixelIdForProperty: jest.fn(async (slug: string) =>
+    slug === 'prahova-mountain-chalet' ? '1010060168431159' : undefined
+  ),
+}));
 
-describe('getPixelIdForProperty (per-property pixel resolution)', () => {
-  it('resolves a configured property and nothing else', () => {
-    expect(getPixelIdForProperty('prahova-mountain-chalet')).toBe('1010060168431159');
-    expect(getPixelIdForProperty('coltei-apartment-bucharest')).toBeUndefined();
-    expect(getPixelIdForProperty(null)).toBeUndefined();
-    expect(getPixelIdForProperty(undefined)).toBeUndefined();
-  });
-});
+import { sendMetaEvent } from '../meta-capi';
 
 describe('sendMetaEvent — multi-property isolation', () => {
   const origTokens = process.env.META_CAPI_TOKENS;

--- a/src/lib/__tests__/meta-pixels.test.ts
+++ b/src/lib/__tests__/meta-pixels.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+jest.mock('@/lib/firebaseAdminSafe', () => ({ getAdminDb: jest.fn() }));
+
+import { getPixelIdForProperty, clearPixelCache } from '../meta-pixels';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb(analyticsBySlug: Record<string, unknown>) {
+  const getMock = jest.fn(async (slug: string) => ({ data: () => ({ analytics: analyticsBySlug[slug] }) }));
+  const db = { collection: jest.fn(() => ({ doc: jest.fn((slug: string) => ({ get: () => getMock(slug) })) })) };
+  return { db, getMock };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearPixelCache();
+});
+
+describe('getPixelIdForProperty (per-property config from Firestore)', () => {
+  it('reads analytics.metaPixelId for the property', async () => {
+    const { db } = makeDb({ 'prahova-mountain-chalet': { metaPixelId: '1010060168431159' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    expect(await getPixelIdForProperty('prahova-mountain-chalet')).toBe('1010060168431159');
+  });
+
+  it('returns undefined when the property has no metaPixelId configured', async () => {
+    const { db } = makeDb({ 'coltei-apartment-bucharest': { enabled: true } });
+    mockGetAdminDb.mockResolvedValue(db);
+    expect(await getPixelIdForProperty('coltei-apartment-bucharest')).toBeUndefined();
+  });
+
+  it('returns undefined for a null/empty slug without hitting Firestore', async () => {
+    const { db, getMock } = makeDb({});
+    mockGetAdminDb.mockResolvedValue(db);
+    expect(await getPixelIdForProperty(null)).toBeUndefined();
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('caches per property (one Firestore read within the TTL)', async () => {
+    const { db, getMock } = makeDb({ 'prahova-mountain-chalet': { metaPixelId: '1010060168431159' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    await getPixelIdForProperty('prahova-mountain-chalet');
+    await getPixelIdForProperty('prahova-mountain-chalet');
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/meta-capi.ts
+++ b/src/lib/meta-capi.ts
@@ -98,7 +98,7 @@ export async function sendMetaEvent(params: MetaEventParams): Promise<void> {
   // Resolve the pixel + token FOR THIS PROPERTY. If either is missing, this
   // property isn't configured for Meta tracking — skip (never fire to another
   // property's pixel).
-  const pixelId = getPixelIdForProperty(propertyId);
+  const pixelId = await getPixelIdForProperty(propertyId);
   const accessToken = propertyId ? getCapiToken(propertyId) : undefined;
   if (!pixelId || !accessToken) {
     logger.debug('Meta CAPI: skipping (no pixel/token for property)', { propertyId, eventName });

--- a/src/lib/meta-pixels.ts
+++ b/src/lib/meta-pixels.ts
@@ -1,21 +1,49 @@
 /**
- * Per-property Meta Pixel / dataset IDs (PUBLIC — they appear in the browser).
+ * Per-property Meta Pixel resolution.
  *
- * MULTI-PROPERTY FIRST: each property fires to ITS OWN pixel. A property with no
- * entry here has NO Meta tracking — its traffic/conversions must never pollute
- * another property's pixel. CAPI access tokens are per-property secrets and live
- * in Secret Manager (see meta-capi.ts / META_CAPI_TOKENS) — NEVER here.
+ * MULTI-PROPERTY FIRST: the pixel id is per-property CONFIG, stored on the
+ * property document at `analytics.metaPixelId` and edited in the admin UI
+ * (/admin/website/settings → Analytics). Each property fires to ITS OWN pixel;
+ * a property with none has no Meta tracking (no cross-property pollution).
  *
- * To onboard a property: create its own dataset in that property's Meta Business,
- * add its id below, and add its token to the META_CAPI_TOKENS secret map.
+ * This resolves from Firestore (domain-agnostic — works whether the property is
+ * reached via its custom domain or via /properties/{slug}) and is cached per
+ * process to avoid a read on every request. CAPI access tokens are separate
+ * secrets (see meta-capi.ts / META_CAPI_TOKENS) — never stored here.
+ *
+ * Server-only (Admin SDK). The browser receives the resolved id as a prop.
  */
-export const PROPERTY_META_PIXELS: Record<string, string> = {
-  'prahova-mountain-chalet': '1010060168431159',
-  // 'coltei-apartment-bucharest': '<create its own dataset, then add its id here>',
-};
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
 
-/** Resolve the Meta pixel id for a property slug (undefined if not configured). */
-export function getPixelIdForProperty(slug?: string | null): string | undefined {
+const logger = loggers.tracking;
+const CACHE_TTL_MS = 5 * 60 * 1000; // property analytics config changes rarely
+
+const cache = new Map<string, { value: string | undefined; at: number }>();
+
+/** Resolve the Meta pixel id configured for a property (undefined if none). */
+export async function getPixelIdForProperty(slug?: string | null): Promise<string | undefined> {
   if (!slug) return undefined;
-  return PROPERTY_META_PIXELS[slug];
+
+  const now = Date.now();
+  const cached = cache.get(slug);
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.value;
+
+  let value: string | undefined;
+  try {
+    const db = await getAdminDb();
+    const doc = await db.collection('properties').doc(slug).get();
+    const analytics = doc.data()?.analytics as { metaPixelId?: string } | undefined;
+    value = analytics?.metaPixelId ? String(analytics.metaPixelId).trim() || undefined : undefined;
+  } catch {
+    logger.warn('getPixelIdForProperty: read failed; using last-known', { slug });
+    value = cached?.value;
+  }
+  cache.set(slug, { value, at: now });
+  return value;
+}
+
+/** Clear the in-process pixel cache (tests / after a config edit). */
+export function clearPixelCache(): void {
+  cache.clear();
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,6 +39,9 @@ export async function middleware(request: NextRequest) {
     const langFromPath = segments.length >= 3 && SUPPORTED_LANGUAGES.includes(segments[2]) ? segments[2] : DEFAULT_LANGUAGE;
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set('x-language', langFromPath);
+    // Expose the property slug so SSR can resolve per-property config (e.g. the
+    // Meta pixel) even when the property has no custom domain (segments[1]=slug).
+    if (segments[1]) requestHeaders.set('x-property-slug', segments[1]);
     return NextResponse.next({ request: { headers: requestHeaders } });
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,7 @@ export interface Property {
   analytics?: {
     enabled: boolean;
     googleAnalyticsId?: string;
+    metaPixelId?: string; // Meta (Facebook/Instagram) Pixel / dataset id — per property
   };
   customDomain?: string | null;
   useCustomDomain?: boolean;


### PR DESCRIPTION
Corrects two flaws: (1) pixel id was a hardcoded code map → now per-property config `property.analytics.metaPixelId`, editable in /admin/website/settings; (2) resolution was custom-domain-only → now works via /properties/{slug} too (middleware sets x-property-slug), resolved from Firestore (cached). Prahova configured; Coltei empty (no pollution). 11 tests, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)