### PR TITLE
feat: Meta ad create chain + insights (Phase 1, dark-launched)

### DIFF
--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -163,3 +163,41 @@ Ran the full OUTCOME_SALES chain against `act_543311232953437` PAUSED, then dele
 - ❌ **Creative creation REQUIRES the app to be in LIVE (public) mode.** With the "rentalspot" app in Development, `/adcreatives` → "Ads creative post was created by an app that is in development mode. It must be in public to create this ad." **OWNER ACTION: publish the app (Development → Live).** (Correction: unpublished is fine for token/campaign/adset ops, but NOT for creating ad creatives, which publish as the Page.)
 - Complex params (`promoted_object`, `targeting`, `object_story_spec`, `special_ad_categories`) go as **JSON strings** in the form body (confirms the Phase-0 client needs JSON.stringify for non-primitives).
 - All PAUSED test objects deleted cleanly (`{"success":true}`).
+
+### 9c. Phase-1 contract VERIFIED end-to-end (app Live, 10 Jul 2026)
+After publishing the "rentalspot" app (Development → Live), the full chain was
+created PAUSED and deleted cleanly — zero spend. `effective_status: IN_PROCESS`
+= accepted into review but PAUSED, cannot spend. **Also verified:** `/adcreatives`
+**accepts (ignores) `status=PAUSED`**, so the PAUSED-enforcing `createResource()`
+is safe to use uniformly for all four object types — the single enforcement
+point holds, no bypass for creatives.
+
+Exact accepted payloads (all against `act_543311232953437`, Graph **v25.0**,
+token in `Authorization: Bearer` header; complex fields as JSON strings):
+
+**Campaign** — POST `act_<id>/campaigns`
+```
+name, objective=OUTCOME_SALES, special_ad_categories=[], status=PAUSED,
+is_adset_budget_sharing_enabled=false
+```
+**Ad Set** — POST `act_<id>/adsets`
+```
+name, campaign_id, billing_event=IMPRESSIONS, optimization_goal=OFFSITE_CONVERSIONS,
+promoted_object={pixel_id, custom_event_type:"PURCHASE"},
+daily_budget=<bani>, conversion_domain=<eTLD+1 of landing page>,
+targeting={geo_locations:{countries:[...]}}, bid_strategy=LOWEST_COST_WITHOUT_CAP,
+status=PAUSED
+```
+**Creative** — POST `act_<id>/adcreatives`
+```
+name, object_story_spec={page_id, link_data:{link (with utm_*), message,
+image_hash, call_to_action:{type:"LEARN_MORE"}}}
+```
+**Ad** — POST `act_<id>/ads`
+```
+name, adset_id, creative={creative_id}, status=PAUSED
+```
+Notes: budgets in **bani** (minor units); Meta auto-adds `smart_pse_enabled:false`
+to `promoted_object`; `conversion_domain` must match the landing page's registrable
+domain (prahova-chalet.ro). Insights read-back for ROAS still to be exercised in
+the create functions, not the spike.

--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -154,3 +154,12 @@ The **`link`** field is where the `?utm_source=facebook&utm_campaign=<adCampaign
 **STILL UNVERIFIED (no account precedent — verify at first PAUSED create):** `OUTCOME_SALES` needs ad-set `optimization_goal:OFFSITE_CONVERSIONS` + `promoted_object:{pixel_id, custom_event_type:PURCHASE}`. The account's history is all LINK_CLICKS/OUTCOME_TRAFFIC/MESSAGES — no conversion campaigns yet.
 
 **API version:** calls used v21 but Meta's paging responses returned **v25.0** URLs → v25 is current; use a current `GRAPH_API_VERSION` constant (existing code hardcodes v21, expiring ~late 2026 — consolidate, Fable L2).
+
+### 9b. Phase-1 create-contract spike (live PAUSED create+delete, 9 Jul 2026)
+Ran the full OUTCOME_SALES chain against `act_543311232953437` PAUSED, then deleted. Findings:
+
+- **Campaign (OUTCOME_SALES) requires `is_adset_budget_sharing_enabled` = `true|false`** when NOT using campaign-level budget (ad-set budgets). Omitting it → error 100/4834011 "Must specify True or False in is_adset_budget_sharing_enabled". Pass `false`.
+- ✅ **Conversion optimization VERIFIED WORKING:** ad set with `optimization_goal=OFFSITE_CONVERSIONS`, `billing_event=IMPRESSIONS`, `promoted_object={pixel_id, custom_event_type:PURCHASE}`, `conversion_domain=prahova-chalet.ro`, `bid_strategy=LOWEST_COST_WITHOUT_CAP`, `daily_budget=5000` (50 RON) — accepted. This was the big open question (no account precedent). Resolved.
+- ❌ **Creative creation REQUIRES the app to be in LIVE (public) mode.** With the "rentalspot" app in Development, `/adcreatives` → "Ads creative post was created by an app that is in development mode. It must be in public to create this ad." **OWNER ACTION: publish the app (Development → Live).** (Correction: unpublished is fine for token/campaign/adset ops, but NOT for creating ad creatives, which publish as the Page.)
+- Complex params (`promoted_object`, `targeting`, `object_story_spec`, `special_ad_categories`) go as **JSON strings** in the form body (confirms the Phase-0 client needs JSON.stringify for non-primitives).
+- All PAUSED test objects deleted cleanly (`{"success":true}`).

--- a/scripts/growth-validate-ad-chain.ts
+++ b/scripts/growth-validate-ad-chain.ts
@@ -1,0 +1,101 @@
+/**
+ * Growth Ad Engine — Phase 1 LIVE validation of createCampaignChain against the
+ * real Meta account. Creates the full OUTCOME_SALES chain PAUSED (zero spend),
+ * reads back to confirm the un-activatable invariant + insights, then DELETES
+ * all four Meta objects AND the adCampaigns Firestore doc. Self-cleaning.
+ *
+ * GROWTH_ADS_MODE is deliberately NOT set to live — creation is zero-spend;
+ * activation stays gated behind adExecutionGateway. The money-scoped ads token
+ * is pulled from Secret Manager at runtime, never passed on the command line.
+ *
+ * Usage: npx tsx scripts/growth-validate-ad-chain.ts
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+// Enable the master switch for THIS PROCESS only (createCampaignChain gates on
+// it). Fetch the ads token map from Secret Manager into the env so
+// resolveAdContext can find it — keeps the token out of argv/transcript.
+process.env.GROWTH_ADS_ENABLED = 'true';
+process.env.META_ADS_TOKENS = execSync(
+  'gcloud secrets versions access latest --secret=META_ADS_TOKENS --project=rentalspot-fzwom',
+  { encoding: 'utf8' }
+).trim();
+
+import { createCampaignChain } from '@/services/growth/metaAds/campaignBuilder';
+import { getInsights } from '@/services/growth/metaAds/insights';
+import { deleteResource } from '@/services/growth/metaAds/client';
+import { resolveAdContext } from '@/services/growth/metaAds/adContext';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const P = 'prahova-mountain-chalet';
+// An image already uploaded to this ad account's library (from the contract spike).
+const IMAGE_HASH = '54daa820bdde391fae64bd2d4b62b4fb';
+
+(async () => {
+  console.log('=== Phase 1 LIVE ad-chain validation (real account, PAUSED, self-cleaning) ===\n');
+
+  const spec = {
+    campaign: { name: 'VALIDATION_delete_me — Phase1 chain' },
+    adSet: {
+      name: 'VALIDATION_delete_me — adset',
+      dailyBudgetMinor: 5000, // 50 RON/day — PAUSED, never spends
+      landingUrl: 'https://prahova-chalet.ro/',
+      targeting: { geo_locations: { countries: ['RO'] } },
+    },
+    creative: {
+      name: 'VALIDATION_delete_me — creative',
+      link: 'https://prahova-chalet.ro/?utm_source=facebook&utm_medium=paid&utm_campaign=validation',
+      message: 'Validation creative — safe to delete.',
+      imageHash: IMAGE_HASH,
+    },
+    ad: { name: 'VALIDATION_delete_me — ad' },
+  };
+
+  const res = await createCampaignChain(P, spec);
+  console.log('createCampaignChain result:', JSON.stringify(res, null, 2));
+  if (!res.ok) {
+    console.error(`\nFAILED at stage "${res.stage}": ${res.error}`);
+    process.exit(1);
+  }
+
+  // Insights on the campaign — should be all-zeros (PAUSED, never delivered).
+  const insights = await getInsights(P, res.campaignId);
+  console.log('\ngetInsights (expect all-zeros):', JSON.stringify(insights, null, 2));
+
+  // Confirm the Firestore doc is un-activatable: draft + NO spend cap.
+  const db = await getAdminDb();
+  const doc = (await db.collection('adCampaigns').doc(res.adCampaignId).get()).data();
+  console.log('\nadCampaigns doc invariant check:', JSON.stringify({
+    status: doc?.status,
+    spendCapMinor: doc?.spendCapMinor ?? '(unset — correct, blocks activation)',
+    metaCampaignId: doc?.metaCampaignId,
+  }, null, 2));
+  const invariantOk = doc?.status === 'draft' && (doc?.spendCapMinor === undefined || doc?.spendCapMinor === null);
+  console.log(invariantOk ? '  ✅ un-activatable invariant holds' : '  ❌ INVARIANT VIOLATED');
+
+  // === CLEANUP === delete most-dependent first, then the Firestore doc.
+  console.log('\n=== CLEANUP ===');
+  const ctx = await resolveAdContext(P);
+  const token = ctx!.token;
+  const targets: Array<[string, string]> = [
+    ['ad', res.adId],
+    ['creative', res.creativeId],
+    ['adSet', res.adSetId],
+    ['campaign', res.campaignId],
+  ];
+  for (const [kind, id] of targets) {
+    const del = await deleteResource(id, token, P);
+    console.log(`  del ${kind} ${id}: ${del.ok ? 'ok' : 'FAILED — ' + del.error}`);
+  }
+  await db.collection('adCampaigns').doc(res.adCampaignId).delete();
+  console.log(`  del adCampaigns doc ${res.adCampaignId}: ok`);
+
+  console.log('\n✅ Live validation complete — chain created PAUSED, verified, fully cleaned up. Zero spend.');
+  process.exit(0);
+})().catch((e) => {
+  console.error('FAILED:', e);
+  process.exit(1);
+});

--- a/src/services/growth/metaAds/__tests__/campaignBuilder.test.ts
+++ b/src/services/growth/metaAds/__tests__/campaignBuilder.test.ts
@@ -1,0 +1,297 @@
+/** @jest-environment node */
+
+// Mock resolution/config/Firestore layers; use the REAL client.ts (createResource
+// / deleteResource / metaGraph) against a mocked global.fetch, so the PAUSED
+// enforcement and exact payload shape are exercised end-to-end, not assumed.
+jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
+jest.mock('@/lib/meta-pixels', () => ({ getPixelIdForProperty: jest.fn() }));
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
+}));
+
+import { createCampaignChain } from '../campaignBuilder';
+import { resolveAdContext } from '../adContext';
+import { getPixelIdForProperty } from '@/lib/meta-pixels';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockGetPixelIdForProperty = getPixelIdForProperty as jest.Mock;
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockFetch = global.fetch as jest.Mock;
+
+const PROPERTY = 'prahova-mountain-chalet';
+const AD_ACCOUNT = 'act_543311232953437';
+const PAGE_ID = '107610677616243';
+
+/** Last path segment of a Graph API URL — 'campaigns' | 'adsets' | 'adcreatives' | 'ads' | a bare resource id (DELETE). */
+function nodeFromUrl(urlStr: string): string {
+  const parts = new URL(urlStr).pathname.split('/').filter(Boolean);
+  return parts[parts.length - 1];
+}
+
+function findCall(node: string): [string, RequestInit] {
+  const call = mockFetch.mock.calls.find(([u]: [string, RequestInit]) => nodeFromUrl(String(u)) === node);
+  if (!call) throw new Error(`no fetch call found for node: ${node}`);
+  return call as [string, RequestInit];
+}
+
+function findDeleteCalls(): [string, RequestInit][] {
+  return mockFetch.mock.calls.filter(
+    ([, init]: [string, RequestInit]) => init?.method === 'DELETE'
+  ) as [string, RequestInit][];
+}
+
+/** Wires mocked fetch to return a distinct id per Graph edge, and success for any DELETE. */
+function mockMetaResponses() {
+  mockFetch.mockImplementation(async (url: string, init: RequestInit) => {
+    if ((init?.method ?? 'GET') === 'DELETE') {
+      return { ok: true, json: async () => ({ success: true }) };
+    }
+    const node = nodeFromUrl(String(url));
+    if (node === 'campaigns') return { ok: true, json: async () => ({ id: 'meta-campaign-1' }) };
+    if (node === 'adsets') return { ok: true, json: async () => ({ id: 'meta-adset-1' }) };
+    if (node === 'adcreatives') return { ok: true, json: async () => ({ id: 'meta-creative-1' }) };
+    if (node === 'ads') return { ok: true, json: async () => ({ id: 'meta-ad-1' }) };
+    return { ok: false, status: 404, text: async () => `unexpected node in test: ${node}` };
+  });
+}
+
+function makeAdminDb() {
+  const addMock = jest.fn().mockResolvedValue({ id: 'adcamp-doc-1' });
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name === 'adCampaigns') return { add: addMock };
+      throw new Error(`unexpected collection read in test: ${name}`);
+    }),
+  };
+  return { db, addMock };
+}
+
+const CHAIN_SPEC = {
+  campaign: { name: 'Test Campaign' },
+  adSet: {
+    name: 'Test Ad Set',
+    dailyBudgetMinor: 5000, // 50 RON
+    landingUrl: 'https://www.prahova-chalet.ro/book',
+    targeting: { geo_locations: { countries: ['RO'] } },
+  },
+  creative: {
+    name: 'Test Creative',
+    link: 'https://prahova-chalet.ro/book?utm_source=facebook&utm_campaign=abc',
+    message: 'Book your stay',
+    imageHash: 'abc123hash',
+  },
+  ad: { name: 'Test Ad' },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetch.mockReset();
+  delete process.env.GROWTH_ADS_ENABLED;
+});
+
+describe('createCampaignChain — dark-launch gate (master switch OFF by default)', () => {
+  it('returns ads-engine-disabled and makes ZERO Meta calls / writes nothing to Firestore', async () => {
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+    expect(res).toEqual({ ok: false, error: 'ads-engine-disabled', stage: 'gate' });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockResolveAdContext).not.toHaveBeenCalled();
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+  });
+});
+
+describe('createCampaignChain — engine enabled', () => {
+  beforeEach(() => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, pageId: PAGE_ID, token: 'tok' });
+    mockGetPixelIdForProperty.mockResolvedValue('pixel-123');
+    mockMetaResponses();
+  });
+
+  it('happy path: creates all four objects via createResource (PAUSED enforced), writes an adCampaigns doc, returns all ids', async () => {
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+
+    expect(res).toEqual({
+      ok: true,
+      campaignId: 'meta-campaign-1',
+      adSetId: 'meta-adset-1',
+      creativeId: 'meta-creative-1',
+      adId: 'meta-ad-1',
+      adCampaignId: 'adcamp-doc-1',
+    });
+
+    // exactly 4 creates, 0 rollback deletes
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(findDeleteCalls()).toHaveLength(0);
+
+    // --- campaign payload ---
+    const [campaignUrl, campaignInit] = findCall('campaigns');
+    expect(String(campaignUrl)).toContain(`${AD_ACCOUNT}/campaigns`);
+    expect(campaignInit.method).toBe('POST');
+    const campaignBody = new URLSearchParams(campaignInit.body as string);
+    expect(campaignBody.get('status')).toBe('PAUSED'); // createResource enforcement (Fable C2)
+    expect(campaignBody.get('name')).toBe('Test Campaign');
+    expect(campaignBody.get('objective')).toBe('OUTCOME_SALES');
+    expect(JSON.parse(campaignBody.get('special_ad_categories') as string)).toEqual([]);
+    expect(campaignBody.get('is_adset_budget_sharing_enabled')).toBe('false');
+
+    // --- ad set payload ---
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    expect(adSetBody.get('status')).toBe('PAUSED');
+    expect(adSetBody.get('campaign_id')).toBe('meta-campaign-1');
+    expect(adSetBody.get('billing_event')).toBe('IMPRESSIONS');
+    expect(adSetBody.get('optimization_goal')).toBe('OFFSITE_CONVERSIONS');
+    expect(adSetBody.get('bid_strategy')).toBe('LOWEST_COST_WITHOUT_CAP');
+    expect(adSetBody.get('daily_budget')).toBe('5000');
+    expect(adSetBody.get('conversion_domain')).toBe('prahova-chalet.ro'); // leading www. stripped
+    expect(JSON.parse(adSetBody.get('promoted_object') as string)).toEqual({
+      pixel_id: 'pixel-123',
+      custom_event_type: 'PURCHASE',
+    });
+
+    // --- creative payload ---
+    const [, creativeInit] = findCall('adcreatives');
+    const creativeBody = new URLSearchParams(creativeInit.body as string);
+    expect(creativeBody.get('status')).toBe('PAUSED');
+    expect(JSON.parse(creativeBody.get('object_story_spec') as string)).toEqual({
+      page_id: PAGE_ID,
+      link_data: {
+        link: CHAIN_SPEC.creative.link,
+        message: CHAIN_SPEC.creative.message,
+        image_hash: 'abc123hash',
+        call_to_action: { type: 'LEARN_MORE' },
+      },
+    });
+
+    // --- ad payload ---
+    const [, adInit] = findCall('ads');
+    const adBody = new URLSearchParams(adInit.body as string);
+    expect(adBody.get('status')).toBe('PAUSED');
+    expect(adBody.get('adset_id')).toBe('meta-adset-1');
+    expect(JSON.parse(adBody.get('creative') as string)).toEqual({ creative_id: 'meta-creative-1' });
+
+    // --- Firestore doc ---
+    expect(addMock).toHaveBeenCalledTimes(1);
+    const doc = addMock.mock.calls[0][0];
+    expect(doc).toMatchObject({
+      propertyId: PROPERTY,
+      metaCampaignId: 'meta-campaign-1',
+      metaAdSetIds: ['meta-adset-1'],
+      metaAdIds: ['meta-ad-1'],
+      objective: 'OUTCOME_SALES',
+      dailyBudgetMinor: 5000,
+      creativeRef: 'meta-creative-1',
+      status: 'draft',
+    });
+    // CRITICAL invariant: never activatable straight out of creation.
+    expect(doc).not.toHaveProperty('spendCapMinor');
+    expect(doc.status).not.toBe('approved');
+  });
+
+  it('pixel missing → adSet stage fails with no-pixel, rolls back the campaign', async () => {
+    mockGetPixelIdForProperty.mockResolvedValue(undefined);
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+    expect(res).toEqual({ ok: false, error: 'no-pixel', stage: 'adSet' });
+
+    // campaign create + campaign delete only
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const deletes = findDeleteCalls();
+    expect(deletes).toHaveLength(1);
+    expect(String(deletes[0][0])).toContain('meta-campaign-1');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('malformed landingUrl → adSet stage fails with invalid-landing-url (no throw), rolls back the campaign', async () => {
+    // A scheme-less URL makes new URL() throw; the guard must convert that into
+    // a clean {ok:false} so the throw never escapes and the campaign is rolled back.
+    const badSpec = {
+      ...CHAIN_SPEC,
+      adSet: { ...CHAIN_SPEC.adSet, landingUrl: 'prahova-chalet.ro/book' },
+    };
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, badSpec);
+    expect(res).toEqual({ ok: false, error: 'invalid-landing-url', stage: 'adSet' });
+
+    // campaign created, then adSet create SHORT-CIRCUITS before any Meta call,
+    // so only the campaign create + its rollback delete hit fetch.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const deletes = findDeleteCalls();
+    expect(deletes).toHaveLength(1);
+    expect(String(deletes[0][0])).toContain('meta-campaign-1');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('page missing → creative stage fails with no-page, rolls back adSet then campaign (reverse order)', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' }); // no pageId
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+    expect(res).toEqual({ ok: false, error: 'no-page', stage: 'creative' });
+
+    // campaign create + adset create + 2 rollback deletes
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    const deletes = findDeleteCalls();
+    expect(deletes).toHaveLength(2);
+    expect(String(deletes[0][0])).toContain('meta-adset-1'); // most-dependent-first
+    expect(String(deletes[1][0])).toContain('meta-campaign-1');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('no ad context → fails at the context stage before any Meta call', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+    expect(res).toEqual({ ok: false, error: 'no-ad-context', stage: 'context' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('ad stage failure rolls back creative, adSet, and campaign (reverse order)', async () => {
+    mockFetch.mockImplementation(async (url: string, init: RequestInit) => {
+      if ((init?.method ?? 'GET') === 'DELETE') return { ok: true, json: async () => ({ success: true }) };
+      const node = nodeFromUrl(String(url));
+      if (node === 'campaigns') return { ok: true, json: async () => ({ id: 'meta-campaign-1' }) };
+      if (node === 'adsets') return { ok: true, json: async () => ({ id: 'meta-adset-1' }) };
+      if (node === 'adcreatives') return { ok: true, json: async () => ({ id: 'meta-creative-1' }) };
+      if (node === 'ads') return { ok: false, status: 400, text: async () => 'ad creation rejected' };
+      return { ok: false, status: 404, text: async () => `unexpected node: ${node}` };
+    });
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.stage).toBe('ad');
+
+    const deletes = findDeleteCalls();
+    expect(deletes).toHaveLength(3);
+    expect(String(deletes[0][0])).toContain('meta-creative-1');
+    expect(String(deletes[1][0])).toContain('meta-adset-1');
+    expect(String(deletes[2][0])).toContain('meta-campaign-1');
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('Firestore write failure rolls back the full chain (ad, creative, adSet, campaign)', async () => {
+    mockGetAdminDb.mockRejectedValue(new Error('firestore unavailable'));
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.stage).toBe('firestore');
+
+    const deletes = findDeleteCalls();
+    expect(deletes).toHaveLength(4);
+    expect(String(deletes[0][0])).toContain('meta-ad-1');
+    expect(String(deletes[1][0])).toContain('meta-creative-1');
+    expect(String(deletes[2][0])).toContain('meta-adset-1');
+    expect(String(deletes[3][0])).toContain('meta-campaign-1');
+  });
+});

--- a/src/services/growth/metaAds/__tests__/client.test.ts
+++ b/src/services/growth/metaAds/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { metaGraph, createResource, pauseResource, activateResource, GRAPH_API_VERSION } from '../client';
+import { metaGraph, createResource, pauseResource, activateResource, deleteResource, GRAPH_API_VERSION } from '../client';
 
 const mockFetch = global.fetch as jest.Mock;
 
@@ -106,5 +106,25 @@ describe('pauseResource / activateResource — status transitions', () => {
     expect(String(url)).toContain('120210000000001');
     const body = new URLSearchParams(init.body as string);
     expect(body.get('status')).toBe('ACTIVE');
+  });
+});
+
+describe('deleteResource — rollback primitive', () => {
+  it('sends a DELETE to the resource id, token in header not URL', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    await deleteResource('120210000000001', 'SECRET-TOKEN', 'prahova-mountain-chalet');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain('120210000000001');
+    expect(init.method).toBe('DELETE');
+    expect(String(url)).not.toContain('SECRET-TOKEN');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer SECRET-TOKEN');
+  });
+
+  it('returns a typed {ok:false,error} on failure, never throws', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, text: async () => '{"error":"cannot delete"}' });
+    const result = await deleteResource('120210000000001', 'tok');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('cannot delete');
   });
 });

--- a/src/services/growth/metaAds/__tests__/insights.test.ts
+++ b/src/services/growth/metaAds/__tests__/insights.test.ts
@@ -1,0 +1,173 @@
+/** @jest-environment node */
+
+jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
+jest.mock('../client', () => ({ metaGraph: jest.fn() }));
+
+import { getInsights } from '../insights';
+import { resolveAdContext } from '../adContext';
+import { metaGraph } from '../client';
+
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockMetaGraph = metaGraph as jest.Mock;
+
+const PROPERTY = 'prahova-mountain-chalet';
+const OBJECT_ID = 'meta-campaign-1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getInsights — no ad context (unconfigured property)', () => {
+  it('returns {ok:false,error:"no-ad-context"} without calling Meta', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({ ok: false, error: 'no-ad-context' });
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+  });
+});
+
+describe('getInsights — request shape', () => {
+  beforeEach(() => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+  });
+
+  it('GETs <objectId>/insights with the expected fields and defaults date_preset to "maximum"', async () => {
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { data: [] } });
+    await getInsights(PROPERTY, OBJECT_ID);
+    expect(mockMetaGraph).toHaveBeenCalledWith(`${OBJECT_ID}/insights`, {
+      method: 'GET',
+      params: {
+        fields: 'spend,impressions,clicks,actions,action_values,purchase_roas',
+        date_preset: 'maximum',
+      },
+      token: 'tok',
+      propertyId: PROPERTY,
+    });
+  });
+
+  it('honors a caller-supplied date_preset override', async () => {
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { data: [] } });
+    await getInsights(PROPERTY, OBJECT_ID, { datePreset: 'last_30d' });
+    const [, opts] = mockMetaGraph.mock.calls[0];
+    expect(opts.params.date_preset).toBe('last_30d');
+  });
+
+  it('propagates a Graph API failure without throwing', async () => {
+    mockMetaGraph.mockResolvedValue({ ok: false, error: 'timeout' });
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({ ok: false, error: 'timeout' });
+  });
+});
+
+describe('getInsights — parsing', () => {
+  beforeEach(() => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+  });
+
+  it('parses spend/impressions/clicks, sums purchases + purchaseValue from actions/action_values, and uses purchase_roas', async () => {
+    mockMetaGraph.mockResolvedValue({
+      ok: true,
+      data: {
+        data: [
+          {
+            spend: '123.45',
+            impressions: '1000',
+            clicks: '50',
+            actions: [
+              { action_type: 'offsite_conversion.fb_pixel_purchase', value: '3' },
+              { action_type: 'link_click', value: '50' }, // non-purchase action, must be ignored
+            ],
+            action_values: [{ action_type: 'offsite_conversion.fb_pixel_purchase', value: '900' }],
+            purchase_roas: [{ value: '7.29' }],
+          },
+        ],
+      },
+    });
+
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({
+      ok: true,
+      data: { spend: 123.45, impressions: 1000, clicks: 50, purchases: 3, purchaseValue: 900, roas: 7.29 },
+    });
+  });
+
+  it('does NOT double-count when both purchase action_types are present — picks the pixel-specific one', async () => {
+    // Meta commonly mirrors the same web conversions under both types; summing
+    // them would double-count. We pick offsite_conversion.fb_pixel_purchase.
+    mockMetaGraph.mockResolvedValue({
+      ok: true,
+      data: {
+        data: [
+          {
+            spend: '100',
+            actions: [
+              { action_type: 'offsite_conversion.fb_pixel_purchase', value: '2' },
+              { action_type: 'purchase', value: '2' },
+            ],
+            action_values: [
+              { action_type: 'offsite_conversion.fb_pixel_purchase', value: '200' },
+              { action_type: 'purchase', value: '200' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.data.purchases).toBe(2); // not 4
+      expect(res.data.purchaseValue).toBe(200); // not 400
+      // no purchase_roas in this fixture → falls back to purchaseValue/spend
+      expect(res.data.roas).toBeCloseTo(2, 5);
+    }
+  });
+
+  it('falls back to the unified "purchase" action_type when the pixel-specific one is absent', async () => {
+    mockMetaGraph.mockResolvedValue({
+      ok: true,
+      data: {
+        data: [
+          {
+            spend: '100',
+            actions: [{ action_type: 'purchase', value: '5' }],
+            action_values: [{ action_type: 'purchase', value: '500' }],
+          },
+        ],
+      },
+    });
+
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.data.purchases).toBe(5);
+      expect(res.data.purchaseValue).toBe(500);
+    }
+  });
+
+  it('falls back to purchaseValue/spend when Meta omits purchase_roas entirely', async () => {
+    mockMetaGraph.mockResolvedValue({
+      ok: true,
+      data: { data: [{ spend: '50', action_values: [{ action_type: 'purchase', value: '150' }] }] },
+    });
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.roas).toBe(3);
+  });
+
+  it('falls back to roas=0 when there is no spend and no purchase_roas (avoids divide-by-zero)', async () => {
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { data: [{ spend: '0' }] } });
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.roas).toBe(0);
+  });
+
+  it('returns all-zero insights when there is no data row yet (object never delivered)', async () => {
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { data: [] } });
+    const res = await getInsights(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({
+      ok: true,
+      data: { spend: 0, impressions: 0, clicks: 0, purchases: 0, purchaseValue: 0, roas: 0 },
+    });
+  });
+});

--- a/src/services/growth/metaAds/campaignBuilder.ts
+++ b/src/services/growth/metaAds/campaignBuilder.ts
@@ -1,0 +1,454 @@
+/**
+ * Ad chain creation — Phase 1 (plan §9 Phase 1; contract verified end-to-end
+ * live and self-deleted, docs/meta-ads-infrastructure-2026.md §9b/§9c).
+ *
+ * Builds the full Meta OUTCOME_SALES chain — campaign → ad set → creative →
+ * ad — one create call per stage, each routed through `createResource()` so
+ * `client.ts`'s single PAUSED-enforcement point applies uniformly (Fable C2;
+ * §9c confirmed even `/adcreatives` accepts/ignores `status=PAUSED`, so there
+ * is no bypass among the four object types). This module NEVER un-pauses
+ * anything — that is `adExecutionGateway.activateCampaign`'s job, gated on
+ * the two-switch live mode + operator approval + a snapshotted spend cap
+ * (H5/M3/M4). Creating PAUSED objects is zero-spend, so `createCampaignChain`
+ * gates creation on the MASTER switch only (`isAdsEngineEnabled`) — NOT on
+ * live mode. Gating creation on live mode too would block the intended
+ * workflow (build it PAUSED → operator reviews it in Ads Manager/admin UI →
+ * approves → gateway activates); the two switches guard DIFFERENT things.
+ *
+ * Rollback: the four Meta objects form a strict dependency chain (ad set
+ * needs `campaign_id`, ad needs `adset_id` + `creative_id`), so a failure at
+ * any stage after the campaign leaves 1-3 already-created PAUSED objects
+ * behind. `createCampaignChain` best-effort deletes everything created so
+ * far, in reverse (most-dependent-first) order, via `deleteResource` — same
+ * "log, never throw" discipline as the rest of this client, because a
+ * cleanup failure must never mask the ORIGINAL creation error being returned
+ * to the caller. PAUSED orphans don't spend, but they are still an ops
+ * hazard (stale noise in Ads Manager, confusing an operator reviewing
+ * pending campaigns), so cleanup is attempted regardless.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + async functions.
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import { isAdsEngineEnabled } from '@/config/growth-ads';
+import { getPixelIdForProperty } from '@/lib/meta-pixels';
+import { resolveAdContext } from './adContext';
+import { createResource, deleteResource, type GraphResult } from './client';
+
+const logger = loggers.ads;
+
+// ---------------------------------------------------------------------------
+// Stage specs
+// ---------------------------------------------------------------------------
+
+export interface CreateCampaignSpec {
+  name: string;
+}
+
+export interface AdSetTargeting {
+  /** Meta `targeting` object shape, e.g. `{ geo_locations: {...}, age_min, age_max }` — passed through as-is (validated shape: docs/meta-ads-infrastructure-2026.md §9). */
+  [key: string]: unknown;
+}
+
+export interface CreateAdSetSpec {
+  name: string;
+  /** Daily budget in bani (minor units) — NEVER major-unit RON (plan §13 M3). */
+  dailyBudgetMinor: number;
+  /** The page the ad ultimately sends traffic to — used ONLY to derive `conversion_domain`; the actual click-through link is set on the creative. */
+  landingUrl: string;
+  targeting: AdSetTargeting;
+}
+
+export interface CreateCreativeSpec {
+  name: string;
+  /** Click-through link — should already carry `?utm_source=facebook&utm_campaign=<adCampaigns.id>` (Fable H1); this module does not append UTMs itself. */
+  link: string;
+  message: string;
+  /** Image hash from `/act_<id>/adimages` — image upload is out of scope for Phase 1; caller supplies it. */
+  imageHash: string;
+  /** Defaults to 'LEARN_MORE', the only CTA verified against the live account (§9c). */
+  callToActionType?: string;
+}
+
+export interface CreateAdSpec {
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Single-stage creators
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a PAUSED campaign. Payload matches the verified contract exactly
+ * (§9c): `objective=OUTCOME_SALES`, `special_ad_categories=[]` (this
+ * account's own history shows `[]` runs fine for direct-booking/travel ads —
+ * Meta does not force HOUSING for vacation rentals), and
+ * `is_adset_budget_sharing_enabled=false` (required when NOT using
+ * campaign-level budgets — we use ad-set-level daily budgets, §9b).
+ */
+export async function createCampaign(
+  propertyId: string,
+  spec: CreateCampaignSpec
+): Promise<GraphResult<{ id: string }>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('createCampaign: no ad context for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  return createResource<{ id: string }>(
+    'campaigns',
+    ctx.adAccountId,
+    ctx.token,
+    {
+      name: spec.name,
+      objective: 'OUTCOME_SALES',
+      special_ad_categories: [],
+      is_adset_budget_sharing_enabled: false,
+    },
+    propertyId
+  );
+}
+
+/**
+ * Derive the registrable domain Meta's `conversion_domain` field expects from
+ * a landing page URL: the hostname with a leading "www." stripped.
+ *
+ * This is an eTLD+1 HEURISTIC, not a correct implementation: it is valid for
+ * the single-level TLDs this system currently onboards properties on (e.g.
+ * "prahova-chalet.ro", "www.prahova-chalet.ro" → both "prahova-chalet.ro").
+ * It is NOT correct for multi-level public-suffix TLDs (e.g. "co.uk") — a
+ * subdomain like "sub.example.co.uk" would incorrectly keep "sub" as part of
+ * the registrable domain. A public-suffix-list lookup (e.g. the `psl`
+ * package) would be required before onboarding a property on such a TLD.
+ *
+ * Returns `undefined` (never throws) on an unparseable `landingUrl` — e.g. a
+ * scheme-less string like "prahova-chalet.ro". `new URL()` throws on those, and
+ * an uncaught throw here would escape `createCampaignChain` and orphan an
+ * already-created campaign with no rollback; the caller turns `undefined` into
+ * a clean `{ok:false}` before any further Meta call instead.
+ */
+function deriveConversionDomain(landingUrl: string): string | undefined {
+  let hostname: string;
+  try {
+    hostname = new URL(landingUrl).hostname;
+  } catch {
+    return undefined;
+  }
+  return hostname.startsWith('www.') ? hostname.slice(4) : hostname;
+}
+
+/**
+ * Create a PAUSED ad set under `campaignId`. Requires the property to have a
+ * configured Meta Pixel (`getPixelIdForProperty` — multi-property config,
+ * never hardcoded); returns `{ok:false,error:'no-pixel'}` without calling
+ * Meta if none is configured, so a mis-onboarded property fails closed
+ * instead of creating an ad set with no conversion tracking. Payload matches
+ * the live-verified OFFSITE_CONVERSIONS/PURCHASE contract (§9b) — this was
+ * the previously-unverified part of the chain and is now confirmed working.
+ */
+export async function createAdSet(
+  propertyId: string,
+  campaignId: string,
+  spec: CreateAdSetSpec
+): Promise<GraphResult<{ id: string }>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('createAdSet: no ad context for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  const pixelId = await getPixelIdForProperty(propertyId);
+  if (!pixelId) {
+    logger.warn('createAdSet: no Meta Pixel configured for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-pixel' };
+  }
+
+  const conversionDomain = deriveConversionDomain(spec.landingUrl);
+  if (!conversionDomain) {
+    logger.warn('createAdSet: landingUrl is not a parseable URL — refusing to create', {
+      propertyId,
+      landingUrl: spec.landingUrl,
+    });
+    return { ok: false, error: 'invalid-landing-url' };
+  }
+
+  return createResource<{ id: string }>(
+    'adsets',
+    ctx.adAccountId,
+    ctx.token,
+    {
+      name: spec.name,
+      campaign_id: campaignId,
+      billing_event: 'IMPRESSIONS',
+      optimization_goal: 'OFFSITE_CONVERSIONS',
+      promoted_object: { pixel_id: pixelId, custom_event_type: 'PURCHASE' },
+      daily_budget: spec.dailyBudgetMinor,
+      conversion_domain: conversionDomain,
+      targeting: spec.targeting,
+      bid_strategy: 'LOWEST_COST_WITHOUT_CAP',
+    },
+    propertyId
+  );
+}
+
+/**
+ * Create a PAUSED ad creative. Requires the property to have a configured
+ * Meta Page (`ctx.pageId` — multi-property config); returns
+ * `{ok:false,error:'no-page'}` without calling Meta if none is configured.
+ * `object_story_spec` shape matches the live-verified contract exactly
+ * (§9c) — `page_id` + `link_data` with `image_hash` (Phase 1 does not upload
+ * images; the caller supplies an already-uploaded hash).
+ */
+export async function createCreative(
+  propertyId: string,
+  spec: CreateCreativeSpec
+): Promise<GraphResult<{ id: string }>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('createCreative: no ad context for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+  if (!ctx.pageId) {
+    logger.warn('createCreative: no Meta Page configured for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-page' };
+  }
+
+  return createResource<{ id: string }>(
+    'adcreatives',
+    ctx.adAccountId,
+    ctx.token,
+    {
+      name: spec.name,
+      object_story_spec: {
+        page_id: ctx.pageId,
+        link_data: {
+          link: spec.link,
+          message: spec.message,
+          image_hash: spec.imageHash,
+          call_to_action: { type: spec.callToActionType ?? 'LEARN_MORE' },
+        },
+      },
+    },
+    propertyId
+  );
+}
+
+/** Create a PAUSED ad under `adSetId`, wired to `creativeId`. Last link in the chain. */
+export async function createAd(
+  propertyId: string,
+  adSetId: string,
+  creativeId: string,
+  spec: CreateAdSpec
+): Promise<GraphResult<{ id: string }>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('createAd: no ad context for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  return createResource<{ id: string }>(
+    'ads',
+    ctx.adAccountId,
+    ctx.token,
+    {
+      name: spec.name,
+      adset_id: adSetId,
+      creative: { creative_id: creativeId },
+    },
+    propertyId
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export interface CreateCampaignChainSpec {
+  campaign: CreateCampaignSpec;
+  adSet: CreateAdSetSpec;
+  creative: CreateCreativeSpec;
+  ad: CreateAdSpec;
+}
+
+export type CreateCampaignChainStage = 'gate' | 'context' | 'campaign' | 'adSet' | 'creative' | 'ad' | 'firestore';
+
+export interface CreateCampaignChainSuccess {
+  ok: true;
+  campaignId: string;
+  adSetId: string;
+  creativeId: string;
+  adId: string;
+  /** Firestore `adCampaigns` doc id — what the approval UI/gateway keys off. */
+  adCampaignId: string;
+}
+
+export interface CreateCampaignChainFailure {
+  ok: false;
+  error: string;
+  /** Which stage failed — lets the caller/UI report precisely, and tells you how far rollback had to reach. */
+  stage: CreateCampaignChainStage;
+}
+
+export type CreateCampaignChainResult = CreateCampaignChainSuccess | CreateCampaignChainFailure;
+
+interface RollbackTarget {
+  kind: 'campaign' | 'adSet' | 'creative' | 'ad';
+  id: string;
+}
+
+/**
+ * Best-effort delete of everything already created before a mid-chain
+ * failure, in the order given by the caller (most-dependent-first). Never
+ * throws — a rollback failure is logged and the loop continues, because the
+ * function's job is "do as much cleanup as possible," not "guarantee full
+ * cleanup." The ORIGINAL creation error is what the caller sees; this is
+ * purely best-effort housekeeping on top of it.
+ */
+async function rollback(propertyId: string, token: string, targets: RollbackTarget[]): Promise<void> {
+  for (const target of targets) {
+    const result = await deleteResource(target.id, token, propertyId);
+    if (result.ok) {
+      logger.info('createCampaignChain: rollback delete succeeded', {
+        propertyId,
+        kind: target.kind,
+        id: target.id,
+      });
+    } else {
+      logger.warn('createCampaignChain: rollback delete failed (best-effort, continuing)', {
+        propertyId,
+        kind: target.kind,
+        id: target.id,
+        error: result.error,
+      });
+    }
+  }
+}
+
+/**
+ * Orchestrate the full chain: gate → context → campaign → ad set → creative
+ * → ad → Firestore record. Order matches the live-verified dependency chain
+ * (§9c). Stops and reports the failing `stage` on the first error; for any
+ * stage after the campaign, best-effort rolls back everything created so far
+ * (reverse order) before returning.
+ *
+ * The Firestore `adCampaigns` doc written on full success is DELIBERATELY
+ * minimal: `status: 'draft'` and NO `spendCapMinor`. Those are set only by a
+ * later human approval step (an admin UI action, not built in Phase 1) —
+ * `adExecutionGateway.activateCampaign` refuses to activate any campaign that
+ * isn't `status === 'approved'` with a positive `spendCapMinor` snapshotted
+ * (H5/M3/M4). Setting either field here would make a freshly-created
+ * campaign activatable straight out of creation, defeating that gate — never
+ * do it, even by convenience/default.
+ */
+export async function createCampaignChain(
+  propertyId: string,
+  spec: CreateCampaignChainSpec
+): Promise<CreateCampaignChainResult> {
+  // (a) master-switch gate — creating PAUSED objects is zero-spend, so this
+  // is the ONLY gate creation needs. Live mode (isAdsLiveAllowed) guards
+  // ACTIVATION, handled entirely by adExecutionGateway — not here.
+  if (!isAdsEngineEnabled()) {
+    logger.info('createCampaignChain: ads engine disabled — no Meta calls made', { propertyId });
+    return { ok: false, error: 'ads-engine-disabled', stage: 'gate' };
+  }
+
+  // (b) resolve context up front — needed both to short-circuit cleanly and
+  // to have a token on hand for rollback deletes without re-resolving later.
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('createCampaignChain: no ad context for property — refusing to create', { propertyId });
+    return { ok: false, error: 'no-ad-context', stage: 'context' };
+  }
+
+  // (c) campaign
+  const campaignRes = await createCampaign(propertyId, spec.campaign);
+  if (!campaignRes.ok) {
+    logger.warn('createCampaignChain: campaign stage failed', { propertyId, error: campaignRes.error });
+    return { ok: false, error: campaignRes.error, stage: 'campaign' };
+  }
+  const campaignId = campaignRes.data.id;
+
+  // (d) ad set
+  const adSetRes = await createAdSet(propertyId, campaignId, spec.adSet);
+  if (!adSetRes.ok) {
+    logger.warn('createCampaignChain: adSet stage failed — rolling back', { propertyId, error: adSetRes.error });
+    await rollback(propertyId, ctx.token, [{ kind: 'campaign', id: campaignId }]);
+    return { ok: false, error: adSetRes.error, stage: 'adSet' };
+  }
+  const adSetId = adSetRes.data.id;
+
+  // (e) creative
+  const creativeRes = await createCreative(propertyId, spec.creative);
+  if (!creativeRes.ok) {
+    logger.warn('createCampaignChain: creative stage failed — rolling back', {
+      propertyId,
+      error: creativeRes.error,
+    });
+    await rollback(propertyId, ctx.token, [
+      { kind: 'adSet', id: adSetId },
+      { kind: 'campaign', id: campaignId },
+    ]);
+    return { ok: false, error: creativeRes.error, stage: 'creative' };
+  }
+  const creativeId = creativeRes.data.id;
+
+  // (f) ad
+  const adRes = await createAd(propertyId, adSetId, creativeId, spec.ad);
+  if (!adRes.ok) {
+    logger.warn('createCampaignChain: ad stage failed — rolling back', { propertyId, error: adRes.error });
+    await rollback(propertyId, ctx.token, [
+      { kind: 'creative', id: creativeId },
+      { kind: 'adSet', id: adSetId },
+      { kind: 'campaign', id: campaignId },
+    ]);
+    return { ok: false, error: adRes.error, stage: 'ad' };
+  }
+  const adId = adRes.data.id;
+
+  // (g) Firestore record — see the function-level doc comment for why
+  // status/spendCapMinor are deliberately NOT set to anything activatable.
+  try {
+    const db = await getAdminDb();
+    const ref = await db.collection('adCampaigns').add({
+      propertyId,
+      metaCampaignId: campaignId,
+      metaAdSetIds: [adSetId],
+      metaAdIds: [adId],
+      objective: 'OUTCOME_SALES',
+      dailyBudgetMinor: spec.adSet.dailyBudgetMinor,
+      creativeRef: creativeId,
+      status: 'draft',
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    logger.info('createCampaignChain: full chain created', {
+      propertyId,
+      campaignId,
+      adSetId,
+      creativeId,
+      adId,
+      adCampaignId: ref.id,
+    });
+
+    return { ok: true, campaignId, adSetId, creativeId, adId, adCampaignId: ref.id };
+  } catch (error) {
+    // The Meta-side chain is valid (PAUSED, zero spend) but unrecorded — an
+    // unrecorded campaign is invisible to the approval workflow and can
+    // never be activated (activateCampaign requires the adCampaigns doc), so
+    // treat it the same as any other mid-chain failure: roll the whole thing
+    // back rather than leave an orphan only discoverable in Ads Manager.
+    logger.warn('createCampaignChain: Firestore write failed — rolling back full chain', {
+      propertyId,
+      error: String(error),
+    });
+    await rollback(propertyId, ctx.token, [
+      { kind: 'ad', id: adId },
+      { kind: 'creative', id: creativeId },
+      { kind: 'adSet', id: adSetId },
+      { kind: 'campaign', id: campaignId },
+    ]);
+    return { ok: false, error: String(error), stage: 'firestore' };
+  }
+}

--- a/src/services/growth/metaAds/client.ts
+++ b/src/services/growth/metaAds/client.ts
@@ -31,22 +31,37 @@ const logger = loggers.ads;
 
 /**
  * Single source of truth for the Marketing API version — do not scatter
- * (plan §9/§13 L2). NOTE: the verified contract spike (docs/meta-ads-
- * infrastructure-2026.md §9) found the live account's paging responses
- * resolving to v25.0; v21.0 is pinned here per explicit Phase-0 spec and is
- * still valid today, but should be bumped to a current version as part of the
- * Phase 1 API contract spike, in this one place.
+ * (plan §9/§13 L2). Bumped v21.0 → v25.0 as part of the Phase 1 contract spike
+ * (docs/meta-ads-infrastructure-2026.md §9/§9b): the live account resolves
+ * paging + create responses to v25.0 and the whole OUTCOME_SALES create chain
+ * was verified against it. (`meta-capi.ts` keeps its own version pin — it is a
+ * separate, already-proven tracking path and is intentionally not touched here.)
  */
-export const GRAPH_API_VERSION = 'v21.0';
+export const GRAPH_API_VERSION = 'v25.0';
 
 const GRAPH_BASE_URL = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
 export type GraphMethod = 'GET' | 'POST';
 
+/**
+ * A single Graph API field value. Primitives are sent as-is; objects and arrays
+ * (e.g. `promoted_object`, `targeting`, `object_story_spec`,
+ * `special_ad_categories`) are JSON-encoded into the form body — the Marketing
+ * API expects those complex fields as JSON strings, confirmed by the Phase 1
+ * contract spike (docs/meta-ads-infrastructure-2026.md §9b).
+ */
+export type GraphParamValue =
+  | string
+  | number
+  | boolean
+  | Record<string, unknown>
+  | unknown[]
+  | undefined;
+
 export interface MetaGraphParams {
   method?: GraphMethod;
   /** Query params (GET) or form body fields (POST). NEVER include `access_token` here. */
-  params?: Record<string, string | number | boolean | undefined>;
+  params?: Record<string, GraphParamValue>;
   token: string;
   /** The property this call is being made for — logging/audit only, never used to pick the token. */
   propertyId?: string;
@@ -82,8 +97,10 @@ export async function metaGraph<T = Record<string, unknown>>(
 
   const fields: Record<string, string> = {};
   for (const [key, value] of Object.entries(opts.params ?? {})) {
-    if (value === undefined) continue;
-    fields[key] = String(value);
+    if (value === undefined || value === null) continue;
+    // Objects/arrays (targeting, promoted_object, object_story_spec,
+    // special_ad_categories, …) must be JSON strings; primitives go as-is.
+    fields[key] = typeof value === 'object' ? JSON.stringify(value) : String(value);
   }
 
   const headers: Record<string, string> = {
@@ -137,7 +154,7 @@ export async function createResource<T = Record<string, unknown>>(
   node: string,
   adAccountId: string,
   token: string,
-  payload: Record<string, string | number | boolean | undefined>,
+  payload: Record<string, GraphParamValue>,
   propertyId?: string
 ): Promise<GraphResult<T>> {
   const enforcedPayload = {

--- a/src/services/growth/metaAds/client.ts
+++ b/src/services/growth/metaAds/client.ts
@@ -41,7 +41,7 @@ export const GRAPH_API_VERSION = 'v25.0';
 
 const GRAPH_BASE_URL = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
-export type GraphMethod = 'GET' | 'POST';
+export type GraphMethod = 'GET' | 'POST' | 'DELETE';
 
 /**
  * A single Graph API field value. Primitives are sent as-is; objects and arrays
@@ -202,6 +202,28 @@ export async function activateResource(
   return metaGraph<{ success: boolean }>(id, {
     method: 'POST',
     params: { status: 'ACTIVE' },
+    token,
+    propertyId,
+  });
+}
+
+/**
+ * Delete a resource by id (campaign/ad set/ad/creative) — the rollback
+ * primitive for `campaignBuilder.createCampaignChain` (plan §9 Phase 1): a
+ * mid-chain create failure must not leave orphaned PAUSED objects sitting in
+ * the ad account. Deleting a PAUSED object is zero-spend, same as creating
+ * one — this never touches anything live. Best-effort by design: callers
+ * (the rollback helper in campaignBuilder) log-and-continue on failure rather
+ * than throw, since a cleanup failure must never mask the original creation
+ * error being surfaced to the caller.
+ */
+export async function deleteResource(
+  id: string,
+  token: string,
+  propertyId?: string
+): Promise<GraphResult<{ success: boolean }>> {
+  return metaGraph<{ success: boolean }>(id, {
+    method: 'DELETE',
     token,
     propertyId,
   });

--- a/src/services/growth/metaAds/insights.ts
+++ b/src/services/growth/metaAds/insights.ts
@@ -1,0 +1,117 @@
+/**
+ * Read-only ROAS/spend insights for a Meta ad object — Phase 1 (plan §9).
+ *
+ * Purely a GET + parse: no `createResource`, no PAUSED enforcement, no
+ * dark-launch gate — reading spend data can never spend money, so the only
+ * precondition is a resolved ad context (an unconfigured property has
+ * nothing to read). This is the data source the admin UI / reconciliation
+ * cron (Phase 2) will use to mirror `AdCampaign.insights` and
+ * `effectiveStatus`.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + async functions.
+ */
+import { loggers } from '@/lib/logger';
+import { resolveAdContext } from './adContext';
+import { metaGraph, type GraphResult } from './client';
+
+const logger = loggers.ads;
+
+export interface GetInsightsOptions {
+  /** Meta `date_preset` — defaults to 'maximum' (the object's full lifetime). */
+  datePreset?: string;
+}
+
+export interface AdInsights {
+  spend: number;
+  impressions: number;
+  clicks: number;
+  purchases: number;
+  purchaseValue: number;
+  roas: number;
+}
+
+interface MetaActionItem {
+  action_type: string;
+  value: string;
+}
+
+interface MetaInsightsRow {
+  spend?: string;
+  impressions?: string;
+  clicks?: string;
+  actions?: MetaActionItem[];
+  action_values?: MetaActionItem[];
+  purchase_roas?: { value: string }[];
+}
+
+interface MetaInsightsResponse {
+  data: MetaInsightsRow[];
+}
+
+/**
+ * A Pixel-tracked purchase is reported under `offsite_conversion.fb_pixel_purchase`
+ * AND, on most accounts, ALSO mirrored under the unified `purchase` action_type
+ * — they describe the SAME web conversions, so SUMMING them double-counts (a
+ * well-known Ads Insights gotcha). We therefore PICK one by priority, never sum:
+ * prefer the pixel-specific type (it is exactly the event our ad set optimizes
+ * on — `promoted_object.custom_event_type=PURCHASE`), and fall back to the
+ * unified `purchase` only when the pixel type is absent. For our pixel-only,
+ * web-only direct-booking setup the two are effectively identical; this ordering
+ * should be re-validated once live conversion data exists (Phase 2).
+ */
+const PURCHASE_ACTION_TYPES_BY_PRIORITY = ['offsite_conversion.fb_pixel_purchase', 'purchase'];
+
+/** Value of the highest-priority purchase-like action present (0 if none) — never sums overlapping types. */
+function pickPurchaseActionValue(actions: MetaActionItem[] | undefined): number {
+  if (!actions) return 0;
+  for (const type of PURCHASE_ACTION_TYPES_BY_PRIORITY) {
+    const match = actions.find((action) => action.action_type === type);
+    if (match) return Number(match.value) || 0;
+  }
+  return 0;
+}
+
+/**
+ * Fetch and parse spend/ROAS insights for a Meta object (campaign, ad set, or
+ * ad — Meta's insights edge works the same way on all three). Never throws;
+ * a resolution or Graph API failure surfaces as `{ok:false,error}`, same
+ * discipline as the rest of this client.
+ */
+export async function getInsights(
+  propertyId: string,
+  objectId: string,
+  opts?: GetInsightsOptions
+): Promise<GraphResult<AdInsights>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('getInsights: no ad context for property', { propertyId, objectId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  const result = await metaGraph<MetaInsightsResponse>(`${objectId}/insights`, {
+    method: 'GET',
+    params: {
+      fields: 'spend,impressions,clicks,actions,action_values,purchase_roas',
+      date_preset: opts?.datePreset ?? 'maximum',
+    },
+    token: ctx.token,
+    propertyId,
+  });
+  if (!result.ok) return result;
+
+  // An object with no delivery yet (e.g. still PAUSED, never activated)
+  // legitimately returns an empty `data` array — treat as all-zero, not an error.
+  const row = result.data.data?.[0];
+  const spend = Number(row?.spend) || 0;
+  const impressions = Number(row?.impressions) || 0;
+  const clicks = Number(row?.clicks) || 0;
+  const purchases = pickPurchaseActionValue(row?.actions);
+  const purchaseValue = pickPurchaseActionValue(row?.action_values);
+
+  // Prefer Meta's own purchase_roas (accounts for its attribution window);
+  // fall back to a naive purchaseValue/spend only when Meta didn't report one.
+  const metaRoasEntry = row?.purchase_roas?.[0];
+  const roas = metaRoasEntry ? Number(metaRoasEntry.value) || 0 : spend > 0 ? purchaseValue / spend : 0;
+
+  return { ok: true, data: { spend, impressions, clicks, purchases, purchaseValue, roas } };
+}


### PR DESCRIPTION
## What
Phase 1 of the Growth Ad Engine: the code that **creates** Meta ad campaigns (PAUSED) and **reads** their ROAS insights. Builds on the Phase 0 client/gateway (#144).

Every object is created **PAUSED** and the tracking doc is written **un-activatable** — so this ships zero ability to spend money. The engine stays **dark** in production (`GROWTH_ADS_ENABLED` unset).

## Verified live
Ran the actual TypeScript `createCampaignChain` against the real ad account: full chain created PAUSED → read back → `getInsights` all-zeros → **all objects + the Firestore doc deleted. Zero spend.** (Harness: `scripts/growth-validate-ad-chain.ts`, self-cleaning, token from Secret Manager.) The underlying Graph API contract was also verified independently via curl and recorded in `docs/meta-ads-infrastructure-2026.md` §9b/§9c.

## Files
- `campaignBuilder.ts` — `createCampaign/AdSet/Creative/Ad` + `createCampaignChain` orchestrator (gate → context → 4 creates → Firestore). Rollback-on-failure (reverse order, best-effort, never throws). Pixel/page/domain per-property; nothing hardcoded.
- `insights.ts` — `getInsights` (spend/impressions/clicks/purchases/roas). Priority-picks one purchase action_type (no pixel-vs-unified double-count); prefers Meta's `purchase_roas`.
- `client.ts` — `deleteResource` (for rollback) + `GraphMethod` gains `DELETE`; (v25 bump + JSON param serialization landed earlier on this branch).
- Tests: 42 across the metaAds suite.

## Safety invariants (why this can't spend)
- **PAUSED enforced in one place** — every create goes through `createResource`, which injects `status:'PAUSED'` last.
- **Un-activatable on creation** — the `adCampaigns` doc is `status:'draft'` with **no `spendCapMinor`**; `adExecutionGateway.activateCampaign` refuses anything not `approved` + positive spend cap + ownership-checked. Approval + budget cap remain a **human step**.
- **Creation gated on the master switch only** (zero-spend); the live-mode switch still gates activation.
- Money-path review (Opus) over the Sonnet build fixed a real hole: a scheme-less `landingUrl` used to throw out of the chain and orphan a campaign — now returns a clean `{ok:false}` and rolls back.

## Not in this PR
Operator approval UI, image upload, activation trigger, ROAS reconciliation cron (Phase 2+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)