### PR TITLE
feat: Growth Ad Engine Phase 0 — stop-side + config resolver (dark)

### DIFF
--- a/docs/growth-ad-engine-plan.md
+++ b/docs/growth-ad-engine-plan.md
@@ -1,0 +1,160 @@
+# Growth Ad Engine — Implementation Plan (Core)
+
+**Author:** Opus 4.8, with full context of the design discussion · 9 July 2026
+**Status:** v2 — reconciled after Fable adversarial review (§9, §10, §12, §13 revised). Companion to `docs/meta-ads-infrastructure-2026.md` (verified Meta infra) and the local driver `plans/growth-engine.md`. **Two structural changes drive everything: (1) prove one ad manually before building the factory (§9 Phase 0.5); (2) build the STOP side before the START side (§13).**
+
+---
+
+## 1. Goal
+Close the **paid-acquisition loop** on Core so ad spend produces *measurable direct bookings*:
+
+```
+segment (guests) → Custom/Lookalike audience → campaign+adset+ad+creative (PAUSED)
+→ operator approves → activate → Meta delivers → insights (spend) → ROAS (spend ÷ attributed bookings)
+```
+
+The **measurement half is already done** (Pixel + CAPI, per-property, deduped). This plan builds the **management half**: create/sync/activate ads and read results back.
+
+**Principle (locked):** build **multi-tenant-shaped, proven on one property**. Beautiful for Prahova now; tenant #2 = config + a token, no rip-out. No onboarding/billing/self-serve yet.
+
+---
+
+## 2. Where it lives (decided)
+- **Core, this codebase, as a clean `growth` module** — NOT a separate project. The engine is data-cohesive with bookings/guests/conversions; the real separation (decisioning) is already the OpenClaw brain. Modular monolith → extractable later only if we ever sell ads-as-a-service to properties *not* on this booking platform.
+- **Meta interface = raw Marketing API from Node** (v25). We set `status: PAUSED` ourselves (replicates the CLI's one safety property). NOT the Python Ads CLI (VM-/single-token-shaped). Hosted MCP reserved for the conversational brain later.
+- **Module namespace:** `src/services/growth/*` (ads), `src/app/admin/ads/*` (operator console + ROAS), `src/app/api/growth/*` (agent proposals). Reuse existing `segmentService`, `executionGateway`, `meta-capi`, `BookingAttribution`.
+
+---
+
+## 3. Business-model shape (agency-first)
+Most future clients will **not** own their Meta ad account — the likely model is **agency**: one agency Business Manager holds an ad account **per property**, managed by **one/few shared system-user token(s)**. So resolution is NOT per-tenant-token; it's:
+
+**Per-property ad config** (extends the `analytics` config we already have):
+```
+property.analytics.meta = {
+  pixelId,            // done (metaPixelId today — fold in here)
+  adAccountId,        // "act_<id>" — the property's ad account
+  tokenRef,           // key into a secret map; may be shared "agency" or property-own
+}
+```
+- **Prahova (now):** its own BM "Comarnic Mountain Chalet", account "Bogdan-Comarnic", own token → `tokenRef: "prahova"` in `META_ADS_TOKENS` secret.
+- **Agency client (later):** agency-owned account, `tokenRef: "agency"` → same shared token manages many accounts.
+
+Tokens live in a per-ref JSON secret `META_ADS_TOKENS = { "<ref>": "<system-user-token>" }` (mirrors `META_CAPI_TOKENS`). CAPI tokens stay separate (already deployed).
+
+---
+
+## 4. Data model
+Reuse `segments`, `messageLog`, `suppressionList`, `campaigns` (WhatsApp). New:
+- **`adCampaigns`** — `{ id, propertyId, segmentId, metaCampaignId?, metaAdSetIds[], metaAdIds[], audienceRef?, objective:'OUTCOME_SALES', dailyBudget, spendCap, status: draft|pending_approval|approved|active|paused|failed, creativeRef?, approvedBy?, insights?{spend,impressions,clicks,bookings,roas}, lastSyncedAt, createdAt, updatedAt }`
+- **`customAudiences`** — `{ id, propertyId, metaAudienceId, sourceSegmentId, type:'custom'|'lookalike', size?, lastSyncedAt }`
+- **`creatives`** (from the driver §5) — copy variants + image refs, `aiLabeled`, provenance, approval. (Phase 3.)
+- Firestore rules: admin/operator read, `write:false` (Admin SDK only). Indexes: `adCampaigns(propertyId, status)`, `adCampaigns(propertyId, lastSyncedAt)`.
+
+---
+
+## 5. Meta integration layer (`src/services/growth/metaAds/*`)
+A thin, well-tested Marketing-API client. **Every write sets `status: PAUSED`.** Every call resolves `(adAccountId, token)` from the property's config — **never a global**. Functions:
+- `resolveAdContext(propertyId) → { adAccountId, token } | null` (cached; no-op if unconfigured → multi-tenant isolation, same discipline as the pixel).
+- **Audiences:** `syncCustomAudience(propertyId, segmentId)` (hash via existing `hashForMeta`, upload), `createLookalike(propertyId, sourceAudienceId, spec)`.
+- **Campaign build:** `createCampaign` / `createAdSet` (targeting: audience + geo/interest) / `createAdCreative` / `createAd` — all PAUSED, budget + **hard spend cap** required.
+- **Activation:** `activateCampaign(propertyId, metaCampaignId)` — the ONLY call that un-PAUSEs; routes through the **Execution Gateway** (audit + caps + operator-approval check).
+- **Insights:** `getInsights(propertyId, metaCampaignId, dateRange) → {spend, impressions, clicks}`.
+- Errors: typed, logged (`loggers.tracking`/new `ads` namespace); never throw into the booking path.
+
+Make the existing inert stubs real: `metaAudienceService.syncCustomAudience`, `metaAdsService.getCampaignInsights` fold into this module.
+
+---
+
+## 6. The operator console + ROAS (`src/app/admin/ads`)
+An **internal operator surface** (one operator, many properties — not per-owner self-serve):
+- **Proposals queue:** campaigns in `pending_approval` (from the brain or created manually) → shows audience (count + reachable), targeting, creative preview, **daily budget + spend cap** → **Approve** (activates via gateway) / Reject.
+- **Active campaigns:** status, spend, and **ROAS by campaign/property** — spend (from insights) ÷ attributed direct bookings (join `BookingAttribution.fbclid/utm` + CAPI Purchases). Judge by *attributed bookings*, not clicks.
+- Property-scoped via `PropertyUrlSync`; super-admin/operator gated; server actions `'use server'` async-only.
+
+---
+
+## 7. The brain seam (agent API)
+Brain proposes; Core executes. `POST /api/growth/ad-proposals` (scoped agent token): `{ propertyId, segmentId, objective, dailyBudget, spendCap, creativeDraft }` → creates an `adCampaigns` doc in `pending_approval` (PAUSED in Meta). Operator approves → activate. One brain serves N tenants (reads each via agent API; holds no secrets). Creative generation (image+copy) is brain-side (AI) — Phase 3.
+
+---
+
+## 8. Guardrails (non-negotiable)
+- **PAUSED-by-default** on every create; only `activateCampaign` un-PAUSEs, and only via the gateway after operator approval.
+- **Hard spend cap** required on every campaign (reject creation without one).
+- **Per-property token/account isolation** — resolve from config; a call for property A can never touch property B's account. (Same test discipline as the pixel: "no-op / no cross-property.")
+- **Autonomy starts at `operator-approves-everything`.** No auto-spend.
+- **Audit:** every activate/spend-affecting action → audit log.
+- **Secrets:** `META_ADS_TOKENS` in Secret Manager; never in repo/property doc (public).
+
+---
+
+## 9. Build phases + model allocation (REVISED after Fable review — H6)
+**Prove manually before building the factory.** My own infra doc (§8) says: run a first ad manually → measure → *then* automate. The original phasing violated that. Corrected:
+
+**Phase 0.5 — MANUAL proof (OWNER, ~1 week, near-zero code) — DO FIRST:**
+- Provision Meta (per revised §10). Create **one small interest+geo campaign manually in Ads Manager**, landing URL stamped `?utm_source=facebook&utm_campaign=<label>`.
+- Existing Pixel/CAPI/`BookingAttribution` measure it. Goal: **prove ads → bookings at Prahova's budget BEFORE building automation** (and give Phase 1 real data to read). Might reveal it doesn't pay — cheapest possible time to learn.
+
+**Phase 0 — config + stop-side scaffolding (small code, no ad-writes):**
+- Per-property ad config (`{adAccountId, pixelId, pageId, instagramActorId, tokenRef}`) + `resolveAdContext` (cached, **shared-token isolation-tested**, H2).
+- `META_ADS_TOKENS` secret + `GRAPH_API_VERSION` consolidation (L2) + `adExecutionGateway` + env switches `GROWTH_ADS_ENABLED`/`GROWTH_ADS_MODE` default-off (H5).
+- Central Meta request builder that injects `status:PAUSED` unconditionally + Bearer-header auth (C2, M5). `pauseCampaign`/`pauseAllForProperty` FIRST (C1). Account-level spending limit as platform backstop (C1).
+
+**Phase 1 — API contract spike + insights (needs token):** a throwaway script exercising each real call against Prahova's account (H4: `special_ad_categories`, `promoted_object`, creative flow, CA ToS, Lookalike floor) BEFORE coding §5 for real. Then `getInsights` reading the Phase-0.5 manual campaign (real data). **No audience layer** (cut — M1).
+
+**Phase 2 — ad creation + activation + stop/reconcile (needs token):** `createCampaign/AdSet/Creative/Ad` (PAUSED, post-create read-back verify, C2) with `promoted_object`+pixel (H4) and `utm_campaign=<adCampaigns.id>` on the creative link (H1). Operator approve (snapshots budget/cap) → `activateCampaign` via `adExecutionGateway`. **Reconciliation cron** (effective_status, REJECTED/WITH_ISSUES, drift → re-approval; catches escapes — C2/M2/M4). DoD includes: **operator pauses it and delivery stops.**
+
+**Phase 3 — creative + full loop:** brain-side creative, agent proposal endpoint (moved here — its consumer lives here, not Phase 0), brain→propose→approve→execute, ROAS closing. Audience/Lookalike layer *if* the pixel pool has grown enough (H4.5/M1), suppression-gated (M1).
+
+*Per phase:* Sonnet builds to spec; Haiku runs tests + watches deploys; **money-path verification + adversarial review on a strong model (not Haiku).**
+
+---
+
+## 10. Prerequisites — token provisioning (OWNER action) — REVISED (H3)
+On the **Comarnic Mountain Chalet** BM (App Review NOT required — own account). The original runbook was **not executable** — it skipped the app and the Page. Corrected order:
+1. **Confirm** the ad account ("Bogdan-Comarnic") exists with a **payment method**, and the **Facebook Page** exists (+ Instagram linked for IG placements).
+2. **Create a new Business-type app** in this BM (the "Access token only" CAPI app **cannot** manage ads — verified, infra doc §0). Enable Marketing API.
+3. **Business Settings → System Users →** create one (role Admin).
+4. **Assign ALL required assets** to the system user: the **ad account**, the **pixel** (`1010060168431159`), **AND the Facebook Page** (+ IG actor) — ads publish *as* a Page; `createAdCreative` needs `page_id` (H3).
+5. **Accept the Custom Audience Terms** on the ad account (one-time, if we ever use customer-list audiences — M1/H4).
+6. **Generate token**, scopes **`ads_management`, `ads_read`, `business_management`**. **Prefer a non-expiring system-user token** (Meta permits it) — expiry silently kills our stop/insights control while spend continues (C1). Copy once.
+7. Note the **ad account id** (`act_<number>`), **Page id**, **IG actor id**.
+Give me **token + ad account id + page id (+ IG id)** → token → `META_ADS_TOKENS` secret; ids → Prahova ad config. Note: scaling to N client properties later needs **business verification + partner access to each client's Page** (weeks — start early; H7).
+
+---
+
+## 11. Reality checks (honest constraints)
+- **Prahova's ~130-guest list is too small for a performant Custom Audience/Lookalike seed** (Meta wants ~100+ *matched*, more to perform). So the real Phase-1/2 acquisition play is **interest+geo targeting + Pixel retargeting**, with Custom Audience mainly for **suppression** (exclude existing guests) and a *seed* for Lookalike once the pixel pool grows. Set expectations: early ROAS ramps; don't over-invest in the audience layer at current volume.
+- **Advantage+ AI creative generation is Ads-Manager-only, not raw API.** So creative is either (a) brain-generated (AI, Phase 3) or (b) real photos + our copy uploaded as creatives. We won't get Meta's auto-creative via the API.
+- **CAPI conversions already feed ROAS** — the measurement input is ready; ROAS is a join, not new tracking.
+
+## 12. Definition of done (loop proven on Prahova) — REVISED
+A campaign **created via our API (PAUSED, read-back-verified)** → visible in Ads Manager → **approved in the operator console** → **activated via `adExecutionGateway`** → spending under its cap → **insights pulled** → **ROAS shown** (utm_campaign join) → **operator PAUSES it and delivery stops** — all through per-property config, with the **reconciliation cron** and **account-level spending limit** proven as backstops.
+
+---
+
+## 13. Adversarial-review reconciliation (Fable, 9 Jul 2026) — accepted changes
+Fable attacked the plan; I accept nearly all of it. §9/§10 already revised above. The rest, by theme:
+
+**Stop-side & PAUSED enforcement (C1, C2) — the biggest miss.** The plan defined how spend *starts*, not how it *stops* — and real ad-ops incidents are about failing to stop.
+- `pauseCampaign` + `pauseAllForProperty` are Phase-2 deliverables (built with/before activation).
+- **Account-level spending limit** set on the ad account = a platform backstop that survives our bugs/dead tokens.
+- **PAUSED is OUR convention, not a platform default** (raw API ≠ CLI). Enforce via: a single request builder that injects `status:PAUSED` (create fns can't pass status), **post-create read-back** asserting `effective_status`, and a **reconciliation cron** listing non-paused campaigns not in our approved set (also catches other-token-holder escapes).
+- **`GROWTH_ADS_ENABLED` + `GROWTH_ADS_MODE=live` env switches, default off** — money path gets the same two-switch gate the messaging path had; a UI click alone must not spend (H5).
+
+**Isolation with a SHARED token (H2) — auth no longer saves you.** Under the agency shared token, `activate(propA, campaignOfB)` *succeeds*. Every mutate-by-id must **fetch the object and assert `account_id === resolved adAccountId`**; `syncCustomAudience` must assert `segment.propertyId === propertyId` (else property A's guest PII → property B's account). Isolation tests must cover the shared-token adversary, not just "unconfigured → no-op." Keep per-property tokens as long as feasible; shared token is a scaling concession + per-account spend limits + IP allowlist.
+
+**Execution gateway is NOT reusable as-is (H5).** The existing `executionGateway` is message-shaped (consent/suppression/messageLog) — no approval check, nothing about un-pausing ads. Build a **dedicated `adExecutionGateway`** (approval-state check, spend-cap-present check, audit doc per activation). "Routes through the gateway" was fiction; corrected.
+
+**ROAS join is weaker than claimed (H1).** `fbclid` = "Meta as channel," NOT a campaign; and CAPI is *outbound* (not a queryable input) — I mis-stated the formula. Real join = `bookings.attribution.utm_campaign ↔ adCampaigns.id`, which only works if `createAdCreative` **stamps `utm_campaign=<adCampaigns.id>&utm_source=facebook` on the landing URL** (hard requirement; reject creative without it). fbclid-only bookings shown as "Meta, campaign unknown." Accept known undercount (cookie window, cross-device, last-touch overwrite) — state it, don't hide it.
+
+**API contract is unverified (H4) — a spike precedes real coding.** Named unknowns to verify against the live account: `special_ad_categories` is **required**; **is vacation-rental forced into the Housing special category** (would kill Lookalikes/detailed targeting?); `OUTCOME_SALES` needs `promoted_object{pixel_id, custom_event_type:PURCHASE}` + `optimization_goal:OFFSITE_CONVERSIONS` at ad-set; creative is multi-step (`/adimages` → `image_hash` → `object_story_spec`); Custom Audiences need ToS accepted + `customer_file_source`; **Lookalike floor ≥100 matched in one country** — Prahova's ~130 likely 400s. Beta; re-verify (v26 expected mid/late 2026).
+
+**Agency Meta mechanics (H7).** "Tenant #2 = config + token" is too glib: BM ad-account creation limits (Comarnic is UNVERIFIED), Marketing API access-tier/verification for scale, **client Pages need partner access** (add `pageId`/`instagramActorId` to config NOW — done in §9), system-user caps. Demoted to "config + a partner-access/verification workflow (weeks)."
+
+**Mediums:** M1 cut the audience layer from Phase 1 (premature at 130; and `buildCustomAudiencePayload` must be **suppression-gated** before ever shipping PII — GDPR). M2 store Meta `effective_status` + reconciliation cadence. M3 budgets in **minor units (bani)** — declare unit, convert once, read-back; verify RON spend-cap/daily minimums (platform min may exceed "small test"). M4 approval snapshots `{budget, cap, creative}`; drift → demote to pending_approval + pause. M5 token in **header/body, never URL** (`getCampaignInsights` stub leaks it today).
+
+**Lows:** L1 don't let the `analytics.metaPixelId → analytics.meta.pixelId` refactor break deployed CAPI/pixel reads (keep old path or migrate atomically). L2 consolidate one `GRAPH_API_VERSION`. L3 cache "last-known" retains spend capability after offboarding (note for agency). L4 insights rate limits bite at N, not 1.
+
+**What Fable agreed was sound:** the per-property `{adAccountId, tokenRef}` + JSON-secret pattern, `write:false` rules, modular-monolith placement, operator-approves-everything, RON-only, and §11's audience-size honesty (the plan just now *acts* on it — M1).

--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -126,3 +126,31 @@ The critical path to running ads. Steps 1–4 are the SAME regardless of which r
 - **B · Ads CLI (for the OpenClaw automation later):** create ONE new **Business-type** app in this same Business Manager, add a **System User**, assign it to the ad account, generate a token (store in GCP Secret Manager), run the `meta-ads` CLI. This is the path for the agentic brain→approve→execute loop.
 
 **Recommended sequence:** setup 1–3 → run first campaign via **A (MCP)** or Ads Manager → wire **Pixel+CAPI conversion tracking** (Core build, `meta-capi.ts`) so bookings attribute to ads → only after ads are proven, build **B** (OpenClaw agentic automation). Don't build the automation before proving the ads work.
+
+---
+
+## 9. Contract spike — VERIFIED against the live account (9 Jul 2026, read-only)
+Facts read directly from ad account **`act_543311232953437`** (Bogdan-Comarnic) + its existing campaigns. Ground truth for building; re-check before go-live (beta).
+
+**Account:** currency **RON**, timezone **CET**, `HAS_VALID_PAYMENT_METHODS`, trust tier 1, `IS_IN_ODAX_EXPERIENCE` (new outcome objectives), business = Comarnic (`284793355854966`). Instagram actor id = **`17841435421272996`**.
+
+**Budgets are in MINOR UNITS (bani)** — verified: old `daily_budget:"1000"` = 10 RON/day. Account minimums:
+- `min_daily_budget` = **464 bani = 4.64 RON/day** (tiny — small tests are cheap).
+- `min_campaign_group_spend_cap` = **50000 bani = 500 RON** ← a campaign-level spend cap **cannot be below 500 RON**. So control a *small* test via **daily budget (~5 RON/day) + an end date**, NOT a sub-500-RON campaign cap. (Resolves Fable M3.)
+- `spend_cap` = **"0"** → NO account-level spending limit set. **Set one in Ads Manager as the platform backstop** (Fable C1).
+
+**special_ad_categories (Fable H4.1 — the Housing question, ANSWERED by precedent):** this account has run vacation-rental ads BOTH as `[]` AND as `["HOUSING"]`. So Meta does NOT force these into HOUSING — **declare `special_ad_categories: []`** for direct-booking/travel ads (the account's own `[]` campaigns ran fine). HOUSING remains a latent ad-review risk; if ever forced, Lookalikes/detailed targeting are lost. `special_ad_categories` IS a required create param.
+
+**Custom Audiences:** `tos_accepted.web_custom_audience_tos = 1` (website/pixel audiences OK); **customer-file ToS NOT accepted** → uploading email/phone lists needs a one-time ToS acceptance first. And existing audiences return **`delivery_status 300: "Audience is too small to be used"`** — confirms the audience/Lookalike layer is premature at this scale (Fable M1: cut from Phase 1).
+
+**Creative flow works (Fable H4.3):** `/act_/adimages` reachable (existing image_hash present). Accepted `object_story_spec` shape:
+```
+object_story_spec: { page_id, instagram_user_id, link_data: { link, message, image_hash, call_to_action:{type:"LEARN_MORE"}, use_flexible_image_aspect_ratio } }
+```
+The **`link`** field is where the `?utm_source=facebook&utm_campaign=<adCampaigns.id>` MUST go (Fable H1).
+
+**Ad-set targeting shape (validated):** `geo_locations{ cities:[{country,key,radius,distance_unit,region}], location_types:["home","recent"] }, age_min, age_max`. Owner's prior play: RO cities (Bucharest 25mi, Braila, Constanta, Galati…), age 30–45.
+
+**STILL UNVERIFIED (no account precedent — verify at first PAUSED create):** `OUTCOME_SALES` needs ad-set `optimization_goal:OFFSITE_CONVERSIONS` + `promoted_object:{pixel_id, custom_event_type:PURCHASE}`. The account's history is all LINK_CLICKS/OUTCOME_TRAFFIC/MESSAGES — no conversion campaigns yet.
+
+**API version:** calls used v21 but Meta's paging responses returned **v25.0** URLs → v25 is current; use a current `GRAPH_API_VERSION` constant (existing code hardcodes v21, expiring ~late 2026 — consolidate, Fable L2).

--- a/firestore.rules
+++ b/firestore.rules
@@ -243,6 +243,17 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only (per-property reactivation config)
     }
 
+    match /adCampaigns/{campaignId} {
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (Meta ad campaigns)
+    }
+
+    match /adAuditLog/{entryId} {
+      // Money-path audit trail — super-admin only.
+      allow read: if isSuperAdmin();
+      allow write: if false;  // Admin SDK only
+    }
+
     // ============================================================================
     // App Config
     // ============================================================================

--- a/src/config/__tests__/growth-ads.test.ts
+++ b/src/config/__tests__/growth-ads.test.ts
@@ -1,0 +1,59 @@
+/** @jest-environment node */
+import { isAdsEngineEnabled, getAdsMode, isAdsLiveAllowed } from '../growth-ads';
+
+/**
+ * The two-switch safety matrix for the ads/spend path: NOTHING is live unless
+ * BOTH GROWTH_ADS_ENABLED=true and GROWTH_ADS_MODE=live are set, with strict
+ * string equality so any fuzzy value fails toward dry-run. Mirrors
+ * growth-engine.test.ts exactly, for the money path (Fable H5).
+ */
+describe('growth-ads flags — two-switch safety matrix', () => {
+  const orig = { ...process.env };
+  afterEach(() => {
+    process.env = { ...orig };
+  });
+
+  it('defaults to dry-run when nothing is set', () => {
+    delete process.env.GROWTH_ADS_ENABLED;
+    delete process.env.GROWTH_ADS_MODE;
+    expect(isAdsEngineEnabled()).toBe(false);
+    expect(getAdsMode()).toBe('dry-run');
+    expect(isAdsLiveAllowed()).toBe(false);
+  });
+
+  it('ENABLED alone stays dry-run', () => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    delete process.env.GROWTH_ADS_MODE;
+    expect(isAdsEngineEnabled()).toBe(true);
+    expect(getAdsMode()).toBe('dry-run');
+    expect(isAdsLiveAllowed()).toBe(false);
+  });
+
+  it('MODE=live alone (engine off) stays dry-run', () => {
+    delete process.env.GROWTH_ADS_ENABLED;
+    process.env.GROWTH_ADS_MODE = 'live';
+    expect(getAdsMode()).toBe('dry-run');
+    expect(isAdsLiveAllowed()).toBe(false);
+  });
+
+  it('both switches on → live', () => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    process.env.GROWTH_ADS_MODE = 'live';
+    expect(getAdsMode()).toBe('live');
+    expect(isAdsLiveAllowed()).toBe(true);
+  });
+
+  it('fuzzy values fail safe (strict equality)', () => {
+    process.env.GROWTH_ADS_ENABLED = 'TRUE';
+    process.env.GROWTH_ADS_MODE = 'live';
+    expect(getAdsMode()).toBe('dry-run');
+
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    process.env.GROWTH_ADS_MODE = 'LIVE ';
+    expect(getAdsMode()).toBe('dry-run');
+
+    process.env.GROWTH_ADS_ENABLED = '1';
+    process.env.GROWTH_ADS_MODE = 'live';
+    expect(getAdsMode()).toBe('dry-run');
+  });
+});

--- a/src/config/growth-ads.ts
+++ b/src/config/growth-ads.ts
@@ -1,0 +1,40 @@
+/**
+ * Growth Ad Engine (Meta Ads) runtime configuration & dark-launch flags —
+ * Phase 0 (plans §9, §13 H5).
+ *
+ * Mirrors `src/config/growth-engine.ts`'s two-switch safety model EXACTLY, but
+ * for the ads/spend path: everything defaults to OFF / dry-run. The ads engine
+ * is inert until `GROWTH_ADS_ENABLED=true` is set at deploy time, and no Meta
+ * campaign is ever un-paused until `GROWTH_ADS_MODE=live` is ALSO set. This is
+ * the same discipline as the messaging path — a stray env var (or a UI click)
+ * alone can never spend real money.
+ *
+ * Plain module (not `'use server'`) so it can export constants and be
+ * imported by both server services and (flag reads only) client code.
+ */
+
+export type AdsMode = 'dry-run' | 'live';
+
+/** Master kill switch for the ads engine. Default OFF — requires a deploy-time env var. */
+export function isAdsEngineEnabled(): boolean {
+  return process.env.GROWTH_ADS_ENABLED === 'true';
+}
+
+/**
+ * Effective ads mode. Defaults to 'dry-run'. Only resolves to 'live' when BOTH
+ * the ads engine is enabled AND `GROWTH_ADS_MODE=live` — two independent
+ * switches must be flipped before any Meta campaign can be un-paused.
+ */
+export function getAdsMode(): AdsMode {
+  if (!isAdsEngineEnabled()) return 'dry-run';
+  return process.env.GROWTH_ADS_MODE === 'live' ? 'live' : 'dry-run';
+}
+
+/**
+ * True only when a real (spend-affecting) Meta activation may be performed.
+ * `adExecutionGateway.activateCampaign` is a no-op live-action whenever this
+ * is false — the money-path gate (Fable H5).
+ */
+export function isAdsLiveAllowed(): boolean {
+  return getAdsMode() === 'live';
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -419,6 +419,8 @@ export const loggers = {
   campaign: createLogger('campaign'),
   segment: createLogger('segment'),
   executionGateway: createLogger('execution:gateway'),
+  // Growth Ad Engine (Meta Ads, dark-launched — Phase 0)
+  ads: createLogger('ads'),
 };
 
 // Type-safe logger categories

--- a/src/services/growth/__tests__/adExecutionGateway.test.ts
+++ b/src/services/growth/__tests__/adExecutionGateway.test.ts
@@ -1,0 +1,197 @@
+/** @jest-environment node */
+
+// Mock the Admin SDK and the metaAds modules BEFORE importing the SUT.
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
+}));
+jest.mock('@/services/growth/metaAds/adContext', () => ({ resolveAdContext: jest.fn() }));
+jest.mock('@/services/growth/metaAds/client', () => ({ metaGraph: jest.fn(), activateResource: jest.fn() }));
+
+import { activateCampaign } from '../adExecutionGateway';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { resolveAdContext } from '@/services/growth/metaAds/adContext';
+import { metaGraph, activateResource } from '@/services/growth/metaAds/client';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockMetaGraph = metaGraph as jest.Mock;
+const mockActivateResource = activateResource as jest.Mock;
+
+function chainableGet(result: unknown) {
+  const q: Record<string, jest.Mock> = {};
+  q.where = jest.fn(() => q);
+  q.limit = jest.fn(() => q);
+  q.get = jest.fn().mockResolvedValue(result);
+  return q;
+}
+
+function makeDb(adCampaignsResult: unknown) {
+  const addMock = jest.fn().mockResolvedValue({ id: 'audit-1' });
+  const adCampaignsQuery = chainableGet(adCampaignsResult);
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name === 'adCampaigns') return adCampaignsQuery;
+      if (name === 'adAuditLog') return { add: addMock };
+      throw new Error(`unexpected collection read in test: ${name}`);
+    }),
+  };
+  return { db, addMock };
+}
+
+function approvedSnap(overrides: Record<string, unknown> = {}) {
+  return {
+    empty: false,
+    docs: [
+      {
+        data: () => ({
+          propertyId: 'prahova-mountain-chalet',
+          metaCampaignId: 'camp-1',
+          status: 'approved',
+          spendCapMinor: 50000, // 500 RON
+          ...overrides,
+        }),
+      },
+    ],
+  };
+}
+
+const PROPERTY = 'prahova-mountain-chalet';
+const CAMPAIGN = 'camp-1';
+const AD_ACCOUNT = 'act_543311232953437';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Enforce DARK LAUNCH default (both switches off) unless a test overrides it.
+  delete process.env.GROWTH_ADS_ENABLED;
+  delete process.env.GROWTH_ADS_MODE;
+});
+
+describe('activateCampaign — dry-run gate (Fable H5, default OFF)', () => {
+  it('is a no-op live-action by default: no context/Meta calls, status=dry-run, audited', async () => {
+    const { db, addMock } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+
+    expect(res).toEqual({ status: 'dry-run' });
+    expect(mockResolveAdContext).not.toHaveBeenCalled();
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+    expect(mockActivateResource).not.toHaveBeenCalled();
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(addMock.mock.calls[0][0]).toMatchObject({ result: 'dry-run' });
+  });
+
+  it('stays dry-run with only GROWTH_ADS_ENABLED set (mode not live)', async () => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    const { db } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res.status).toBe('dry-run');
+    expect(mockActivateResource).not.toHaveBeenCalled();
+  });
+});
+
+describe('activateCampaign — live mode (both switches on)', () => {
+  beforeEach(() => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    process.env.GROWTH_ADS_MODE = 'live';
+  });
+
+  it('rejects when no adCampaigns doc exists for property+campaign', async () => {
+    const { db, addMock } = makeDb({ empty: true, docs: [] });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'no-adCampaigns-doc' });
+    expect(mockResolveAdContext).not.toHaveBeenCalled();
+    expect(addMock.mock.calls[0][0]).toMatchObject({ result: 'rejected', reason: 'no-adCampaigns-doc' });
+  });
+
+  it('rejects an unapproved campaign (e.g. pending_approval)', async () => {
+    const { db } = makeDb(approvedSnap({ status: 'pending_approval' }));
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'not-approved:pending_approval' });
+    expect(mockActivateResource).not.toHaveBeenCalled();
+  });
+
+  it('rejects an approved campaign with NO spend cap snapshotted (M3/M4)', async () => {
+    const { db } = makeDb(approvedSnap({ spendCapMinor: undefined }));
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'no-spend-cap' });
+    expect(mockActivateResource).not.toHaveBeenCalled();
+  });
+
+  it('rejects an approved campaign with spendCapMinor <= 0', async () => {
+    const { db } = makeDb(approvedSnap({ spendCapMinor: 0 }));
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'no-spend-cap' });
+  });
+
+  it('rejects when the property has no ad context (unconfigured)', async () => {
+    const { db } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockResolveAdContext.mockResolvedValue(null);
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'no-ad-context' });
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+  });
+
+  it('rejects on OWNERSHIP MISMATCH — the shared-token adversary (Fable H2)', async () => {
+    const { db, addMock } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'shared-agency-token' });
+    // The Meta campaign fetched back belongs to a DIFFERENT ad account —
+    // simulates activate(propertyA, campaignOfPropertyB) under a shared token.
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: CAMPAIGN, account_id: '999999999999999' } });
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'ownership-mismatch' });
+    expect(mockActivateResource).not.toHaveBeenCalled();
+    expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ result: 'rejected', reason: 'ownership-mismatch' });
+  });
+
+  it('rejects when the Meta campaign fetch itself fails', async () => {
+    const { db } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+    mockMetaGraph.mockResolvedValue({ ok: false, error: 'timeout' });
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'campaign-fetch-failed:timeout' });
+    expect(mockActivateResource).not.toHaveBeenCalled();
+  });
+
+  it('activates when every gate passes, normalizing the act_ prefix for the ownership check', async () => {
+    const { db, addMock } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+    // Meta's read-back omits the "act_" prefix on account_id — must still match.
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: CAMPAIGN, account_id: '543311232953437' } });
+    mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN, { actor: 'operator-1' });
+    expect(res).toEqual({ status: 'activated' });
+    expect(mockActivateResource).toHaveBeenCalledWith(CAMPAIGN, 'tok', PROPERTY);
+    expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ result: 'activated', actor: 'operator-1' });
+  });
+
+  it('rejects (does not throw) when the un-pause call itself fails', async () => {
+    const { db } = makeDb(approvedSnap());
+    mockGetAdminDb.mockResolvedValue(db);
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: CAMPAIGN, account_id: '543311232953437' } });
+    mockActivateResource.mockResolvedValue({ ok: false, error: 'meta-down' });
+
+    const res = await activateCampaign(PROPERTY, CAMPAIGN);
+    expect(res).toEqual({ status: 'rejected', reason: 'activate-failed:meta-down' });
+  });
+});

--- a/src/services/growth/adExecutionGateway.ts
+++ b/src/services/growth/adExecutionGateway.ts
@@ -1,0 +1,197 @@
+/**
+ * adExecutionGateway — the activation choke point for Meta ad campaigns
+ * (plan §13 Fable H5: the existing `executionGateway.ts` is message-shaped —
+ * consent/suppression/messageLog — and has no approval check, spend-cap
+ * check, or notion of un-pausing an ad; "routes through the gateway" was
+ * fiction for ads, so this is a DEDICATED gateway). Mirrors the shape of
+ * `executionGateway.ts` (resolve → gate → act → audit) but the gates are
+ * ads-specific and money-shaped:
+ *
+ *  1. Two-switch dry-run gate (`GROWTH_ADS_ENABLED` + `GROWTH_ADS_MODE=live`)
+ *     — a UI click alone can never spend (Fable H5).
+ *  2. Operator-approval + spend-cap gate — the `adCampaigns` doc for this
+ *     property+campaign must exist, be `status === 'approved'`, and carry a
+ *     SNAPSHOTTED `spendCapMinor` — no spend cap, no activation (Fable
+ *     H5/M3/M4).
+ *  3. Ownership assert — the Meta campaign is fetched and its `account_id`
+ *     MUST equal the property's resolved ad account. Under a SHARED agency
+ *     token, auth alone does not stop `activate(propA, campaignOfB)` from
+ *     succeeding — this is the check that does (Fable H2).
+ *
+ * Every activation attempt (dry-run, rejected, or activated) writes an audit
+ * doc to `adAuditLog` so the money path has a complete trail regardless of
+ * outcome — same discipline as `executionGateway`'s messageLog writes.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + async functions.
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { AdCampaignStatus } from '@/types';
+import { isAdsLiveAllowed } from '@/config/growth-ads';
+import { resolveAdContext } from './metaAds/adContext';
+import { metaGraph, activateResource } from './metaAds/client';
+
+const logger = loggers.ads;
+
+type AdminDb = Awaited<ReturnType<typeof getAdminDb>>;
+
+export type ActivateStatus = 'dry-run' | 'activated' | 'rejected';
+
+export interface ActivateResult {
+  status: ActivateStatus;
+  reason?: string;
+}
+
+export interface ActivateOptions {
+  /** Who/what triggered this activation attempt — recorded on the audit doc. */
+  actor?: string;
+}
+
+interface AdCampaignDoc {
+  propertyId?: string;
+  metaCampaignId?: string;
+  status?: AdCampaignStatus;
+  spendCapMinor?: number;
+}
+
+interface MetaCampaignReadBack {
+  id: string;
+  account_id?: string;
+}
+
+/**
+ * Meta returns a campaign's `account_id` WITHOUT the `act_` prefix (e.g.
+ * "543311232953437"), while our resolved ad-account config carries it WITH
+ * the prefix (e.g. "act_543311232953437", the form the Marketing API expects
+ * in a path). Normalize both sides before comparing so the ownership assert
+ * doesn't false-reject on a prefix mismatch.
+ */
+function normalizeAccountId(id: string | undefined | null): string | undefined {
+  if (!id) return undefined;
+  return id.startsWith('act_') ? id.slice(4) : id;
+}
+
+async function writeAudit(
+  db: AdminDb,
+  entry: {
+    propertyId: string;
+    metaCampaignId: string;
+    result: ActivateStatus;
+    reason?: string;
+    actor?: string;
+  }
+): Promise<void> {
+  try {
+    await db.collection('adAuditLog').add({
+      propertyId: entry.propertyId,
+      metaCampaignId: entry.metaCampaignId,
+      action: 'activate',
+      result: entry.result,
+      reason: entry.reason ?? null,
+      actor: entry.actor ?? null,
+      at: FieldValue.serverTimestamp(),
+    });
+  } catch (error) {
+    logger.warn('adExecutionGateway: audit write failed', {
+      propertyId: entry.propertyId,
+      metaCampaignId: entry.metaCampaignId,
+      result: entry.result,
+      error: String(error),
+    });
+  }
+}
+
+async function reject(
+  db: AdminDb,
+  propertyId: string,
+  metaCampaignId: string,
+  reason: string,
+  actor?: string
+): Promise<ActivateResult> {
+  logger.warn('activateCampaign: rejected', { propertyId, metaCampaignId, reason });
+  await writeAudit(db, { propertyId, metaCampaignId, result: 'rejected', reason, actor });
+  return { status: 'rejected', reason };
+}
+
+/**
+ * Activate (un-PAUSE) a Meta campaign for a property. The ONLY path in this
+ * codebase allowed to call `activateResource` — every check below runs in
+ * order and short-circuits to a rejection (with an audit record) on the first
+ * failure.
+ */
+export async function activateCampaign(
+  propertyId: string,
+  metaCampaignId: string,
+  opts?: ActivateOptions
+): Promise<ActivateResult> {
+  const db = await getAdminDb();
+  const actor = opts?.actor;
+
+  // (a) two-switch dry-run gate — a UI click alone can never spend (H5).
+  if (!isAdsLiveAllowed()) {
+    logger.info('activateCampaign: dry-run mode — no live action taken', { propertyId, metaCampaignId });
+    await writeAudit(db, { propertyId, metaCampaignId, result: 'dry-run', actor });
+    return { status: 'dry-run' };
+  }
+
+  // (b) operator-approval + spend-cap gate (H5/M3/M4).
+  const snap = await db
+    .collection('adCampaigns')
+    .where('propertyId', '==', propertyId)
+    .where('metaCampaignId', '==', metaCampaignId)
+    .limit(1)
+    .get();
+
+  if (snap.empty) {
+    return reject(db, propertyId, metaCampaignId, 'no-adCampaigns-doc', actor);
+  }
+  const campaignDoc = snap.docs[0].data() as AdCampaignDoc;
+  if (campaignDoc.status !== 'approved') {
+    return reject(db, propertyId, metaCampaignId, `not-approved:${campaignDoc.status ?? 'unknown'}`, actor);
+  }
+  if (!campaignDoc.spendCapMinor || campaignDoc.spendCapMinor <= 0) {
+    return reject(db, propertyId, metaCampaignId, 'no-spend-cap', actor);
+  }
+
+  // Resolve context (needed for both the ownership assert and the token).
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    return reject(db, propertyId, metaCampaignId, 'no-ad-context', actor);
+  }
+
+  // (c) ownership assert — the shared-token safety net (H2). Fetch the Meta
+  // campaign and confirm it actually belongs to THIS property's resolved ad
+  // account before touching it; auth alone does not prove that under a
+  // shared agency token (activate(propA, campaignOfB) would otherwise
+  // succeed silently).
+  const fetched = await metaGraph<MetaCampaignReadBack>(metaCampaignId, {
+    method: 'GET',
+    params: { fields: 'id,account_id' },
+    token: ctx.token,
+    propertyId,
+  });
+  if (!fetched.ok) {
+    return reject(db, propertyId, metaCampaignId, `campaign-fetch-failed:${fetched.error}`, actor);
+  }
+  const fetchedAccountId = normalizeAccountId(fetched.data.account_id);
+  const expectedAccountId = normalizeAccountId(ctx.adAccountId);
+  if (!fetchedAccountId || fetchedAccountId !== expectedAccountId) {
+    logger.error('activateCampaign: OWNERSHIP MISMATCH — refusing to activate', undefined, {
+      propertyId,
+      metaCampaignId,
+      fetchedAccountId,
+      expectedAccountId,
+    });
+    return reject(db, propertyId, metaCampaignId, 'ownership-mismatch', actor);
+  }
+
+  // All gates passed — activate (un-PAUSE).
+  const activated = await activateResource(metaCampaignId, ctx.token, propertyId);
+  if (!activated.ok) {
+    return reject(db, propertyId, metaCampaignId, `activate-failed:${activated.error}`, actor);
+  }
+
+  await writeAudit(db, { propertyId, metaCampaignId, result: 'activated', actor });
+  logger.info('activateCampaign: activated', { propertyId, metaCampaignId });
+  return { status: 'activated' };
+}

--- a/src/services/growth/metaAds/__tests__/adContext.test.ts
+++ b/src/services/growth/metaAds/__tests__/adContext.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+jest.mock('@/lib/firebaseAdminSafe', () => ({ getAdminDb: jest.fn() }));
+
+import { resolveAdContext, clearAdContextCache } from '../adContext';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb(analyticsByProperty: Record<string, unknown>) {
+  const getMock = jest.fn(async (propertyId: string) => ({
+    data: () => ({ analytics: analyticsByProperty[propertyId] }),
+  }));
+  const db = {
+    collection: jest.fn(() => ({
+      doc: jest.fn((propertyId: string) => ({ get: () => getMock(propertyId) })),
+    })),
+  };
+  return { db, getMock };
+}
+
+const origTokens = process.env.META_ADS_TOKENS;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearAdContextCache();
+});
+
+afterAll(() => {
+  process.env.META_ADS_TOKENS = origTokens;
+});
+
+describe('resolveAdContext — per-property Meta Ads config (Phase 0)', () => {
+  it('resolves a fully configured property', async () => {
+    process.env.META_ADS_TOKENS = JSON.stringify({ 'prahova-mountain-chalet': 'tok-prahova' });
+    const { db } = makeDb({
+      'prahova-mountain-chalet': {
+        metaAdAccountId: 'act_543311232953437',
+        metaPageId: '107610677616243',
+        metaInstagramActorId: '17841435421272996',
+        metaTokenRef: 'prahova-mountain-chalet',
+      },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const ctx = await resolveAdContext('prahova-mountain-chalet');
+    expect(ctx).toEqual({
+      adAccountId: 'act_543311232953437',
+      pageId: '107610677616243',
+      instagramActorId: '17841435421272996',
+      token: 'tok-prahova',
+    });
+  });
+
+  it('returns null for a property with no ad account configured (isolation)', async () => {
+    process.env.META_ADS_TOKENS = JSON.stringify({ 'prahova-mountain-chalet': 'tok-prahova' });
+    const { db } = makeDb({ 'coltei-apartment-bucharest': { metaPixelId: 'px-only' } });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    expect(await resolveAdContext('coltei-apartment-bucharest')).toBeNull();
+  });
+
+  it('returns null when the ad account is configured but the tokenRef has no secret entry (isolation)', async () => {
+    process.env.META_ADS_TOKENS = JSON.stringify({ 'some-other-ref': 'tok-x' });
+    const { db } = makeDb({
+      'coltei-apartment-bucharest': {
+        metaAdAccountId: 'act_999',
+        metaTokenRef: 'coltei-apartment-bucharest', // not in the secret map
+      },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    expect(await resolveAdContext('coltei-apartment-bucharest')).toBeNull();
+  });
+
+  it('returns null for an empty/falsy propertyId without hitting Firestore', async () => {
+    const { db, getMock } = makeDb({});
+    mockGetAdminDb.mockResolvedValue(db);
+    expect(await resolveAdContext('')).toBeNull();
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('caches per property (one Firestore read within the TTL)', async () => {
+    process.env.META_ADS_TOKENS = JSON.stringify({ 'prahova-mountain-chalet': 'tok-prahova' });
+    const { db, getMock } = makeDb({
+      'prahova-mountain-chalet': { metaAdAccountId: 'act_543311232953437', metaTokenRef: 'prahova-mountain-chalet' },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    await resolveAdContext('prahova-mountain-chalet');
+    await resolveAdContext('prahova-mountain-chalet');
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a shared tokenRef resolves the SAME token for two different properties (agency shape)', async () => {
+    process.env.META_ADS_TOKENS = JSON.stringify({ agency: 'tok-agency' });
+    const { db } = makeDb({
+      'property-a': { metaAdAccountId: 'act_a', metaTokenRef: 'agency' },
+      'property-b': { metaAdAccountId: 'act_b', metaTokenRef: 'agency' },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const ctxA = await resolveAdContext('property-a');
+    const ctxB = await resolveAdContext('property-b');
+    expect(ctxA?.token).toBe('tok-agency');
+    expect(ctxB?.token).toBe('tok-agency');
+    expect(ctxA?.adAccountId).not.toBe(ctxB?.adAccountId); // still two distinct accounts
+  });
+});

--- a/src/services/growth/metaAds/__tests__/client.test.ts
+++ b/src/services/growth/metaAds/__tests__/client.test.ts
@@ -1,0 +1,110 @@
+/** @jest-environment node */
+import { metaGraph, createResource, pauseResource, activateResource, GRAPH_API_VERSION } from '../client';
+
+const mockFetch = global.fetch as jest.Mock;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('metaGraph — token placement (Fable M5)', () => {
+  it('NEVER puts the token in the URL, for GET', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ id: '123' }) });
+    await metaGraph('act_123/campaigns', { method: 'GET', params: { fields: 'id,name' }, token: 'SECRET-TOKEN' });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).not.toContain('SECRET-TOKEN');
+    expect(String(url)).not.toContain('access_token');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer SECRET-TOKEN');
+  });
+
+  it('NEVER puts the token in the URL or body, for POST', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ id: '123' }) });
+    await metaGraph('act_123/campaigns', {
+      method: 'POST',
+      params: { name: 'Test Campaign' },
+      token: 'SECRET-TOKEN',
+    });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).not.toContain('SECRET-TOKEN');
+    expect(String(init.body)).not.toContain('SECRET-TOKEN');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer SECRET-TOKEN');
+  });
+
+  it('builds the URL from the single GRAPH_API_VERSION constant', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    await metaGraph('act_123/campaigns', { method: 'GET', token: 't' });
+    const [url] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain(`graph.facebook.com/${GRAPH_API_VERSION}/`);
+  });
+
+  it('returns a typed {ok:false,error} on a non-OK response, never throws', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, text: async () => '{"error":"bad request"}' });
+    const result = await metaGraph('act_123/campaigns', { method: 'GET', token: 't' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('bad request');
+      expect(result.status).toBe(400);
+    }
+  });
+
+  it('returns a typed {ok:false,error} on a network error, never throws', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    const result = await metaGraph('act_123/campaigns', { method: 'GET', token: 't' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('network down');
+  });
+});
+
+describe('createResource — PAUSED enforcement (Fable C2)', () => {
+  it('injects status:PAUSED when the caller supplies no status', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ id: 'campaign-1' }) });
+    await createResource('campaigns', 'act_123', 'tok', { name: 'Test' });
+
+    const [, init] = mockFetch.mock.calls[0];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('status')).toBe('PAUSED');
+    expect(body.get('name')).toBe('Test');
+  });
+
+  it('OVERRIDES a caller-supplied status — cannot be made to create live (Fable C2)', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ id: 'campaign-1' }) });
+    await createResource('campaigns', 'act_123', 'tok', { name: 'Test', status: 'ACTIVE' });
+
+    const [, init] = mockFetch.mock.calls[0];
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('status')).toBe('PAUSED'); // NOT 'ACTIVE'
+  });
+
+  it('POSTs to <adAccountId>/<node>', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ id: 'campaign-1' }) });
+    await createResource('campaigns', 'act_543311232953437', 'tok', { name: 'Test' });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain('act_543311232953437/campaigns');
+    expect(init.method).toBe('POST');
+  });
+});
+
+describe('pauseResource / activateResource — status transitions', () => {
+  it('pauseResource POSTs status=PAUSED to the resource id', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    await pauseResource('120210000000001', 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain('120210000000001');
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('status')).toBe('PAUSED');
+  });
+
+  it('activateResource POSTs status=ACTIVE to the resource id', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    await activateResource('120210000000001', 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain('120210000000001');
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('status')).toBe('ACTIVE');
+  });
+});

--- a/src/services/growth/metaAds/__tests__/lifecycle.test.ts
+++ b/src/services/growth/metaAds/__tests__/lifecycle.test.ts
@@ -1,0 +1,86 @@
+/** @jest-environment node */
+
+jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
+jest.mock('../client', () => ({ metaGraph: jest.fn(), pauseResource: jest.fn() }));
+
+import { pauseCampaign, pauseAllForProperty } from '../lifecycle';
+import { resolveAdContext } from '../adContext';
+import { metaGraph, pauseResource } from '../client';
+
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockMetaGraph = metaGraph as jest.Mock;
+const mockPauseResource = pauseResource as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('pauseCampaign — the STOP primitive (Fable C1)', () => {
+  it('no-ops for a property with no ad context (never calls Meta)', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await pauseCampaign('unconfigured-property', 'camp-1');
+    expect(res).toEqual({ success: false, campaignId: 'camp-1', error: 'no-ad-context' });
+    expect(mockPauseResource).not.toHaveBeenCalled();
+  });
+
+  it('pauses via the client for a configured property', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+    mockPauseResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+    const res = await pauseCampaign('prahova-mountain-chalet', 'camp-1');
+    expect(res).toEqual({ success: true, campaignId: 'camp-1' });
+    expect(mockPauseResource).toHaveBeenCalledWith('camp-1', 'tok', 'prahova-mountain-chalet');
+  });
+
+  it('surfaces (but does not throw on) a Meta-side pause failure', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+    mockPauseResource.mockResolvedValue({ ok: false, error: 'meta-down' });
+
+    const res = await pauseCampaign('prahova-mountain-chalet', 'camp-1');
+    expect(res).toEqual({ success: false, campaignId: 'camp-1', error: 'meta-down' });
+  });
+});
+
+describe('pauseAllForProperty — the panic button (Fable C1)', () => {
+  it('no-ops (empty list) for a property with no ad context — never a blind pause-everything', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await pauseAllForProperty('unconfigured-property');
+    expect(res).toEqual([]);
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+    expect(mockPauseResource).not.toHaveBeenCalled();
+  });
+
+  it('lists non-paused campaigns for the property and pauses each', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_543311232953437', token: 'tok' });
+    mockMetaGraph.mockResolvedValue({
+      ok: true,
+      data: {
+        data: [
+          { id: 'camp-1', status: 'ACTIVE' },
+          { id: 'camp-2', status: 'PAUSED' }, // already paused — skipped
+          { id: 'camp-3', status: 'PENDING_REVIEW' },
+        ],
+      },
+    });
+    mockPauseResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+    const res = await pauseAllForProperty('prahova-mountain-chalet');
+    expect(mockPauseResource).toHaveBeenCalledTimes(2);
+    expect(mockPauseResource).toHaveBeenCalledWith('camp-1', 'tok', 'prahova-mountain-chalet');
+    expect(mockPauseResource).toHaveBeenCalledWith('camp-3', 'tok', 'prahova-mountain-chalet');
+    expect(mockPauseResource).not.toHaveBeenCalledWith('camp-2', 'tok', 'prahova-mountain-chalet');
+    expect(res).toEqual([
+      { success: true, campaignId: 'camp-1' },
+      { success: true, campaignId: 'camp-3' },
+    ]);
+  });
+
+  it('returns an empty list (no throw) when listing campaigns fails', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+    mockMetaGraph.mockResolvedValue({ ok: false, error: 'timeout' });
+
+    const res = await pauseAllForProperty('prahova-mountain-chalet');
+    expect(res).toEqual([]);
+    expect(mockPauseResource).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/growth/metaAds/adContext.ts
+++ b/src/services/growth/metaAds/adContext.ts
@@ -1,0 +1,109 @@
+/**
+ * Per-property Meta Ads context resolution — Phase 0 (plan §3, §5, §8, §13 H2).
+ *
+ * MULTI-PROPERTY FIRST, AGENCY-SHAPED: the ad account/page/IG actor are
+ * per-property CONFIG stored on the property document at
+ * `analytics.{metaAdAccountId,metaPageId,metaInstagramActorId,metaTokenRef}`
+ * (extends the existing `analytics.metaPixelId` config — see meta-pixels.ts,
+ * whose read/cache pattern this mirrors). The token itself is NOT stored per
+ * property; it's resolved from the `META_ADS_TOKENS` secret, a JSON map keyed
+ * by `metaTokenRef` — mirrors meta-capi.ts's `META_CAPI_TOKENS` pattern. Most
+ * future clients won't own their Meta ad account (agency model, plan §3), so
+ * `metaTokenRef` may be a shared ref used by several properties — resolution
+ * is keyed by ref, never assumed 1:1 with propertyId.
+ *
+ * A property with no ad account configured, OR whose `metaTokenRef` has no
+ * entry in the secret, resolves to `null` — multi-tenant isolation: an
+ * unconfigured property gets NO ads, same discipline as the pixel (plan §8).
+ * This null-on-missing check is necessary but NOT sufficient for isolation
+ * under a SHARED token — see `adExecutionGateway`'s ownership assert (H2),
+ * which is the check that catches `activate(propA, campaignOfB)`.
+ *
+ * Cached per process (TTL 5min — ad config changes rarely) to avoid a
+ * Firestore read on every call. Server-only (Admin SDK).
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export interface AdContext {
+  adAccountId: string;
+  pageId?: string;
+  instagramActorId?: string;
+  token: string;
+}
+
+const cache = new Map<string, { value: AdContext | null; at: number }>();
+
+/**
+ * Per-tokenRef Meta Ads access tokens, from the META_ADS_TOKENS secret — a
+ * JSON map `{ "<tokenRef>": "<system-user-token>" }`. Parsed once (lazily,
+ * like meta-capi.ts's capiTokens). A tokenRef with no entry resolves to
+ * undefined (isolation).
+ */
+let adsTokens: Record<string, string> | null = null;
+function getAdsToken(tokenRef: string): string | undefined {
+  if (adsTokens === null) {
+    try {
+      adsTokens = process.env.META_ADS_TOKENS ? JSON.parse(process.env.META_ADS_TOKENS) : {};
+    } catch {
+      logger.warn('resolveAdContext: META_ADS_TOKENS is not valid JSON');
+      adsTokens = {};
+    }
+  }
+  return (adsTokens ?? {})[tokenRef];
+}
+
+/**
+ * Resolve the Meta Ads context configured for a property. Returns null if the
+ * property has no ad account configured OR its `metaTokenRef` has no token in
+ * the secret — an unconfigured/misconfigured property gets NO ads.
+ */
+export async function resolveAdContext(propertyId: string): Promise<AdContext | null> {
+  if (!propertyId) return null;
+
+  const now = Date.now();
+  const cached = cache.get(propertyId);
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.value;
+
+  let value: AdContext | null = null;
+  try {
+    const db = await getAdminDb();
+    const doc = await db.collection('properties').doc(propertyId).get();
+    const analytics = doc.data()?.analytics as
+      | {
+          metaAdAccountId?: string;
+          metaPageId?: string;
+          metaInstagramActorId?: string;
+          metaTokenRef?: string;
+        }
+      | undefined;
+
+    const adAccountId = analytics?.metaAdAccountId?.trim() || undefined;
+    const tokenRef = analytics?.metaTokenRef?.trim() || undefined;
+    const token = tokenRef ? getAdsToken(tokenRef) : undefined;
+
+    if (adAccountId && token) {
+      value = {
+        adAccountId,
+        pageId: analytics?.metaPageId?.trim() || undefined,
+        instagramActorId: analytics?.metaInstagramActorId?.trim() || undefined,
+        token,
+      };
+    }
+  } catch {
+    logger.warn('resolveAdContext: read failed; using last-known', { propertyId });
+    value = cached?.value ?? null;
+  }
+
+  cache.set(propertyId, { value, at: now });
+  return value;
+}
+
+/** Clear the in-process ad-context cache (tests / after a config edit). */
+export function clearAdContextCache(): void {
+  cache.clear();
+  adsTokens = null;
+}

--- a/src/services/growth/metaAds/client.ts
+++ b/src/services/growth/metaAds/client.ts
@@ -1,0 +1,191 @@
+/**
+ * Meta Graph/Marketing API client — Phase 0 (plan §5, §9, §13).
+ *
+ * The ONLY module in this codebase that calls `graph.facebook.com`. Every
+ * other growth-ads module goes through here so the safety properties from the
+ * adversarial review are enforced in exactly ONE place:
+ *
+ * - The access token is NEVER placed in the URL query string (Fable M5) — it
+ *   always travels in the `Authorization: Bearer` header, for both GET and
+ *   POST/DELETE calls. (The existing `getCampaignInsights` stub in
+ *   `metaAdsService.ts` puts it in the URL — that is the leak Fable flagged;
+ *   this client is the fix, new callers must use it instead.)
+ * - `createResource()` unconditionally injects `status: 'PAUSED'` into every
+ *   create payload, AFTER spreading the caller's payload, so a caller cannot
+ *   pass a different status and have it win (Fable C2). PAUSED is OUR
+ *   convention — the raw Marketing API has no such default (unlike the
+ *   official Ads CLI/MCP) — so this is the one place that enforces it.
+ * - Non-OK responses are returned as a typed `{ ok: false, error }`, logged
+ *   via `loggers.ads`, and NEVER thrown — a Meta API hiccup must never crash a
+ *   caller's critical path (mirrors `meta-capi.ts`'s fetch handling).
+ *
+ * Phase 0 intentionally stops at this low-level client + the PAUSED-enforcing
+ * create helper + the pause/activate status-transition helpers — no
+ * campaign/adset/ad/creative business logic yet. That needs a verified API
+ * contract spike against the live account first (plan §9 Phase 1); building it
+ * blind would bake in wrong assumptions about a beta API.
+ */
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+/**
+ * Single source of truth for the Marketing API version — do not scatter
+ * (plan §9/§13 L2). NOTE: the verified contract spike (docs/meta-ads-
+ * infrastructure-2026.md §9) found the live account's paging responses
+ * resolving to v25.0; v21.0 is pinned here per explicit Phase-0 spec and is
+ * still valid today, but should be bumped to a current version as part of the
+ * Phase 1 API contract spike, in this one place.
+ */
+export const GRAPH_API_VERSION = 'v21.0';
+
+const GRAPH_BASE_URL = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+
+export type GraphMethod = 'GET' | 'POST';
+
+export interface MetaGraphParams {
+  method?: GraphMethod;
+  /** Query params (GET) or form body fields (POST). NEVER include `access_token` here. */
+  params?: Record<string, string | number | boolean | undefined>;
+  token: string;
+  /** The property this call is being made for — logging/audit only, never used to pick the token. */
+  propertyId?: string;
+}
+
+export interface GraphSuccess<T> {
+  ok: true;
+  data: T;
+}
+
+export interface GraphFailure {
+  ok: false;
+  error: string;
+  status?: number;
+}
+
+export type GraphResult<T> = GraphSuccess<T> | GraphFailure;
+
+/**
+ * Low-level Graph API call. `path` is the node/edge, e.g. `act_123/campaigns`
+ * or a bare object id like `120210000000001`. The token ALWAYS travels in the
+ * `Authorization` header — never appended to the URL — regardless of method
+ * (Fable M5). Never throws: network/parse errors and non-OK HTTP responses
+ * both resolve to `{ ok: false, error }`.
+ */
+export async function metaGraph<T = Record<string, unknown>>(
+  path: string,
+  opts: MetaGraphParams
+): Promise<GraphResult<T>> {
+  const method = opts.method ?? 'GET';
+  const cleanPath = path.replace(/^\/+/, '');
+  const url = new URL(`${GRAPH_BASE_URL}/${cleanPath}`);
+
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(opts.params ?? {})) {
+    if (value === undefined) continue;
+    fields[key] = String(value);
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${opts.token}`,
+  };
+  const init: RequestInit = { method, headers };
+
+  if (method === 'GET') {
+    for (const [key, value] of Object.entries(fields)) url.searchParams.set(key, value);
+  } else {
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    init.body = new URLSearchParams(fields).toString();
+  }
+
+  try {
+    const response = await fetch(url.toString(), init);
+    if (!response.ok) {
+      const text = await response.text();
+      logger.warn('metaGraph: non-OK response', {
+        path: cleanPath,
+        method,
+        status: response.status,
+        propertyId: opts.propertyId,
+        body: text,
+      });
+      return { ok: false, error: text, status: response.status };
+    }
+    const data = (await response.json()) as T;
+    return { ok: true, data };
+  } catch (error) {
+    logger.warn('metaGraph: fetch error', {
+      path: cleanPath,
+      method,
+      propertyId: opts.propertyId,
+      error: String(error),
+    });
+    return { ok: false, error: String(error) };
+  }
+}
+
+/**
+ * Create a resource under an ad account (e.g. a campaign/ad set/ad/creative,
+ * addressed as an edge name like `campaigns`). This is THE enforcement point
+ * for PAUSED-by-default (Fable C2): `status: 'PAUSED'` is spread into the
+ * outgoing payload LAST, so any `status` the caller supplied is overwritten,
+ * not merely defaulted. Every other module MUST create Meta resources through
+ * this helper — never call `metaGraph()` directly for a create — so there is
+ * exactly one place a future change could accidentally let a live ad through.
+ */
+export async function createResource<T = Record<string, unknown>>(
+  node: string,
+  adAccountId: string,
+  token: string,
+  payload: Record<string, string | number | boolean | undefined>,
+  propertyId?: string
+): Promise<GraphResult<T>> {
+  const enforcedPayload = {
+    ...payload,
+    status: 'PAUSED', // enforced HERE, unconditionally — not a caller convention (C2)
+  };
+  return metaGraph<T>(`${adAccountId}/${node}`, {
+    method: 'POST',
+    params: enforcedPayload,
+    token,
+    propertyId,
+  });
+}
+
+/**
+ * Pause an existing resource by id (campaign/ad set/ad) — the STOP primitive
+ * (Fable C1: build the stop side before/with the start side). Safe to call
+ * repeatedly; pausing an already-paused resource is idempotent on Meta's side.
+ */
+export async function pauseResource(
+  id: string,
+  token: string,
+  propertyId?: string
+): Promise<GraphResult<{ success: boolean }>> {
+  return metaGraph<{ success: boolean }>(id, {
+    method: 'POST',
+    params: { status: 'PAUSED' },
+    token,
+    propertyId,
+  });
+}
+
+/**
+ * Un-pause (activate) an existing resource by id. This is the ONLY helper in
+ * this client that can set a non-PAUSED status, which is why it must only ever
+ * be reached through `adExecutionGateway.activateCampaign` — after the
+ * dry-run/approval/spend-cap/ownership checks, never called directly by
+ * feature code.
+ */
+export async function activateResource(
+  id: string,
+  token: string,
+  propertyId?: string
+): Promise<GraphResult<{ success: boolean }>> {
+  return metaGraph<{ success: boolean }>(id, {
+    method: 'POST',
+    params: { status: 'ACTIVE' },
+    token,
+    propertyId,
+  });
+}

--- a/src/services/growth/metaAds/lifecycle.ts
+++ b/src/services/growth/metaAds/lifecycle.ts
@@ -1,0 +1,90 @@
+/**
+ * The STOP side of the ads engine — built and tested BEFORE the start side
+ * (plan §9 Phase 0, §13 Fable C1: "The plan defined how spend *starts*, not
+ * how it *stops* — and real ad-ops incidents are about failing to stop").
+ *
+ * `pauseCampaign` pauses one campaign; `pauseAllForProperty` is the panic
+ * button — list every non-paused campaign in the property's ad account and
+ * pause each one. Both resolve the property's ad context first and no-op
+ * (nothing to pause, no context to act through) for an unconfigured property
+ * — never a blind "pause everything reachable by this token," which would
+ * violate per-property isolation just as much as an uncontrolled activate
+ * would (H2).
+ */
+import { loggers } from '@/lib/logger';
+import { resolveAdContext } from './adContext';
+import { metaGraph, pauseResource } from './client';
+
+const logger = loggers.ads;
+
+export interface PauseResult {
+  success: boolean;
+  campaignId: string;
+  error?: string;
+}
+
+/** Pause a single Meta campaign for a property. No-op if the property has no ad context. */
+export async function pauseCampaign(propertyId: string, metaCampaignId: string): Promise<PauseResult> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('pauseCampaign: no ad context for property — no-op', { propertyId, metaCampaignId });
+    return { success: false, campaignId: metaCampaignId, error: 'no-ad-context' };
+  }
+
+  const result = await pauseResource(metaCampaignId, ctx.token, propertyId);
+  if (!result.ok) {
+    logger.warn('pauseCampaign failed', { propertyId, metaCampaignId, error: result.error });
+    return { success: false, campaignId: metaCampaignId, error: result.error };
+  }
+  logger.info('pauseCampaign: paused', { propertyId, metaCampaignId });
+  return { success: true, campaignId: metaCampaignId };
+}
+
+interface MetaCampaignListItem {
+  id: string;
+  status?: string;
+  effective_status?: string;
+}
+
+interface MetaCampaignListResponse {
+  data: MetaCampaignListItem[];
+}
+
+/**
+ * The panic button: list every non-paused campaign in the property's ad
+ * account and pause each one. No-op (empty list) for an unconfigured
+ * property. Best-effort per campaign — one failure doesn't stop the rest from
+ * being attempted, since the whole point is to stop as much spend as possible.
+ */
+export async function pauseAllForProperty(propertyId: string): Promise<PauseResult[]> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('pauseAllForProperty: no ad context for property — no-op', { propertyId });
+    return [];
+  }
+
+  const list = await metaGraph<MetaCampaignListResponse>(`${ctx.adAccountId}/campaigns`, {
+    method: 'GET',
+    params: { fields: 'id,status,effective_status', limit: 500 },
+    token: ctx.token,
+    propertyId,
+  });
+
+  if (!list.ok) {
+    logger.warn('pauseAllForProperty: failed to list campaigns', { propertyId, error: list.error });
+    return [];
+  }
+
+  const nonPaused = (list.data.data ?? []).filter((c) => c.status !== 'PAUSED');
+  const results: PauseResult[] = [];
+  for (const campaign of nonPaused) {
+    const r = await pauseResource(campaign.id, ctx.token, propertyId);
+    results.push(
+      r.ok
+        ? { success: true, campaignId: campaign.id }
+        : { success: false, campaignId: campaign.id, error: r.error }
+    );
+  }
+  logger.info('pauseAllForProperty: done', { propertyId, paused: results.filter((r) => r.success).length, total: results.length });
+  return results;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,6 +93,14 @@ export interface Property {
     enabled: boolean;
     googleAnalyticsId?: string;
     metaPixelId?: string; // Meta (Facebook/Instagram) Pixel / dataset id — per property
+    // Growth Ad Engine (Phase 0) — per-property Meta Ads config. Agency-shaped:
+    // metaTokenRef is a key into the META_ADS_TOKENS secret map, NOT the token
+    // itself, and may be shared across properties under one agency BM. See
+    // src/services/growth/metaAds/adContext.ts.
+    metaAdAccountId?: string;       // "act_<id>"
+    metaPageId?: string;            // Facebook Page id (ads publish AS a Page)
+    metaInstagramActorId?: string;  // IG actor id, for IG placements
+    metaTokenRef?: string;          // key into META_ADS_TOKENS
   };
   customDomain?: string | null;
   useCustomDomain?: boolean;
@@ -413,6 +421,63 @@ export interface Campaign {
   createdAt?: SerializableTimestamp;
   updatedAt?: SerializableTimestamp;
   sentAt?: SerializableTimestamp | null;
+}
+
+/**
+ * Growth Ad Engine (Meta Ads) — `adCampaigns` collection doc status. Every
+ * Meta-side create lands PAUSED regardless of this status (see
+ * src/services/growth/metaAds/client.ts); this is OUR operator-approval state
+ * machine that `adExecutionGateway.activateCampaign` gates on before it will
+ * ever un-pause the Meta campaign (plan §13 H5).
+ */
+export type AdCampaignStatus =
+  | 'draft'
+  | 'pending_approval'
+  | 'approved'
+  | 'active'
+  | 'paused'
+  | 'failed';
+
+/**
+ * `adCampaigns` collection doc — Growth Ad Engine (Meta) campaign tracking
+ * (plan §4). Money fields are in Meta's MINOR UNITS (bani for RON) — always
+ * suffixed `Minor` to make the unit explicit and impossible to confuse with a
+ * major-unit RON amount (plan §13 M3). Phase 0 only depends on `propertyId`,
+ * `metaCampaignId`, `status`, and `spendCapMinor` (what `adExecutionGateway`
+ * gates activation on); the remaining fields land with Phase 2 campaign
+ * creation but are declared now so the shape is stable.
+ */
+export interface AdCampaign {
+  id: string;
+  propertyId: string;
+  segmentId?: string;
+  metaCampaignId?: string;
+  metaAdSetIds?: string[];
+  metaAdIds?: string[];
+  audienceRef?: string;
+  objective?: string;              // e.g. 'OUTCOME_SALES'
+  dailyBudgetMinor?: number;       // bani
+  spendCapMinor?: number;          // bani — required (snapshotted) before activation
+  status: AdCampaignStatus;
+  effectiveStatus?: string;        // Meta's effective_status, mirrored by the Phase-2 reconciliation cron
+  creativeRef?: string;
+  approvedBy?: string;
+  approvalSnapshot?: {
+    dailyBudgetMinor?: number;
+    spendCapMinor?: number;
+    creativeRef?: string;
+    at?: SerializableTimestamp;
+  };
+  insights?: {
+    spend: number;
+    impressions: number;
+    clicks: number;
+    bookings?: number;
+    roas?: number;
+  };
+  lastSyncedAt?: SerializableTimestamp;
+  createdAt?: SerializableTimestamp;
+  updatedAt?: SerializableTimestamp;
 }
 
 export interface Inquiry {


### PR DESCRIPTION
Money-path safety scaffolding (Sonnet-built, Opus money-path-reviewed). Per-property `resolveAdContext`, the Graph client that **forces PAUSED** + keeps the token in the Bearer header, `pauseCampaign`/`pauseAllForProperty` (stop-side first), and `adExecutionGateway.activateCampaign` (two-switch dry-run gate + approval + spend-cap + **ownership assert** — the account_id format was empirically verified against the live account). No live Meta calls, no spend, fully dark behind `GROWTH_ADS_ENABLED`+`GROWTH_ADS_MODE`. 38 tests, build green. Includes ad-engine plan + verified contract-spike docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)