### PR TITLE
feat: Meta ad operator console — Phase 2a (machinery validation, dark)

### DIFF
--- a/docs/growth-ad-engine-plan.md
+++ b/docs/growth-ad-engine-plan.md
@@ -89,25 +89,31 @@ Brain proposes; Core executes. `POST /api/growth/ad-proposals` (scoped agent tok
 
 ---
 
-## 9. Build phases + model allocation (REVISED after Fable review — H6)
-**Prove manually before building the factory.** My own infra doc (§8) says: run a first ad manually → measure → *then* automate. The original phasing violated that. Corrected:
+## 9. Build phases + model allocation (REVISED 10 Jul — shipped reality + smart phasing)
 
-**Phase 0.5 — MANUAL proof (OWNER, ~1 week, near-zero code) — DO FIRST:**
-- Provision Meta (per revised §10). Create **one small interest+geo campaign manually in Ads Manager**, landing URL stamped `?utm_source=facebook&utm_campaign=<label>`.
-- Existing Pixel/CAPI/`BookingAttribution` measure it. Goal: **prove ads → bookings at Prahova's budget BEFORE building automation** (and give Phase 1 real data to read). Might reveal it doesn't pay — cheapest possible time to learn.
+**Phase 0.5 (manual proof) — SUPERSEDED.** The owner has run FB/IG ads for years; the open question is not "do ads work" but "does OUR machinery work." So we validate the machinery end-to-end (Phase 2a) instead of a manual proof ad.
 
-**Phase 0 — config + stop-side scaffolding (small code, no ad-writes):**
-- Per-property ad config (`{adAccountId, pixelId, pageId, instagramActorId, tokenRef}`) + `resolveAdContext` (cached, **shared-token isolation-tested**, H2).
-- `META_ADS_TOKENS` secret + `GRAPH_API_VERSION` consolidation (L2) + `adExecutionGateway` + env switches `GROWTH_ADS_ENABLED`/`GROWTH_ADS_MODE` default-off (H5).
-- Central Meta request builder that injects `status:PAUSED` unconditionally + Bearer-header auth (C2, M5). `pauseCampaign`/`pauseAllForProperty` FIRST (C1). Account-level spending limit as platform backstop (C1).
+**Phase 0 — DONE (PR #144).** Config + `resolveAdContext` (shared-token isolation, H2) + `META_ADS_TOKENS` + `adExecutionGateway` + `GROWTH_ADS_ENABLED/MODE` (default off, H5) + PAUSED-enforcing Bearer-only client (C2/M5) + `pauseCampaign`/`pauseAllForProperty` (stop-side first, C1).
 
-**Phase 1 — API contract spike + insights (needs token):** a throwaway script exercising each real call against Prahova's account (H4: `special_ad_categories`, `promoted_object`, creative flow, CA ToS, Lookalike floor) BEFORE coding §5 for real. Then `getInsights` reading the Phase-0.5 manual campaign (real data). **No audience layer** (cut — M1).
+**Phase 1 — DONE (PR #145).** Contract spike VERIFIED live (§9b/§9c: `OUTCOME_SALES` + `promoted_object{pixel,PURCHASE}`, `is_adset_budget_sharing_enabled`, app-must-be-Live for creatives) → `createCampaign/AdSet/Creative/Ad` + `createCampaignChain` (PAUSED, rollback) + `getInsights` (ROAS parse) + v25 + JSON param serialization. 42 tests, dark.
 
-**Phase 2 — ad creation + activation + stop/reconcile (needs token):** `createCampaign/AdSet/Creative/Ad` (PAUSED, post-create read-back verify, C2) with `promoted_object`+pixel (H4) and `utm_campaign=<adCampaigns.id>` on the creative link (H1). Operator approve (snapshots budget/cap) → `activateCampaign` via `adExecutionGateway`. **Reconciliation cron** (effective_status, REJECTED/WITH_ISSUES, drift → re-approval; catches escapes — C2/M2/M4). DoD includes: **operator pauses it and delivery stops.**
+**Phase 2a — NEXT: one real ad, end-to-end, via the operator console (machinery validation).** All permanent code:
+- Image upload → per-account hash cache (keyed `{platform,accountId,contentHash}` — TikTok-ready).
+- Neutral compose layer (`adComposer`): pre-allocate `adCampaigns` id → `utm_campaign` (ROAS join, H1) → creative (single image + auto-fit, `object_story_spec` proven) → `createCampaignChain`.
+- **Operator console v1** (`admin/ads`): compose from an existing gallery photo + copy + budget + targeting → PAUSED draft → preview → **approve** (sets spend cap, H5/M3) → **activate** via `adExecutionGateway` → ROAS view.
+- Acceptance (§12): real ~5-RON/day FB+IG ad, `end_time`-bounded, Pixel/CAPI+utm attribute, ROAS reads back, operator pauses → delivery stops. Detail: `scratchpad/phase2a-plan.md` (Fable-reviewed).
 
-**Phase 3 — creative + full loop:** brain-side creative, agent proposal endpoint (moved here — its consumer lives here, not Phase 0), brain→propose→approve→execute, ROAS closing. Audience/Lookalike layer *if* the pixel pool has grown enough (H4.5/M1), suppression-gated (M1).
+**Phase 2b — creative quality: the asset catalog.** The real §14.2 asset model over the gallery (variant lineage, gallery-vs-catalog flag, dedup, LLM descriptions) + 4:5/9:16 crops via `asset_feed_spec` + reconciliation cron (effective_status/REJECTED drift, C2/M2). Built when the composer needs richer assets — greenfield, additive.
 
-*Per phase:* Sonnet builds to spec; Haiku runs tests + watches deploys; **money-path verification + adversarial review on a strong model (not Haiku).**
+**Phase 2c — generation gateway.** External relight/populate-with-people via Brain→Core→provider + Meta Advantage+ enrollment (`degrees_of_freedom_spec`: `image_uncrop`/`image_animation`/`text_generation`, §10). Gated on the provider A/B choice (§14.11). Guardrail: bring REAL scenes to life, never fabricate the property.
+
+**Phase 2d — the brain seam.** OpenClaw proposes INTO the console (pre-fills the compose form), selects over the catalog, via the structured `/api/growth/ad-proposals` contract (§7/§14.8: idempotency, catalogVersion pinning, ownership assert on assetIds, spend cap, preview-before-activate). Gated on OpenClaw existing. Audience/Lookalike only if the pixel pool has grown (§11).
+
+**TikTok** — a new adapter under the neutral core (`adComposer` unchanged), whenever.
+
+**Design principles (no-throwaway):** (A) the operator console is the permanent human surface — manual now, Brain pre-fills later; (B) platform-neutral core + per-platform adapters — Meta-isms stay in `metaAds/*`; (C) introduce each store only when a consumer reads it.
+
+*Per phase:* Opus plans (full context) + Fable adversarial-reviews the plan; Sonnet builds to spec; Haiku runs tests/deploys; money-path verification + adversarial review on a strong model (not Haiku); live spend validation is owner-gated.
 
 ---
 

--- a/docs/growth-ad-engine-plan.md
+++ b/docs/growth-ad-engine-plan.md
@@ -158,3 +158,77 @@ Fable attacked the plan; I accept nearly all of it. §9/§10 already revised abo
 **Lows:** L1 don't let the `analytics.metaPixelId → analytics.meta.pixelId` refactor break deployed CAPI/pixel reads (keep old path or migrate atomically). L2 consolidate one `GRAPH_API_VERSION`. L3 cache "last-known" retains spend capability after offboarding (note for agency). L4 insights rate limits bite at N, not 1.
 
 **What Fable agreed was sound:** the per-property `{adAccountId, tokenRef}` + JSON-secret pattern, `write:false` rules, modular-monolith placement, operator-approves-everything, RON-only, and §11's audience-size honesty (the plan just now *acts* on it — M1).
+
+## 14. Media Assets & Creative (design — 10 Jul 2026)
+
+Media is the thing that quietly makes or breaks an ad engine. Verified Meta specs live in `docs/meta-ads-infrastructure-2026.md` §10; this section is the ARCHITECTURE. Core rule from §2 applies: media lives on **Core**, the Brain reasons over metadata, Meta stores its own copy.
+
+### 14.1 Three planes (media)
+- **Core** — canonical bytes (reuse the EXISTING gallery/`PropertyImage` + Firebase Storage), holds the Meta token AND the generation-provider keys, does uploads, owns bookings/guests/conversions.
+- **Brain (OpenClaw)** — reasons over a metadata **catalog**; never touches bytes; holds no secrets; formulates needs.
+- **Meta** — its own store: `image_hash`/`video_id` are **per-ad-account** (§10) → Core keeps a per-account upload cache; `copy_from` copies bytes across accounts (agency).
+
+### 14.2 The asset record (one store, two views)
+Extends `PropertyImage`. Key fields:
+```
+id, propertyId, kind: image|video
+role: master | variant
+derivedFrom: <parentAssetId|null>      # variant lineage — a tree; variants can have variants
+transform: crop-9:16 | ai-relight | ai-people | short-clip | platform-tiktok ...
+aiAdjusted: bool, aiMethod, aiPrompt   # INTERNAL flag + provenance (see 14.6)
+contentHash                            # dedup — computed on the MASTER only
+llmDescription: { subjects, setting, season, mood, activities, people, palette,
+                  aspirational_angle, fits_copy_themes[] }   # the Brain's decision input
+tags[], rights/consent
+galleryVisible: bool                   # website gallery = CURATED SUBSET, not the catalog
+uploads: { <adAccountId>: image_hash|video_id }   # per-account cache
+performance: { withinDynamicCreative[], aggregate }   # see 14.7
+state: draft → described → qa_passed → in_use → retired
+```
+Two orthogonal axes, both owner-requested:
+- **Gallery ≠ catalog.** The public website gallery shows only curated, real, picked assets (`galleryVisible`). The ad catalog is the superset — every crop/style/platform variant, and **all AI-adjusted versions, which are catalog-only and NEVER shown in the gallery** (they'd misrepresent the property).
+- **Variant lineage.** Every derived asset points at its parent via `derivedFrom` + a `transform`. Group by root master. This both answers "these are variants of the same photo" AND makes dedup correct: hash the master, so intentional variants aren't flagged as dupes.
+
+### 14.3 Selection (Brain picks over metadata)
+Given `{objective, audience, season, offer, copy}` + the catalog snapshot, the Brain **ranks candidate assets, picks a set (1 single / N for `asset_feed_spec`), justifies, and runs an adversarial judge pass** to kill mismatches. Returns asset IDs — never bytes. Favors: on-season, subject matches the message, brand-safe, available in needed ratios, and (weakly) past performance.
+
+### 14.4 Creative assembly (Core)
+Ship multi-ratio quality via **`asset_feed_spec`** (§10, API-native): put the 4:5 + 9:16 crops (and copy variants) in ONE creative and let Meta place per-placement. Store a high-res **master** → derive crops; keep copy AS TEXT (localizes RO/EN, avoids text-heavy throttle); respect Reels/Stories **safe zones**. Video: master → short-clip variants (9:16, ~15-30s), captions, async upload (poll status).
+
+### 14.5 Generation — layered, Core-gated (DECIDED: Brain → Core → external service)
+The image/video model is an **external service**; **the Brain formulates the need, CORE calls the service** (never Brain-direct). Rationale: the provider key is a Core secret (Brain holds none); the output must become a Core catalog asset anyway; Core meters cost + dedups-before-generate; Core routes to the right provider per transform without the Brain knowing; symmetry with ad execution + one audit trail. Core grows a **generation gateway** (sibling to `adExecutionGateway`): validate → cache/dedup check → route to provider → meter cost → store result as a first-class provenance-tagged asset → QA judge → return assetId. Exposed to the Brain AS A TOOL (same agentic ergonomics), **async** (job handle → poll/notify).
+
+Three routes Core chooses among per need:
+1. **Use existing** catalog asset (free) — always checked first.
+2. **Meta Advantage+ enrollment** (`degrees_of_freedom_spec`, §10) — `image_uncrop` (ratio fill), `image_animation` (still→video), `text_generation` (copy). Cheap, API-toggled at creative build; NO new asset (Meta transforms at serve time); good for ratio/animate/minor touch-ups.
+3. **External generation** (dedicated tool) — novel imagery Meta can't do: **relight (more sun), populate scenes with people doing the activity in the copy** (the owner's priority — high-performing lifestyle imagery). Produces a NEW catalog asset.
+
+**Guardrails (non-negotiable):** never invent rooms/decor/amenities — only bring REAL scenes to life; activities shown must actually be available; synthetic people need no release but must not imply non-existent experiences. Quality is paramount → Advantage+ only where it's genuinely good; dedicated tools for people-compositing/relight; **A/B Meta-enhanced vs dedicated early to calibrate.**
+
+### 14.6 AI labeling (verified §10)
+Commercial ads: **no advertiser self-declaration required** and **no Marketing API field** to declare it. Meta **auto-detects + labels** ("AI Info") significant AI edits (image/background generation, people-population) as of **1 Jun 2026**; minor edits (resize/color) don't trigger. (Political/social-issue ads DO require self-disclosure — not us.) We still keep an **internal `aiAdjusted` flag** regardless — for governance, honesty/QA, and future-proofing.
+
+### 14.7 Performance attribution (honest)
+A single ad's outcome **cannot be blamed on the photo alone** — confounded by copy/audience/budget/timing/bid. Per-asset signal is trustworthy ONLY in two places: (1) **within Dynamic Creative / `asset_feed_spec`**, where Meta rotates images inside the SAME ad set → a controlled experiment isolating the image (Meta's per-asset breakdown); (2) **aggregate across many campaigns**. Store per-asset performance, but the Brain weights within-experiment + aggregate and treats single instances as weak signal. The feedback loop (asset→ROAS) is real but statistically humble.
+
+### 14.8 Brain ↔ Core contract (structured, verified handshake)
+Not free text. Mirrors the gateway discipline (validate → gate → act → audit):
+- **Catalog request →** Core returns a VERSIONED snapshot (metadata + `llmDescription`, no bytes, `catalogVersion`).
+- **Ad proposal (Brain→Core) →** `{schemaVersion, proposalId (idempotency key), propertyId, catalogVersion, objective, targeting, budget{dailyMinor, capMinor}, copy[{primary,headline,cta,lang}], assets:[{assetId,role}], generationRequests:[{prompt,baseAssetId,transform}], landing{url,utms}}`.
+- **Core validates (the teeth) →** schema ok; `catalogVersion` not stale (else reconcile); **every assetId exists AND belongs to propertyId** (shared-token ownership assert, H2, applies to asset selection too); budget within policy; spend cap present; targeting sane; dedupe by `proposalId`. Returns `{accepted|rejected, reasons[], createdPausedIds?}`. Creation stays PAUSED; activation stays the human gate.
+- **Nuances:** idempotency/retries; catalog-version pinning + drift reconciliation; authN/authZ of the Brain↔Core channel (scoped to allowed properties); a dry-run "validate without creating" preflight; generation cost governance (metered/capped); **preview as a formal step** (Meta create-PAUSED → GET preview → activate — where AI output is judged).
+
+### 14.9 Pre-flight QA + dedup
+- **Pre-flight QA judge** (adversarial): every asset-at-crop / AI output reviewed before it can become a live ad — on-message, safe-zone-clean, not-beheaded, realistic (AI people), on-brand, HONEST (no implied non-existent amenity). Uses Meta's PAUSED→preview flow.
+- **Dedup** on the master's `contentHash`; variants are known derivations, not dupes.
+
+### 14.10 Phasing
+- **2a (minimal, now):** reuse existing photos, thin ad-asset record + per-account upload cache, proper 4:5 + 9:16 crops via `asset_feed_spec`, opt into Meta auto-enhance. Enough to run REAL ads with real photos — and it seeds the catalog/performance data. (Pairs with the "one manual real ad first" step.)
+- **2b:** vision-caption the library (`llmDescription`) + Brain-driven selection with judge + per-asset performance capture (within-Dynamic-Creative).
+- **2c:** the generation gateway (Brain need → Core → external service) for relight/people/seasonal gaps + video short-clip splitting + Meta `image_animation`.
+Don't build 2b/2c before 2a proves photos → bookings.
+
+### 14.11 Open decisions
+- Which external provider(s) for relight vs people-compositing (quality-led; A/B vs Advantage+).
+- Video: split the existing tour/drone master into short-clip variants now, or wait for more footage.
+- Exact catalog-snapshot/versioning + agent-API auth mechanism (part of the §7 brain seam).

--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -201,3 +201,24 @@ Notes: budgets in **bani** (minor units); Meta auto-adds `smart_pse_enabled:fals
 to `promoted_object`; `conversion_domain` must match the landing page's registrable
 domain (prahova-chalet.ro). Insights read-back for ROAS still to be exercised in
 the create functions, not the spike.
+
+---
+
+## 10. Creative assets & AI generation — verified specs (10 Jul 2026)
+Verified against developers.facebook.com (v25.0) + facebook.com/business ad-guide. Source tiers: **[P]** = read on a Meta property, **[S]** = secondary/snippet (spot-check before hard-coding). Extends/corrects §3/§5.
+
+**Image specs [P]:** JPG/PNG, **max 30 MB**, **min width 600px**, aspect-ratio tolerance **±3%**. Per placement: FB Feed **4:5** (also 1:1, 1.91:1), rec 1440×1800, min 600×750; Stories/Reels **9:16**, 1080×1920; FB right-column **1:1**; IG Feed 1.91:1→4:5. **The "20% text rule" is RETIRED (since Sep 2020), not enforced** — only a soft "less text performs better" recommendation; claims of a silent 2026 delivery penalty are [S] folklore, unconfirmed. Text (FB Feed/Awareness only, [P]): primary **50–150 chars** before "See more", headline **27 chars**; other placement/objective limits [S]/UNCONFIRMED — use `/act_<id>/generatepreview` rather than hard-coding truncation.
+
+**Video specs [P]:** MP4/MOV, H.264/H.265, **16:9 → 9:16**, min width 1200px (rec 1280×720+, scale up for 9:16), 24–60 fps, "up to 10 GB recommended" (the blog "4 GB max" is NOT what Meta's doc says). Upload `/act_<id>/advideos` is **chunked + ASYNC** (`upload_phase: start→transfer→finish`) → poll `GET /<video_id>?fields=status` until `processing_phase.status=complete` before use. Length limits UNCONFIRMED on a Meta source.
+
+**image_hash is (very likely) ACCOUNT-SCOPED [P-inferred]:** `/act_<id>/adimages` → `{hash,url,...}` (the returned `url` is temp — "do NOT use in creative"). The reference exposes `copy_from:{source_account_id,hash}` specifically to copy an image into ANOTHER account → strong evidence hashes don't transfer across accounts. **CONFIRMS the per-account upload cache design** `(assetId, adAccountId)→image_hash`. Verify empirically (upload same file to 2 accounts, diff hashes). Agency note: `copy_from` lets us copy a master account's image to each property account without re-uploading bytes.
+
+**`asset_feed_spec` — multi-asset/multi-ratio in ONE ad, API-creatable [P] (KEY):** POST `/act_<id>/adcreatives` with `asset_feed_spec` carrying `images[]`(≤~10)/`videos[]`, `bodies[]`/`titles[]`/`descriptions[]`(≤5 each), `link_urls[]`, `call_to_action_types[]`, `ad_formats`(`SINGLE_IMAGE|CAROUSEL_IMAGE|SINGLE_VIDEO|AUTOMATIC_FORMAT`), `asset_customization_rules[]`. So ONE ad can hold per-placement ratio variants and Meta picks per placement — **this is the API-native answer to "proper crops vs auto-crop": provide the crops as assets, let Meta select.** Not UI-only. (Catalog ads use a different `preferred_image_tags`/`adapt_to_placement` path — catalog-only, overkill for 1–2 properties.)
+
+**AI creative generation — API vs UI (corrects §3/§5) [P]:** the earlier "AI gen is not API-driven" is INCOMPLETE. Two layers:
+- **API-CONTROLLABLE via `degrees_of_freedom_spec.creative_features_spec`** (per-feature `{enroll_status: OPT_IN|OPT_OUT}`, submitted on adcreative/ad create): `text_generation` (copy variations), **`image_uncrop`** (AI expand/outcrop a still to fit a ratio — placement-limited to IG/Reels/Stories/Mobile-Feed), **`image_animation`** (still→short video), `image_background_gen` (**catalog ads only**), `music`/`music_generation`, `standard_enhancements` bundle (image touch-ups, text optim — sub-features NOT individually API-toggleable since v22.0, bundle-only). Workflow: create PAUSED → GET preview to see the AI output → then ACTIVE. **These directly cover our ratio-fill + still→video gaps, for free, via the API.**
+- **NOT API-accessible (UI / Business-AI-agent only):** free-form **prompt-to-image / prompt-to-video** (AI Sandbox/Creative Studio) — no endpoint. The Apr-2026 Ads CLI/MCP "Assets" tools appear to be upload/list only, no generation. → **Any *prompted* generation we must run ourselves** (Core-side), then upload as a normal asset.
+
+**AI-content labeling [P]:** Meta auto-labels ads "created or significantly edited" with generative AI ("AI info" on About-this-ad); minor edits (resize/color) don't trigger. Political/social-issue ads have stricter mandatory AI disclosure. → another reason to prefer real photos + light enhancement over heavy generation.
+
+**Rights/consent [S, consistent]:** advertiser must own/license every asset (image/video/music); IP infringement → rejection/termination. People need releases; don't fabricate the property (trust + policy + chargeback risk).

--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -222,3 +222,10 @@ Verified against developers.facebook.com (v25.0) + facebook.com/business ad-guid
 **AI-content labeling [P]:** Meta auto-labels ads "created or significantly edited" with generative AI ("AI info" on About-this-ad); minor edits (resize/color) don't trigger. Political/social-issue ads have stricter mandatory AI disclosure. → another reason to prefer real photos + light enhancement over heavy generation.
 
 **Rights/consent [S, consistent]:** advertiser must own/license every asset (image/video/music); IP infringement → rejection/termination. People need releases; don't fabricate the property (trust + policy + chargeback risk).
+
+### 9d. Phase-2a contract spike (live PAUSED, 10 Jul 2026) — upload + creative/adset fields
+Verified against `act_543311232953437` (v25), all PAUSED + deleted, zero spend:
+- **Image upload — multipart works.** `POST /act_<id>/adimages` with `curl -F "<field>=@file.jpg"` (or Node FormData/Blob) → `{"images":{"<field>":{"hash","width","height",...}}}`. Uploaded a 2048×1536 / 1.7MB JPG → hash returned. (§10: max 30MB, min width 600px — size-guard before base64 which inflates +33%; the returned `url` is temporary, store the HASH only.)
+- **Ad set `start_time` + `end_time` accepted with `daily_budget`** — a bounded run (auto-stop) works; read-back confirmed both. Use for the first live test's spend bound (Meta campaign spend-cap floor is 500 RON, too high for a small test).
+- **Creative `object_story_spec` accepts `instagram_user_id`** (→ IG placements, not FB-only), **`use_flexible_image_aspect_ratio:true`** (Meta auto-fits placements), and **`link_data.name`** (the headline). All read back correctly.
+- **B1 (build, verify at live test):** create injects PAUSED into campaign+adset+ad; Meta `effective_status` is a hierarchy rollup, so activation must un-pause ALL THREE (campaign + adset + ad) to deliver — un-pausing only the campaign leaves the ad paused. Pause stays campaign-only (ancestor pause gates children). Not verified autonomously (would require real delivery/spend) — confirm at the owner-gated live test.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -108,6 +108,14 @@
         { "fieldPath": "propertyId", "order": "ASCENDING" },
         { "fieldPath": "at", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "adCampaigns",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -254,6 +254,13 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only
     }
 
+    match /adImageCache/{cacheId} {
+      // Per-(platform, ad account, content hash) image-hash dedup cache
+      // (Phase 2a Build A) — no user-facing write path exists.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only
+    }
+
     // ============================================================================
     // App Config
     // ============================================================================

--- a/src/app/admin/ads/[id]/page.tsx
+++ b/src/app/admin/ads/[id]/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { AdminPage } from '@/components/admin';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import { fetchAdCampaignAction } from '../actions';
+import { AdDetailPanel } from '../_components/ad-detail-panel';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const campaign = await fetchAdCampaignAction(id);
+  if (!campaign) notFound();
+
+  return (
+    <AdminPage
+      title={`Ad ${id.slice(0, 10)}…`}
+      description={`Property: ${campaign.propertyId}`}
+      actions={
+        <Button asChild variant="outline">
+          <Link href={`/admin/ads?propertyId=${campaign.propertyId}`}>
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to ads
+          </Link>
+        </Button>
+      }
+    >
+      <AdDetailPanel campaign={campaign} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/ads/__tests__/actions.test.ts
+++ b/src/app/admin/ads/__tests__/actions.test.ts
@@ -1,0 +1,371 @@
+/** @jest-environment node */
+
+// Mock everything the money-touch actions call BEFORE importing the SUT —
+// same discipline as adExecutionGateway.test.ts / adComposer.test.ts.
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+jest.mock('@/lib/authorization', () => {
+  const actual = jest.requireActual('@/lib/authorization');
+  return { ...actual, requireSuperAdmin: jest.fn() };
+});
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
+}));
+
+jest.mock('@/services/growth/adComposer', () => ({
+  composeAndCreateAd: jest.fn(),
+  validateApprovalCap: jest.fn(),
+}));
+
+jest.mock('@/services/growth/adExecutionGateway', () => ({ activateCampaign: jest.fn() }));
+
+jest.mock('@/services/growth/metaAds/lifecycle', () => ({ pauseCampaign: jest.fn() }));
+
+jest.mock('@/services/growth/metaAds/insights', () => ({
+  getInsights: jest.fn(),
+  getEffectiveStatus: jest.fn(),
+}));
+
+jest.mock('@/services/growth/metaAds/adContext', () => ({ resolveAdContext: jest.fn() }));
+
+import {
+  composeAdAction,
+  approveAdAction,
+  activateAdAction,
+  pauseAdAction,
+  refreshAdInsightsAction,
+} from '../actions';
+import { requireSuperAdmin, AuthorizationError } from '@/lib/authorization';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { composeAndCreateAd, validateApprovalCap } from '@/services/growth/adComposer';
+import { activateCampaign } from '@/services/growth/adExecutionGateway';
+import { pauseCampaign } from '@/services/growth/metaAds/lifecycle';
+import { getInsights, getEffectiveStatus } from '@/services/growth/metaAds/insights';
+import type { ComposeAndCreateAdInput } from '@/types';
+
+const mockRequireSuperAdmin = requireSuperAdmin as jest.Mock;
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockComposeAndCreateAd = composeAndCreateAd as jest.Mock;
+const mockValidateApprovalCap = validateApprovalCap as jest.Mock;
+const mockActivateCampaign = activateCampaign as jest.Mock;
+const mockPauseCampaign = pauseCampaign as jest.Mock;
+const mockGetInsights = getInsights as jest.Mock;
+const mockGetEffectiveStatus = getEffectiveStatus as jest.Mock;
+
+const ACTOR = { uid: 'uid-1', email: 'operator@rentalspot.test', role: 'super_admin', managedProperties: [] };
+const ADCAMPAIGN_ID = 'campaign-doc-1';
+const PROPERTY = 'prahova-mountain-chalet';
+const META_CAMPAIGN_ID = 'meta-campaign-1';
+
+/** A `db.collection('adCampaigns').doc(id)` stub whose `.get()`/`.update()` are inspectable. */
+function makeDb(docData: unknown, exists = true) {
+  const updateMock = jest.fn().mockResolvedValue(undefined);
+  const getMock = jest.fn().mockResolvedValue({ exists, id: ADCAMPAIGN_ID, data: () => docData });
+  const docMock = jest.fn(() => ({ get: getMock, update: updateMock }));
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name === 'adCampaigns') return { doc: docMock };
+      throw new Error(`unexpected collection read in test: ${name}`);
+    }),
+  };
+  return { db, getMock, updateMock, docMock };
+}
+
+const DRAFT_DOC = {
+  propertyId: PROPERTY,
+  metaCampaignId: META_CAMPAIGN_ID,
+  status: 'draft',
+  dailyBudgetMinor: 5000,
+  endTime: '2099-01-01T00:00:00Z',
+  creativeRef: 'creative-1',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireSuperAdmin.mockResolvedValue(ACTOR);
+});
+
+// ---------------------------------------------------------------------------
+// composeAdAction — super-admin gate
+// ---------------------------------------------------------------------------
+
+describe('composeAdAction', () => {
+  const INPUT: ComposeAndCreateAdInput = {
+    propertyId: PROPERTY,
+    assetRef: { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/a.jpg` },
+    copy: [{ primary: 'Book your stay', cta: 'learn_more' }],
+    objective: 'sales',
+    landingBaseUrl: 'https://prahova-chalet.ro',
+    dailyBudgetMinor: 5000,
+    targeting: { countries: ['RO'], ageMin: 25, ageMax: 65 },
+    endTime: '2099-01-01T00:00:00Z',
+  };
+
+  it('gates on super-admin — rejects BEFORE calling composeAndCreateAd when not authorized', async () => {
+    mockRequireSuperAdmin.mockRejectedValue(new AuthorizationError('nope', 'NOT_SUPER_ADMIN'));
+
+    const res = await composeAdAction(INPUT);
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.stage).toBe('gate');
+    expect(mockComposeAndCreateAd).not.toHaveBeenCalled();
+  });
+
+  it('calls composeAndCreateAd with the input verbatim (no actor field grafted on) and returns its result', async () => {
+    mockComposeAndCreateAd.mockResolvedValue({
+      ok: true,
+      adCampaignId: 'gen-1',
+      metaCampaignId: 'm-1',
+      metaAdSetId: 'as-1',
+      metaAdId: 'ad-1',
+      creativeId: 'cr-1',
+    });
+
+    const res = await composeAdAction(INPUT);
+
+    expect(mockRequireSuperAdmin).toHaveBeenCalledTimes(1);
+    expect(mockComposeAndCreateAd).toHaveBeenCalledWith(INPUT);
+    expect(res).toEqual({
+      ok: true,
+      adCampaignId: 'gen-1',
+      metaCampaignId: 'm-1',
+      metaAdSetId: 'as-1',
+      metaAdId: 'ad-1',
+      creativeId: 'cr-1',
+    });
+  });
+
+  it('surfaces a failure result from composeAndCreateAd verbatim', async () => {
+    mockComposeAndCreateAd.mockResolvedValue({ ok: false, error: 'ads-engine-disabled', stage: 'gate' });
+    const res = await composeAdAction(INPUT);
+    expect(res).toEqual({ ok: false, error: 'ads-engine-disabled', stage: 'gate' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approveAdAction — state machine + spend-cap gate (S3/B2)
+// ---------------------------------------------------------------------------
+
+describe('approveAdAction', () => {
+  it('gates on super-admin — rejects before touching Firestore', async () => {
+    mockRequireSuperAdmin.mockRejectedValue(new AuthorizationError('nope', 'NOT_SUPER_ADMIN'));
+
+    const res = await approveAdAction(ADCAMPAIGN_ID, 10000);
+
+    expect(res.ok).toBe(false);
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+  });
+
+  it('rejects with not-found when the doc does not exist', async () => {
+    const { db } = makeDb(undefined, false);
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await approveAdAction(ADCAMPAIGN_ID, 10000);
+    expect(res).toEqual({ ok: false, error: 'not-found' });
+    expect(mockValidateApprovalCap).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-draft campaign with not-draft:<status> and never calls validateApprovalCap', async () => {
+    const { db, updateMock } = makeDb({ ...DRAFT_DOC, status: 'active' });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await approveAdAction(ADCAMPAIGN_ID, 10000);
+
+    expect(res).toEqual({ ok: false, error: 'not-draft:active' });
+    expect(mockValidateApprovalCap).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when validateApprovalCap fails, surfacing its reason, and never writes the doc', async () => {
+    const { db, updateMock } = makeDb(DRAFT_DOC);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockValidateApprovalCap.mockReturnValue({ ok: false, reason: 'spend-cap-too-low:projected=6250>cap=1000' });
+
+    const res = await approveAdAction(ADCAMPAIGN_ID, 1000);
+
+    expect(mockValidateApprovalCap).toHaveBeenCalledWith({
+      dailyBudgetMinor: DRAFT_DOC.dailyBudgetMinor,
+      spendCapMinor: 1000,
+      endTime: DRAFT_DOC.endTime,
+    });
+    expect(res).toEqual({ ok: false, error: 'spend-cap-too-low:projected=6250>cap=1000' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('on success, writes status=approved + spendCapMinor + approvalSnapshot(with creativeRef) + approvedBy=session-actor', async () => {
+    const { db, updateMock } = makeDb(DRAFT_DOC);
+    mockGetAdminDb.mockResolvedValue(db);
+    mockValidateApprovalCap.mockReturnValue({ ok: true });
+
+    const res = await approveAdAction(ADCAMPAIGN_ID, 10000);
+
+    expect(res).toEqual({ ok: true });
+    expect(updateMock).toHaveBeenCalledWith({
+      status: 'approved',
+      spendCapMinor: 10000,
+      approvalSnapshot: {
+        dailyBudgetMinor: DRAFT_DOC.dailyBudgetMinor,
+        spendCapMinor: 10000,
+        creativeRef: DRAFT_DOC.creativeRef,
+        at: 'server-ts',
+      },
+      approvedBy: ACTOR.email, // session actor, not a client-supplied value (S4)
+      updatedAt: 'server-ts',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activateAdAction — thin wrapper; actor derived from session (S4)
+// ---------------------------------------------------------------------------
+
+describe('activateAdAction', () => {
+  it('gates on super-admin — rejects before touching Firestore or the gateway', async () => {
+    mockRequireSuperAdmin.mockRejectedValue(new AuthorizationError('nope', 'NOT_SUPER_ADMIN'));
+
+    const res = await activateAdAction(ADCAMPAIGN_ID);
+
+    expect(res.status).toBe('rejected');
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+    expect(mockActivateCampaign).not.toHaveBeenCalled();
+  });
+
+  it('rejects with not-found when the doc does not exist, without calling the gateway', async () => {
+    const { db } = makeDb(undefined, false);
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateAdAction(ADCAMPAIGN_ID);
+    expect(res).toEqual({ status: 'rejected', reason: 'not-found' });
+    expect(mockActivateCampaign).not.toHaveBeenCalled();
+  });
+
+  it('derives actor from the SESSION (requireSuperAdmin), never from the input, and passes it to the gateway', async () => {
+    const { db } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockActivateCampaign.mockResolvedValue({ status: 'activated' });
+
+    // activateAdAction takes ONLY an adCampaignId — there is no way for a
+    // caller to inject an actor; this test locks that contract in.
+    const res = await activateAdAction(ADCAMPAIGN_ID);
+
+    expect(mockActivateCampaign).toHaveBeenCalledWith(PROPERTY, META_CAMPAIGN_ID, { actor: ACTOR.email });
+    expect(res).toEqual({ status: 'activated' });
+  });
+
+  it('returns the gateway result verbatim (dry-run) and adds no money logic of its own', async () => {
+    const { db } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockActivateCampaign.mockResolvedValue({ status: 'dry-run' });
+
+    const res = await activateAdAction(ADCAMPAIGN_ID);
+    expect(res).toEqual({ status: 'dry-run' });
+  });
+
+  it('returns the gateway rejection verbatim', async () => {
+    const { db } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockActivateCampaign.mockResolvedValue({ status: 'rejected', reason: 'ownership-mismatch' });
+
+    const res = await activateAdAction(ADCAMPAIGN_ID);
+    expect(res).toEqual({ status: 'rejected', reason: 'ownership-mismatch' });
+  });
+
+  it('rejects (does not call the gateway) when the doc is missing propertyId/metaCampaignId', async () => {
+    const { db } = makeDb({ propertyId: PROPERTY }); // no metaCampaignId
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await activateAdAction(ADCAMPAIGN_ID);
+    expect(res).toEqual({ status: 'rejected', reason: 'doc-missing-propertyId-or-metaCampaignId' });
+    expect(mockActivateCampaign).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pauseAdAction — lighter coverage (never spends; STOP primitive)
+// ---------------------------------------------------------------------------
+
+describe('pauseAdAction', () => {
+  it('gates on super-admin', async () => {
+    mockRequireSuperAdmin.mockRejectedValue(new AuthorizationError('nope', 'NOT_SUPER_ADMIN'));
+    const res = await pauseAdAction(ADCAMPAIGN_ID);
+    expect(res.success).toBe(false);
+    expect(mockPauseCampaign).not.toHaveBeenCalled();
+  });
+
+  it('on success, calls pauseCampaign and flips adCampaigns.status to paused', async () => {
+    const { db, updateMock } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockPauseCampaign.mockResolvedValue({ success: true, campaignId: META_CAMPAIGN_ID });
+
+    const res = await pauseAdAction(ADCAMPAIGN_ID);
+
+    expect(mockPauseCampaign).toHaveBeenCalledWith(PROPERTY, META_CAMPAIGN_ID);
+    expect(res).toEqual({ success: true, campaignId: META_CAMPAIGN_ID });
+    expect(updateMock).toHaveBeenCalledWith({ status: 'paused', updatedAt: 'server-ts' });
+  });
+
+  it('does NOT flip status when pauseCampaign fails', async () => {
+    const { db, updateMock } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockPauseCampaign.mockResolvedValue({ success: false, campaignId: META_CAMPAIGN_ID, error: 'no-ad-context' });
+
+    const res = await pauseAdAction(ADCAMPAIGN_ID);
+    expect(res).toEqual({ success: false, campaignId: META_CAMPAIGN_ID, error: 'no-ad-context' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshAdInsightsAction — read-only, lighter coverage
+// ---------------------------------------------------------------------------
+
+describe('refreshAdInsightsAction', () => {
+  it('gates on super-admin', async () => {
+    mockRequireSuperAdmin.mockRejectedValue(new AuthorizationError('nope', 'NOT_SUPER_ADMIN'));
+    const res = await refreshAdInsightsAction(ADCAMPAIGN_ID);
+    expect(res.ok).toBe(false);
+    expect(mockGetInsights).not.toHaveBeenCalled();
+  });
+
+  it('writes insights + effectiveStatus + lastSyncedAt on success', async () => {
+    const { db, updateMock } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetInsights.mockResolvedValue({
+      ok: true,
+      data: { spend: 12.5, impressions: 100, clicks: 4, purchases: 1, purchaseValue: 50, roas: 4 },
+    });
+    mockGetEffectiveStatus.mockResolvedValue({ ok: true, data: { effectiveStatus: 'ACTIVE' } });
+
+    const res = await refreshAdInsightsAction(ADCAMPAIGN_ID);
+
+    expect(res).toEqual({
+      ok: true,
+      insights: { spend: 12.5, impressions: 100, clicks: 4, bookings: 1, roas: 4 },
+      effectiveStatus: 'ACTIVE',
+    });
+    expect(updateMock).toHaveBeenCalledWith({
+      insights: { spend: 12.5, impressions: 100, clicks: 4, bookings: 1, roas: 4 },
+      lastSyncedAt: 'server-ts',
+      effectiveStatus: 'ACTIVE',
+    });
+  });
+
+  it('a failed effective_status read-back does not block a successful insights write (best-effort)', async () => {
+    const { db, updateMock } = makeDb({ propertyId: PROPERTY, metaCampaignId: META_CAMPAIGN_ID });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetInsights.mockResolvedValue({
+      ok: true,
+      data: { spend: 0, impressions: 0, clicks: 0, purchases: 0, purchaseValue: 0, roas: 0 },
+    });
+    mockGetEffectiveStatus.mockResolvedValue({ ok: false, error: 'no-ad-context' });
+
+    const res = await refreshAdInsightsAction(ADCAMPAIGN_ID);
+    expect(res.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith({
+      insights: { spend: 0, impressions: 0, clicks: 0, bookings: 0, roas: 0 },
+      lastSyncedAt: 'server-ts',
+    });
+  });
+});

--- a/src/app/admin/ads/_components/ad-detail-panel.tsx
+++ b/src/app/admin/ads/_components/ad-detail-panel.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, ExternalLink, RefreshCw, Ban, ShieldCheck, Rocket } from 'lucide-react';
+import type { AdCampaign } from '@/types';
+import { approveAdAction, activateAdAction, pauseAdAction, refreshAdInsightsAction } from '../actions';
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  draft: 'outline',
+  pending_approval: 'secondary',
+  approved: 'secondary',
+  active: 'default',
+  paused: 'outline',
+  failed: 'destructive',
+};
+
+const PROBLEM_EFFECTIVE_STATUSES = new Set(['DISAPPROVED', 'REJECTED', 'WITH_ISSUES', 'CAMPAIGN_PAUSED', 'ADSET_PAUSED']);
+
+function formatMinor(minor: number | undefined): string {
+  if (minor === undefined || minor === null) return '—';
+  return `${(minor / 100).toFixed(2)} RON`;
+}
+
+/** Mirrors `validateApprovalCap`'s own day-count so the operator sees the SAME projection the server will check against — display only, never trusted for the actual gate. */
+function daysToEndTime(endTime: string | undefined): number | null {
+  if (!endTime) return null;
+  const endMs = Date.parse(endTime);
+  if (Number.isNaN(endMs)) return null;
+  const days = Math.ceil((endMs - Date.now()) / (24 * 60 * 60 * 1000));
+  return days > 0 ? days : null;
+}
+
+export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManagerUrl?: string } }) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [approving, startApprove] = useTransition();
+  const [activating, startActivate] = useTransition();
+  const [pausing, startPause] = useTransition();
+  const [refreshing, startRefresh] = useTransition();
+  const [approveOpen, setApproveOpen] = useState(false);
+  const [spendCapRon, setSpendCapRon] = useState('50');
+
+  const days = daysToEndTime(campaign.endTime);
+  const projectedSpendMinor =
+    days && campaign.dailyBudgetMinor ? Math.round(campaign.dailyBudgetMinor * days * 1.25) : undefined;
+
+  const approve = () => {
+    const spendCapMinor = Math.round(Number(spendCapRon) * 100);
+    if (!Number.isFinite(spendCapMinor) || spendCapMinor <= 0) {
+      toast({ title: 'Invalid spend cap', variant: 'destructive' });
+      return;
+    }
+    startApprove(async () => {
+      const res = await approveAdAction(campaign.id, spendCapMinor);
+      if (res.ok) {
+        toast({ title: 'Approved', description: `Spend cap set to ${spendCapRon} RON.` });
+        setApproveOpen(false);
+        router.refresh();
+      } else {
+        toast({ title: 'Approve failed', description: res.error, variant: 'destructive' });
+      }
+    });
+  };
+
+  const activate = () => {
+    startActivate(async () => {
+      const res = await activateAdAction(campaign.id);
+      if (res.status === 'activated') {
+        toast({ title: 'Activated', description: 'Meta is now serving this ad.' });
+      } else if (res.status === 'dry-run') {
+        toast({ title: 'Dry-run', description: 'GROWTH_ADS_MODE is not live — no Meta call was made.' });
+      } else {
+        toast({ title: 'Rejected', description: res.reason, variant: 'destructive' });
+      }
+      router.refresh();
+    });
+  };
+
+  const pause = () => {
+    startPause(async () => {
+      const res = await pauseAdAction(campaign.id);
+      if (res.success) {
+        toast({ title: 'Paused' });
+      } else {
+        toast({ title: 'Pause failed', description: res.error, variant: 'destructive' });
+      }
+      router.refresh();
+    });
+  };
+
+  const refresh = () => {
+    startRefresh(async () => {
+      const res = await refreshAdInsightsAction(campaign.id);
+      if (res.ok) {
+        toast({
+          title: 'Insights refreshed',
+          description: `ROAS ${res.insights.roas.toFixed(2)} · spend ${res.insights.spend.toFixed(2)}${
+            res.effectiveStatus ? ` · ${res.effectiveStatus}` : ''
+          }`,
+        });
+      } else {
+        toast({ title: 'Refresh failed', description: res.error, variant: 'destructive' });
+      }
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            Campaign
+            <Badge variant={STATUS_VARIANT[campaign.status] || 'outline'}>{campaign.status}</Badge>
+            {campaign.effectiveStatus && PROBLEM_EFFECTIVE_STATUSES.has(campaign.effectiveStatus) && (
+              <Badge variant="destructive">{campaign.effectiveStatus}</Badge>
+            )}
+          </CardTitle>
+          <CardDescription>{campaign.metaCampaignId ?? 'No Meta campaign id recorded'}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <dl className="grid grid-cols-2 gap-y-2">
+            <dt className="text-muted-foreground">Objective</dt>
+            <dd>{campaign.objective ?? '—'}</dd>
+            <dt className="text-muted-foreground">Daily budget</dt>
+            <dd>{formatMinor(campaign.dailyBudgetMinor)}</dd>
+            <dt className="text-muted-foreground">Spend cap</dt>
+            <dd>{formatMinor(campaign.spendCapMinor)}</dd>
+            <dt className="text-muted-foreground">End time</dt>
+            <dd>{campaign.endTime ? new Date(campaign.endTime).toLocaleString() : '—'}</dd>
+            <dt className="text-muted-foreground">Approved by</dt>
+            <dd>{campaign.approvedBy ?? '—'}</dd>
+            <dt className="text-muted-foreground">Effective status</dt>
+            <dd>{campaign.effectiveStatus ?? 'not synced yet'}</dd>
+          </dl>
+
+          {campaign.insights && (
+            <div className="rounded-md border bg-muted/40 p-3">
+              <p className="font-medium mb-1">Insights</p>
+              <dl className="grid grid-cols-2 gap-y-1">
+                <dt className="text-muted-foreground">Spend</dt>
+                <dd>{campaign.insights.spend.toFixed(2)} RON</dd>
+                <dt className="text-muted-foreground">Impressions</dt>
+                <dd>{campaign.insights.impressions}</dd>
+                <dt className="text-muted-foreground">Clicks</dt>
+                <dd>{campaign.insights.clicks}</dd>
+                <dt className="text-muted-foreground">Bookings</dt>
+                <dd>{campaign.insights.bookings ?? 0}</dd>
+                <dt className="text-muted-foreground">ROAS</dt>
+                <dd>{campaign.insights.roas?.toFixed(2) ?? '—'}</dd>
+              </dl>
+            </div>
+          )}
+
+          {campaign.adsManagerUrl && (
+            <a
+              href={campaign.adsManagerUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              Open in Ads Manager <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
+        </CardContent>
+        <CardFooter>
+          <Button variant="outline" size="sm" onClick={refresh} disabled={refreshing}>
+            {refreshing ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-1 h-3.5 w-3.5" />}
+            Refresh insights
+          </Button>
+        </CardFooter>
+      </Card>
+
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle>Actions</CardTitle>
+          <CardDescription>Approve sets a spend cap. Activate spends real money once both engine switches are on.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Dialog open={approveOpen} onOpenChange={setApproveOpen}>
+            <DialogTrigger asChild>
+              <Button className="w-full" variant="secondary" disabled={campaign.status !== 'draft'}>
+                <ShieldCheck className="mr-1 h-4 w-4" />
+                Approve
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Approve this ad</DialogTitle>
+                <DialogDescription>
+                  Set a spend cap. The server rejects the cap unless{' '}
+                  <code>dailyBudget × days-to-end-time × 1.25 ≤ spendCap</code>.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-2">
+                <Label htmlFor="spend-cap">Spend cap (RON)</Label>
+                <Input id="spend-cap" type="number" min={1} step="0.01" value={spendCapRon} onChange={(e) => setSpendCapRon(e.target.value)} />
+                {days !== null && projectedSpendMinor !== undefined && (
+                  <p className="text-xs text-muted-foreground">
+                    Projected: {formatMinor(campaign.dailyBudgetMinor)}/day × {days} day{days === 1 ? '' : 's'} × 1.25 ={' '}
+                    <strong>{formatMinor(projectedSpendMinor)}</strong> — your cap must be at least this.
+                  </p>
+                )}
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setApproveOpen(false)} disabled={approving}>
+                  Cancel
+                </Button>
+                <Button onClick={approve} disabled={approving}>
+                  {approving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Confirm approval
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button className="w-full" disabled={campaign.status !== 'approved' || activating}>
+                {activating ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Rocket className="mr-1 h-4 w-4" />}
+                Activate
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Activate this ad?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This un-pauses the campaign, every ad set, and every ad on Meta. If the engine is live, this starts real
+                  spend up to the approved cap. If it&apos;s still in dry-run mode, nothing spends.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={activating}>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={activate} disabled={activating}>
+                  {activating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Yes, activate
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <Button className="w-full" variant="destructive" onClick={pause} disabled={pausing}>
+            {pausing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Ban className="mr-1 h-4 w-4" />}
+            Pause
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/ads/_components/ad-table.tsx
+++ b/src/app/admin/ads/_components/ad-table.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import type { AdCampaign } from '@/types';
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  draft: 'outline',
+  pending_approval: 'secondary',
+  approved: 'secondary',
+  active: 'default',
+  paused: 'outline',
+  failed: 'destructive',
+};
+
+/** Meta `effective_status` values that mean "this will not deliver" — flagged in a second, louder badge regardless of our own `status` field (OD4: on-demand drift detection). */
+const PROBLEM_EFFECTIVE_STATUSES = new Set(['DISAPPROVED', 'REJECTED', 'WITH_ISSUES', 'CAMPAIGN_PAUSED', 'ADSET_PAUSED']);
+
+function formatMinor(minor: number | undefined): string {
+  if (minor === undefined || minor === null) return '—';
+  return `${(minor / 100).toFixed(2)} RON`;
+}
+
+function formatDate(value: string | undefined): string {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleDateString();
+  } catch {
+    return '—';
+  }
+}
+
+export function AdTable({ campaigns }: { campaigns: AdCampaign[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Ad</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Daily budget</TableHead>
+          <TableHead className="text-right">Spend cap</TableHead>
+          <TableHead className="text-right">ROAS</TableHead>
+          <TableHead>Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {campaigns.map((c) => (
+          <TableRow key={c.id} className="cursor-pointer hover:bg-muted/40">
+            <TableCell className="font-medium">
+              <Link href={`/admin/ads/${c.id}`} className="hover:underline">
+                {c.id.slice(0, 10)}…
+              </Link>
+            </TableCell>
+            <TableCell className="space-x-1.5">
+              <Badge variant={STATUS_VARIANT[c.status] || 'outline'}>{c.status}</Badge>
+              {c.effectiveStatus && PROBLEM_EFFECTIVE_STATUSES.has(c.effectiveStatus) && (
+                <Badge variant="destructive">{c.effectiveStatus}</Badge>
+              )}
+            </TableCell>
+            <TableCell className="text-right">{formatMinor(c.dailyBudgetMinor)}</TableCell>
+            <TableCell className="text-right">{formatMinor(c.spendCapMinor)}</TableCell>
+            <TableCell className="text-right">{c.insights?.roas ? c.insights.roas.toFixed(2) : '—'}</TableCell>
+            <TableCell className="text-muted-foreground text-sm">{formatDate(c.createdAt as string | undefined)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/app/admin/ads/_components/compose-form.tsx
+++ b/src/app/admin/ads/_components/compose-form.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Check, ImageOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { AdCallToAction, ComposeAndCreateAdInput } from '@/types';
+import { composeAdAction } from '../actions';
+
+// A short, curated list — a Romanian vacation-rental audience realistically
+// targets these; the neutral compose input takes an arbitrary countries[]
+// array so this list is a UX convenience, not a platform limit.
+const COUNTRY_OPTIONS = [
+  { code: 'RO', label: 'Romania' },
+  { code: 'GB', label: 'United Kingdom' },
+  { code: 'DE', label: 'Germany' },
+  { code: 'FR', label: 'France' },
+  { code: 'IT', label: 'Italy' },
+  { code: 'NL', label: 'Netherlands' },
+  { code: 'US', label: 'United States' },
+];
+
+const CTA_OPTIONS: Array<{ value: AdCallToAction; label: string; verified: boolean }> = [
+  { value: 'learn_more', label: 'Learn more', verified: true },
+  { value: 'book_now', label: 'Book now', verified: false },
+  { value: 'contact_us', label: 'Contact us', verified: false },
+];
+
+interface GalleryImage {
+  storagePath: string;
+  url: string;
+  alt: string;
+  thumbnailUrl?: string;
+}
+
+interface ComposeFormProps {
+  propertyId: string;
+  images: GalleryImage[];
+  defaultLandingUrl: string;
+  /** Bani — server's `MAX_DAILY_BUDGET_MINOR`. Display/UX guard only; `adComposer.validateDailyBudget` is the real enforcement (B2). */
+  maxDailyBudgetMinor: number;
+}
+
+/** End-of-day ISO 8601 for a `YYYY-MM-DD` date input value — `endTime` is required (B2), so a bare date needs a concrete time-of-day. */
+function endOfDayIso(dateStr: string): string | null {
+  if (!dateStr) return null;
+  const d = new Date(`${dateStr}T23:59:59`);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBudgetMinor }: ComposeFormProps) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const [storagePath, setStoragePath] = useState<string>(images[0]?.storagePath ?? '');
+  const [primary, setPrimary] = useState('');
+  const [headline, setHeadline] = useState('');
+  const [cta, setCta] = useState<AdCallToAction>('learn_more');
+  const [landingBaseUrl, setLandingBaseUrl] = useState(defaultLandingUrl);
+  const [dailyBudgetRon, setDailyBudgetRon] = useState<string>('20');
+  const [countries, setCountries] = useState<string[]>(['RO']);
+  const [ageMin, setAgeMin] = useState('25');
+  const [ageMax, setAgeMax] = useState('65');
+  const [endDate, setEndDate] = useState('');
+
+  const maxDailyBudgetRon = maxDailyBudgetMinor / 100;
+
+  const toggleCountry = (code: string) => {
+    setCountries((prev) => (prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code]));
+  };
+
+  const validate = (): string | null => {
+    if (!storagePath) return 'Select a photo.';
+    if (!primary.trim()) return 'Primary text is required.';
+    if (!landingBaseUrl.trim()) return 'Landing URL is required.';
+    try {
+      new URL(landingBaseUrl);
+    } catch {
+      return 'Landing URL is not a valid URL.';
+    }
+    const budget = Number(dailyBudgetRon);
+    if (!Number.isFinite(budget) || budget <= 0) return 'Daily budget must be a positive number.';
+    if (countries.length === 0) return 'Select at least one country.';
+    const min = Number(ageMin);
+    const max = Number(ageMax);
+    if (!Number.isFinite(min) || !Number.isFinite(max) || min < 13 || max > 65 || min > max) {
+      return 'Age range must be between 13 and 65, min ≤ max.';
+    }
+    const endIso = endOfDayIso(endDate);
+    if (!endIso) return 'End date is required.';
+    if (Date.parse(endIso) <= Date.now()) return 'End date must be in the future.';
+    return null;
+  };
+
+  const submit = () => {
+    const validationError = validate();
+    if (validationError) {
+      toast({ title: 'Check the form', description: validationError, variant: 'destructive' });
+      return;
+    }
+
+    const input: ComposeAndCreateAdInput = {
+      propertyId,
+      assetRef: { kind: 'gallery', storagePath },
+      copy: [{ primary: primary.trim(), headline: headline.trim() || undefined, cta }],
+      objective: 'sales',
+      landingBaseUrl: landingBaseUrl.trim(),
+      dailyBudgetMinor: Math.round(Number(dailyBudgetRon) * 100),
+      targeting: { countries, ageMin: Number(ageMin), ageMax: Number(ageMax) },
+      endTime: endOfDayIso(endDate)!,
+    };
+
+    startTransition(async () => {
+      const result = await composeAdAction(input);
+      if (result.ok) {
+        toast({ title: 'Draft created', description: 'PAUSED on Meta, zero spend. Review and approve it next.' });
+        router.push(`/admin/ads/${result.adCampaignId}`);
+      } else {
+        toast({
+          title: 'Compose failed',
+          description: `[${result.stage}] ${result.error}`,
+          variant: 'destructive',
+        });
+      }
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_420px]">
+      <Card>
+        <CardHeader>
+          <CardTitle>Photo</CardTitle>
+          <CardDescription>Pick one photo from this property&apos;s gallery. Meta auto-fits it to each placement.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {images.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+              <ImageOff className="h-8 w-8" />
+              <p className="text-sm">No gallery images with a stored file found for this property.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+              {images.map((img) => (
+                <button
+                  key={img.storagePath}
+                  type="button"
+                  onClick={() => setStoragePath(img.storagePath)}
+                  className={cn(
+                    'relative aspect-square rounded-md overflow-hidden border-2 transition-all',
+                    storagePath === img.storagePath
+                      ? 'border-primary ring-2 ring-primary/30'
+                      : 'border-transparent hover:border-muted-foreground/30'
+                  )}
+                >
+                  <Image
+                    src={img.thumbnailUrl || img.url}
+                    alt={img.alt || ''}
+                    fill
+                    className="object-cover"
+                    sizes="150px"
+                  />
+                  {storagePath === img.storagePath && (
+                    <div className="absolute inset-0 bg-primary/20 flex items-center justify-center">
+                      <div className="rounded-full bg-primary p-1">
+                        <Check className="h-4 w-4 text-primary-foreground" />
+                      </div>
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle>Ad details</CardTitle>
+          <CardDescription>Composing always creates a PAUSED, zero-spend draft on Meta.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="primary">Primary text</Label>
+            <Textarea
+              id="primary"
+              value={primary}
+              onChange={(e) => setPrimary(e.target.value)}
+              placeholder="e.g. Escape to the mountains — book your stay at Prahova Chalet"
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="headline">Headline (optional)</Label>
+            <Input id="headline" value={headline} onChange={(e) => setHeadline(e.target.value)} placeholder="e.g. Prahova Mountain Chalet" />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Call to action</Label>
+            <Select value={cta} onValueChange={(v) => setCta(v as AdCallToAction)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CTA_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                    {!o.verified ? ' (unverified against this account)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="landing-url">Landing URL</Label>
+            <Input
+              id="landing-url"
+              value={landingBaseUrl}
+              onChange={(e) => setLandingBaseUrl(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Defaults to the property&apos;s canonical custom domain — keep it that way so Meta&apos;s conversion tracking matches the pixel domain.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="daily-budget">Daily budget (RON)</Label>
+            <Input
+              id="daily-budget"
+              type="number"
+              min={1}
+              max={maxDailyBudgetRon}
+              step="0.01"
+              value={dailyBudgetRon}
+              onChange={(e) => setDailyBudgetRon(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">Max {maxDailyBudgetRon} RON/day (server-enforced, this is a display hint only).</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Countries</Label>
+            <div className="grid grid-cols-2 gap-2">
+              {COUNTRY_OPTIONS.map((c) => (
+                <label key={c.code} className="flex items-center gap-2 text-sm">
+                  <Checkbox checked={countries.includes(c.code)} onCheckedChange={() => toggleCountry(c.code)} />
+                  {c.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="age-min">Min age</Label>
+              <Input id="age-min" type="number" min={13} max={65} value={ageMin} onChange={(e) => setAgeMin(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="age-max">Max age</Label>
+              <Input id="age-max" type="number" min={13} max={65} value={ageMax} onChange={(e) => setAgeMax(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="end-date">End date (required)</Label>
+            <Input id="end-date" type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+            <p className="text-xs text-muted-foreground">Bounds real spend — Meta&apos;s campaign-level spend-cap floor is too high for a small first test.</p>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button onClick={submit} disabled={pending} className="w-full">
+            {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create draft
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -1,0 +1,439 @@
+'use server';
+
+/**
+ * Growth Ad Engine — operator console server actions (Phase 2a Build B).
+ *
+ * Mirrors `src/app/admin/campaigns/actions.ts`'s shape (super-admin gate →
+ * try/catch → log → return a typed result) but wires to the Meta Ads Build A
+ * backend (`adComposer`, `adExecutionGateway`, `metaAds/lifecycle`,
+ * `metaAds/insights`) instead of the WhatsApp campaign service.
+ *
+ * MONEY-TOUCH DISCIPLINE (this file is the seam the Opus review targets):
+ *  - `actor` is ALWAYS derived from `requireSuperAdmin()` (the authenticated
+ *    session), NEVER from a client-supplied parameter (plan REVISIONS S4).
+ *  - No cap/budget arithmetic lives here — `validateApprovalCap` (approve) and
+ *    `validateDailyBudget` (compose, called inside `composeAndCreateAd`) own
+ *    that policy; this file only calls them and surfaces their verdicts.
+ *  - `activateAdAction` is a THIN wrapper over `adExecutionGateway.activateCampaign`
+ *    — the gateway owns every activation gate (two-switch, approval,
+ *    spend-cap, ownership, all-three-levels) AND the `status:'active'` write.
+ *    This action adds no money logic, only doc lookups.
+ *  - No `graph.facebook.com` calls happen here — every Meta call is reached
+ *    through `adComposer`/`adExecutionGateway`/`metaAds/*`, which are this
+ *    file's only "downstream" imports for anything Meta-shaped.
+ *
+ * `'use server'` files may only export async functions (never objects,
+ * consts, or top-level types) — see CLAUDE.md; return-type shapes below are
+ * expressed as inline object types on each function signature instead of
+ * exported `interface`/`type` declarations.
+ */
+
+import { revalidatePath } from 'next/cache';
+import { loggers } from '@/lib/logger';
+import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { convertTimestampsToISOStrings } from '@/lib/utils';
+import { getBaseUrl } from '@/lib/structured-data';
+import { getMaxDailyBudgetMinor } from '@/config/growth-ads';
+import type { AdCampaign, AdCampaignStatus, ComposeAndCreateAdInput, PropertyImage } from '@/types';
+import { composeAndCreateAd, validateApprovalCap, type ComposeAndCreateAdResult } from '@/services/growth/adComposer';
+import { activateCampaign, type ActivateResult } from '@/services/growth/adExecutionGateway';
+import { pauseCampaign, type PauseResult } from '@/services/growth/metaAds/lifecycle';
+import { getInsights, getEffectiveStatus } from '@/services/growth/metaAds/insights';
+import { resolveAdContext } from '@/services/growth/metaAds/adContext';
+
+const logger = loggers.ads;
+
+// ---------------------------------------------------------------------------
+// Shared helpers (not exported — this is a `'use server'` file)
+// ---------------------------------------------------------------------------
+
+/** Resolve the authenticated super-admin and a stable actor string for audit trails. Throws `AuthorizationError` if not authorized. */
+async function requireActor(): Promise<string> {
+  const user = await requireSuperAdmin();
+  return user.email || user.uid;
+}
+
+/** Meta returns `account_id` without the `act_` prefix; Ads Manager URLs also want it bare. */
+function normalizeAccountId(id: string | undefined): string | undefined {
+  if (!id) return undefined;
+  return id.startsWith('act_') ? id.slice(4) : id;
+}
+
+/** Best-effort Ads Manager deep link — never blocks the console if the account id can't be resolved. */
+function buildAdsManagerUrl(adAccountId: string | undefined, metaCampaignId: string | undefined): string | undefined {
+  if (!metaCampaignId) return undefined;
+  const act = normalizeAccountId(adAccountId);
+  const params = new URLSearchParams({ selected_campaign_ids: metaCampaignId });
+  if (act) params.set('act', act);
+  return `https://www.facebook.com/adsmanager/manage/campaigns?${params.toString()}`;
+}
+
+interface AdCampaignDocData {
+  propertyId?: string;
+  metaCampaignId?: string;
+  metaAdSetIds?: string[];
+  metaAdIds?: string[];
+  objective?: string;
+  dailyBudgetMinor?: number;
+  endTime?: string | null;
+  spendCapMinor?: number;
+  status?: AdCampaignStatus;
+  effectiveStatus?: string;
+  creativeRef?: string;
+  approvedBy?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Reads (list / detail / compose-form data)
+// ---------------------------------------------------------------------------
+
+/** List `adCampaigns` for a property, newest first. Empty array (not a thrown error) on auth failure — mirrors `campaigns/actions.ts:fetchCampaigns`. */
+export async function fetchAdCampaignsAction(propertyId: string): Promise<Array<AdCampaign>> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return [];
+    throw error;
+  }
+  try {
+    const db = await getAdminDb();
+    const snap = await db
+      .collection('adCampaigns')
+      .where('propertyId', '==', propertyId)
+      .orderBy('createdAt', 'desc')
+      .get();
+    return snap.docs.map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as AdCampaign);
+  } catch (error) {
+    logger.error('fetchAdCampaignsAction failed', error as Error, { propertyId });
+    return [];
+  }
+}
+
+/** Single `adCampaigns` doc, plus a best-effort Ads Manager deep link (account id resolved server-side; the Meta access token never leaves this module). Null on not-found or auth failure. */
+export async function fetchAdCampaignAction(
+  adCampaignId: string
+): Promise<(AdCampaign & { adsManagerUrl?: string }) | null> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return null;
+    throw error;
+  }
+  try {
+    const db = await getAdminDb();
+    const snap = await db.collection('adCampaigns').doc(adCampaignId).get();
+    if (!snap.exists) return null;
+    const data = snap.data() as AdCampaignDocData;
+
+    let adsManagerUrl: string | undefined;
+    if (data.propertyId) {
+      const ctx = await resolveAdContext(data.propertyId);
+      adsManagerUrl = buildAdsManagerUrl(ctx?.adAccountId, data.metaCampaignId);
+    }
+
+    return {
+      ...(convertTimestampsToISOStrings({ id: snap.id, ...data }) as AdCampaign),
+      adsManagerUrl,
+    };
+  } catch (error) {
+    logger.error('fetchAdCampaignAction failed', error as Error, { adCampaignId });
+    return null;
+  }
+}
+
+/** Data the compose form needs: the property's gallery images (storagePath-present, owned by this property), the canonical-domain landing URL default (S8), and the server's max-daily-budget ceiling (UX display only — B2's real enforcement lives in `adComposer.validateDailyBudget`). Null on auth failure or missing property. */
+export async function fetchComposeDataAction(propertyId: string): Promise<{
+  propertyId: string;
+  images: Array<{ storagePath: string; url: string; alt: string; thumbnailUrl?: string }>;
+  defaultLandingUrl: string;
+  maxDailyBudgetMinor: number;
+} | null> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return null;
+    throw error;
+  }
+  try {
+    const db = await getAdminDb();
+    const doc = await db.collection('properties').doc(propertyId).get();
+    if (!doc.exists) return null;
+    const data = doc.data() as { images?: PropertyImage[]; customDomain?: string | null };
+
+    const ownPrefix = `properties/${propertyId}/`;
+    const images = (data.images ?? [])
+      .filter((img): img is PropertyImage & { storagePath: string } =>
+        Boolean(img.storagePath && img.storagePath.startsWith(ownPrefix))
+      )
+      .map((img) => ({
+        storagePath: img.storagePath,
+        url: img.url,
+        alt: img.alt || '',
+        thumbnailUrl: img.thumbnailUrl,
+      }));
+
+    return {
+      propertyId,
+      images,
+      defaultLandingUrl: getBaseUrl(data.customDomain),
+      maxDailyBudgetMinor: getMaxDailyBudgetMinor(),
+    };
+  } catch (error) {
+    logger.error('fetchComposeDataAction failed', error as Error, { propertyId });
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Money-touch actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose a neutral ad request into a full PAUSED Meta chain (draft, zero
+ * spend). Super-admin gate; actor resolved from the session (S4) — NOT
+ * accepted as an input field, and never forwarded anywhere (`composeAndCreateAd`
+ * itself doesn't take an actor; the session check IS the provenance control
+ * here, same discipline the plan describes for the compose step).
+ *
+ * No money logic here: `MAX_DAILY_BUDGET_MINOR` enforcement lives inside
+ * `composeAndCreateAd` (`validateDailyBudget`) — this action only gates auth
+ * and surfaces whatever `composeAndCreateAd` returns, verbatim.
+ */
+export async function composeAdAction(input: ComposeAndCreateAdInput): Promise<ComposeAndCreateAdResult> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return { ok: false, error: handleAuthError(error).error, stage: 'gate' };
+    }
+    throw error;
+  }
+
+  logger.info('composeAdAction: composing', { actor, propertyId: input.propertyId });
+  const result = await composeAndCreateAd(input);
+  if (result.ok) {
+    logger.info('composeAdAction: composed draft', { actor, adCampaignId: result.adCampaignId });
+    revalidatePath('/admin/ads');
+  } else {
+    logger.warn('composeAdAction: compose failed', { actor, propertyId: input.propertyId, stage: result.stage, error: result.error });
+  }
+  return result;
+}
+
+/**
+ * Approve a draft ad campaign — the state machine + spend-bound gate (plan
+ * REVISIONS S3/B2). Super-admin gate; actor from session (S4).
+ *
+ *  1. Require `status === 'draft'` — approving anything else (already
+ *     approved/active/paused) is rejected with `not-draft:<status>`.
+ *  2. `validateApprovalCap` — the ONLY place spend-cap arithmetic runs; this
+ *     action never re-derives or duplicates that math, it only surfaces the
+ *     policy's verdict.
+ *  3. On ok: `status:'approved'`, `spendCapMinor`, an `approvalSnapshot`
+ *     (dailyBudgetMinor + spendCapMinor + creativeRef + server `at`),
+ *     `approvedBy: actor`, `updatedAt`.
+ */
+export async function approveAdAction(
+  adCampaignId: string,
+  spendCapMinor: number
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('adCampaigns').doc(adCampaignId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      return { ok: false, error: 'not-found' };
+    }
+    const doc = snap.data() as AdCampaignDocData;
+
+    if (doc.status !== 'draft') {
+      return { ok: false, error: `not-draft:${doc.status ?? 'unknown'}` };
+    }
+
+    const dailyBudgetMinor = doc.dailyBudgetMinor ?? 0;
+    const capCheck = validateApprovalCap({
+      dailyBudgetMinor,
+      spendCapMinor,
+      endTime: doc.endTime ?? '',
+    });
+    if (!capCheck.ok) {
+      logger.warn('approveAdAction: rejected by validateApprovalCap', {
+        actor,
+        adCampaignId,
+        reason: capCheck.reason,
+      });
+      return { ok: false, error: capCheck.reason };
+    }
+
+    await ref.update({
+      status: 'approved',
+      spendCapMinor,
+      approvalSnapshot: {
+        dailyBudgetMinor,
+        spendCapMinor,
+        creativeRef: doc.creativeRef ?? null,
+        at: FieldValue.serverTimestamp(),
+      },
+      approvedBy: actor,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    logger.info('approveAdAction: approved', { actor, adCampaignId, spendCapMinor });
+    revalidatePath('/admin/ads');
+    revalidatePath(`/admin/ads/${adCampaignId}`);
+    return { ok: true };
+  } catch (error) {
+    logger.error('approveAdAction failed', error as Error, { adCampaignId });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+/**
+ * Activate an approved ad campaign — a THIN wrapper. Super-admin gate; actor
+ * from session (S4), passed to the gateway (never a client-supplied value).
+ * Every money gate (two-switch dry-run, approval + spend-cap, ownership,
+ * activate-all-three-levels) AND the `status:'active'` write live in
+ * `adExecutionGateway.activateCampaign` — this action does nothing but look up
+ * `propertyId`/`metaCampaignId` and return the gateway's result verbatim.
+ */
+export async function activateAdAction(adCampaignId: string): Promise<ActivateResult> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return { status: 'rejected', reason: handleAuthError(error).error };
+    }
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const snap = await db.collection('adCampaigns').doc(adCampaignId).get();
+    if (!snap.exists) return { status: 'rejected', reason: 'not-found' };
+    const doc = snap.data() as AdCampaignDocData;
+    if (!doc.propertyId || !doc.metaCampaignId) {
+      return { status: 'rejected', reason: 'doc-missing-propertyId-or-metaCampaignId' };
+    }
+
+    const result = await activateCampaign(doc.propertyId, doc.metaCampaignId, { actor });
+    revalidatePath('/admin/ads');
+    revalidatePath(`/admin/ads/${adCampaignId}`);
+    return result;
+  } catch (error) {
+    logger.error('activateAdAction failed', error as Error, { adCampaignId });
+    return { status: 'rejected', reason: 'internal-error' };
+  }
+}
+
+/** Pause a campaign (STOP primitive — ungated by the two-switch on purpose, mirrors `lifecycle.pauseCampaign`'s own "always available" design). Super-admin gate; on success also flips `adCampaigns.status='paused'` (console must not lie about state, S2). */
+export async function pauseAdAction(adCampaignId: string): Promise<PauseResult> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return { success: false, campaignId: adCampaignId, error: handleAuthError(error).error };
+    }
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('adCampaigns').doc(adCampaignId);
+    const snap = await ref.get();
+    if (!snap.exists) return { success: false, campaignId: adCampaignId, error: 'not-found' };
+    const doc = snap.data() as AdCampaignDocData;
+    if (!doc.propertyId || !doc.metaCampaignId) {
+      return { success: false, campaignId: adCampaignId, error: 'doc-missing-propertyId-or-metaCampaignId' };
+    }
+
+    const result = await pauseCampaign(doc.propertyId, doc.metaCampaignId);
+    if (result.success) {
+      await ref.update({ status: 'paused', updatedAt: FieldValue.serverTimestamp() });
+      logger.info('pauseAdAction: paused', { actor, adCampaignId });
+    } else {
+      logger.warn('pauseAdAction: pauseCampaign failed', { actor, adCampaignId, error: result.error });
+    }
+    revalidatePath('/admin/ads');
+    revalidatePath(`/admin/ads/${adCampaignId}`);
+    return result;
+  } catch (error) {
+    logger.error('pauseAdAction failed', error as Error, { adCampaignId });
+    return { success: false, campaignId: adCampaignId, error: 'internal-error' };
+  }
+}
+
+/** Read-only ROAS + `effective_status` refresh (plan REVISIONS OD4 — on-demand drift/REJECTED detection in lieu of a 2a reconciliation cron). Writes `insights` + `lastSyncedAt` (+ `effectiveStatus` when the read-back succeeds) onto the doc. */
+export async function refreshAdInsightsAction(adCampaignId: string): Promise<
+  | { ok: true; insights: { spend: number; impressions: number; clicks: number; bookings: number; roas: number }; effectiveStatus?: string }
+  | { ok: false; error: string }
+> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('adCampaigns').doc(adCampaignId);
+    const snap = await ref.get();
+    if (!snap.exists) return { ok: false, error: 'not-found' };
+    const doc = snap.data() as AdCampaignDocData;
+    if (!doc.propertyId || !doc.metaCampaignId) {
+      return { ok: false, error: 'doc-missing-propertyId-or-metaCampaignId' };
+    }
+
+    const insightsResult = await getInsights(doc.propertyId, doc.metaCampaignId);
+    if (!insightsResult.ok) {
+      logger.warn('refreshAdInsightsAction: getInsights failed', { adCampaignId, error: insightsResult.error });
+      return { ok: false, error: insightsResult.error };
+    }
+
+    // Best-effort — a failed effective_status read-back must not block the
+    // (successful) insights refresh from being saved (same "never let a
+    // secondary read-back flip a primary success" discipline as the gateway's
+    // own post-activation read-back).
+    const effectiveStatusResult = await getEffectiveStatus(doc.propertyId, doc.metaCampaignId);
+    const effectiveStatus = effectiveStatusResult.ok ? effectiveStatusResult.data.effectiveStatus : undefined;
+    if (!effectiveStatusResult.ok) {
+      logger.warn('refreshAdInsightsAction: getEffectiveStatus failed (non-fatal)', {
+        adCampaignId,
+        error: effectiveStatusResult.error,
+      });
+    }
+
+    const insights = {
+      spend: insightsResult.data.spend,
+      impressions: insightsResult.data.impressions,
+      clicks: insightsResult.data.clicks,
+      bookings: insightsResult.data.purchases,
+      roas: insightsResult.data.roas,
+    };
+
+    await ref.update({
+      insights,
+      lastSyncedAt: FieldValue.serverTimestamp(),
+      ...(effectiveStatus ? { effectiveStatus } : {}),
+    });
+
+    revalidatePath('/admin/ads');
+    revalidatePath(`/admin/ads/${adCampaignId}`);
+    return { ok: true, insights, effectiveStatus };
+  } catch (error) {
+    logger.error('refreshAdInsightsAction failed', error as Error, { adCampaignId });
+    return { ok: false, error: 'internal-error' };
+  }
+}

--- a/src/app/admin/ads/new/page.tsx
+++ b/src/app/admin/ads/new/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { AdminPage } from '@/components/admin';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import { fetchComposeDataAction } from '../actions';
+import { ComposeForm } from '../_components/compose-form';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function NewAdPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const composeData = await fetchComposeDataAction(property);
+
+  return (
+    <AdminPage
+      title="New ad"
+      description="Compose a PAUSED, zero-spend Meta ad draft from an existing property photo. Nothing spends until you Approve and Activate it."
+      actions={
+        <Button asChild variant="outline">
+          <Link href={`/admin/ads?propertyId=${property}`}>
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to ads
+          </Link>
+        </Button>
+      }
+    >
+      {composeData ? (
+        <ComposeForm
+          propertyId={composeData.propertyId}
+          images={composeData.images}
+          defaultLandingUrl={composeData.defaultLandingUrl}
+          maxDailyBudgetMinor={composeData.maxDailyBudgetMinor}
+        />
+      ) : (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Could not load property data for &quot;{property}&quot;. Check you have access and the property exists.
+          </CardContent>
+        </Card>
+      )}
+    </AdminPage>
+  );
+}

--- a/src/app/admin/ads/page.tsx
+++ b/src/app/admin/ads/page.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { AdminPage, EmptyState } from '@/components/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { Target, Plus } from 'lucide-react';
+import { fetchAdCampaignsAction } from './actions';
+import { AdTable } from './_components/ad-table';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function AdsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const campaigns = await fetchAdCampaignsAction(property);
+
+  return (
+    <AdminPage
+      title="Ads"
+      description="Compose, approve, and activate Meta (Facebook + Instagram) ads from a property photo. Dark-launched — composing always creates a zero-spend PAUSED draft; activation only spends once both engine switches are on."
+      actions={
+        <Button asChild>
+          <Link href={`/admin/ads/new?propertyId=${property}`}>
+            <Plus className="mr-1 h-4 w-4" />
+            New ad
+          </Link>
+        </Button>
+      }
+    >
+      <PropertyUrlSync />
+      <Card>
+        <CardHeader>
+          <CardTitle>Campaigns</CardTitle>
+          <CardDescription>Every row started as a PAUSED, zero-spend draft. Approve, then activate.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {campaigns.length > 0 ? (
+            <AdTable campaigns={campaigns} />
+          ) : (
+            <EmptyState
+              icon={Target}
+              title="No ads yet"
+              description="Compose your first ad from a property photo."
+            />
+          )}
+        </CardContent>
+      </Card>
+    </AdminPage>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -12,6 +12,7 @@ import {
   CalendarCheck,
   Ticket,
   Megaphone,
+  Target,
   MessageSquare,
   Sliders,
   RefreshCw,
@@ -87,6 +88,7 @@ const navigationGroups = [
       { title: 'Attribution', href: '/admin/attribution', icon: BarChart3 },
       { title: 'Coupons', href: '/admin/coupons', icon: Ticket },
       { title: 'Campaigns', href: '/admin/campaigns', icon: Megaphone },
+      { title: 'Ads', href: '/admin/ads', icon: Target },
     ],
   },
 ];

--- a/src/config/__tests__/growth-ads.test.ts
+++ b/src/config/__tests__/growth-ads.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { isAdsEngineEnabled, getAdsMode, isAdsLiveAllowed } from '../growth-ads';
+import { isAdsEngineEnabled, getAdsMode, isAdsLiveAllowed, MAX_DAILY_BUDGET_MINOR, getMaxDailyBudgetMinor } from '../growth-ads';
 
 /**
  * The two-switch safety matrix for the ads/spend path: NOTHING is live unless
@@ -55,5 +55,12 @@ describe('growth-ads flags — two-switch safety matrix', () => {
     process.env.GROWTH_ADS_ENABLED = '1';
     process.env.GROWTH_ADS_MODE = 'live';
     expect(getAdsMode()).toBe('dry-run');
+  });
+});
+
+describe('MAX_DAILY_BUDGET_MINOR — server-side daily budget ceiling (plan REVISIONS B2)', () => {
+  it('is a sane positive value in bani (minor units), and the getter matches the constant', () => {
+    expect(MAX_DAILY_BUDGET_MINOR).toBe(20000); // 200 RON/day
+    expect(getMaxDailyBudgetMinor()).toBe(MAX_DAILY_BUDGET_MINOR);
   });
 });

--- a/src/config/growth-ads.ts
+++ b/src/config/growth-ads.ts
@@ -38,3 +38,17 @@ export function getAdsMode(): AdsMode {
 export function isAdsLiveAllowed(): boolean {
   return getAdsMode() === 'live';
 }
+
+/**
+ * Hard server-side ceiling on daily ad spend, in bani — 200 RON/day (plan
+ * REVISIONS B2). This is the REAL gate: `adComposer.validateDailyBudget`
+ * enforces it at compose time, and it is meant to be RE-CHECKED at approve
+ * time too (Build B) — a compose form's own max-budget field is UX only, not
+ * a security boundary, per B2/S1.5 ("form max budget — enforce SERVER-side").
+ */
+export const MAX_DAILY_BUDGET_MINOR = 20000; // 200 RON/day
+
+/** Getter form, for parity with the other flag readers in this module. */
+export function getMaxDailyBudgetMinor(): number {
+  return MAX_DAILY_BUDGET_MINOR;
+}

--- a/src/services/growth/__tests__/adComposer.test.ts
+++ b/src/services/growth/__tests__/adComposer.test.ts
@@ -1,0 +1,288 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({ getAdminDb: jest.fn() }));
+jest.mock('@/config/growth-ads', () => ({
+  isAdsEngineEnabled: jest.fn(),
+  getMaxDailyBudgetMinor: jest.fn(),
+}));
+jest.mock('../metaAds/adImages', () => ({ uploadImageToAccount: jest.fn() }));
+jest.mock('../metaAds/campaignBuilder', () => ({ createCampaignChain: jest.fn() }));
+
+import { composeAndCreateAd, validateDailyBudget, validateApprovalCap } from '../adComposer';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { isAdsEngineEnabled, getMaxDailyBudgetMinor } from '@/config/growth-ads';
+import { uploadImageToAccount } from '../metaAds/adImages';
+import { createCampaignChain } from '../metaAds/campaignBuilder';
+import type { ComposeAndCreateAdInput } from '@/types';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockIsAdsEngineEnabled = isAdsEngineEnabled as jest.Mock;
+const mockGetMaxDailyBudgetMinor = getMaxDailyBudgetMinor as jest.Mock;
+const mockUploadImageToAccount = uploadImageToAccount as jest.Mock;
+const mockCreateCampaignChain = createCampaignChain as jest.Mock;
+
+const PROPERTY = 'prahova-mountain-chalet';
+
+const BASE_INPUT: ComposeAndCreateAdInput = {
+  propertyId: PROPERTY,
+  assetRef: {
+    kind: 'gallery',
+    storagePath: `properties/${PROPERTY}/images/a.jpg`,
+    contentHash: 'hash123',
+  },
+  copy: [{ primary: 'Book your stay', headline: 'Escape to the mountains', cta: 'learn_more' }],
+  objective: 'sales',
+  landingBaseUrl: 'https://prahova-chalet.ro/book',
+  dailyBudgetMinor: 5000, // 50 RON
+  targeting: { countries: ['RO'], ageMin: 30, ageMax: 45 },
+  endTime: '2099-08-01T00:00:00Z',
+};
+
+function makeDb(generatedId = 'gen-id-1') {
+  const idDoc = { id: generatedId };
+  const docMock = jest.fn(() => idDoc);
+  const db = { collection: jest.fn((name: string) => (name === 'adCampaigns' ? { doc: docMock } : (() => { throw new Error(`unexpected collection: ${name}`); })())) };
+  return { db, docMock };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsAdsEngineEnabled.mockReturnValue(true);
+  mockGetMaxDailyBudgetMinor.mockReturnValue(20000); // 200 RON/day
+  const { db } = makeDb();
+  mockGetAdminDb.mockResolvedValue(db);
+  mockUploadImageToAccount.mockResolvedValue({ ok: true, data: { imageHash: 'img-hash-1' } });
+  mockCreateCampaignChain.mockResolvedValue({
+    ok: true,
+    campaignId: 'meta-campaign-1',
+    adSetId: 'meta-adset-1',
+    creativeId: 'meta-creative-1',
+    adId: 'meta-ad-1',
+    adCampaignId: 'gen-id-1',
+  });
+});
+
+describe('composeAndCreateAd — master-switch gate', () => {
+  it('refuses when the ads engine is disabled, before touching Storage/Meta/Firestore', async () => {
+    mockIsAdsEngineEnabled.mockReturnValue(false);
+    const res = await composeAndCreateAd(BASE_INPUT);
+    expect(res).toEqual({ ok: false, error: 'ads-engine-disabled', stage: 'gate' });
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+    expect(mockCreateCampaignChain).not.toHaveBeenCalled();
+  });
+});
+
+describe('composeAndCreateAd — MAX_DAILY_BUDGET_MINOR policy (B2)', () => {
+  it('rejects a daily budget over the server-side max', async () => {
+    mockGetMaxDailyBudgetMinor.mockReturnValue(20000);
+    const res = await composeAndCreateAd({ ...BASE_INPUT, dailyBudgetMinor: 20001 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.stage).toBe('validation');
+      expect(res.error).toContain('daily-budget-exceeds-max');
+    }
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+
+  it('accepts a daily budget exactly at the max', async () => {
+    mockGetMaxDailyBudgetMinor.mockReturnValue(20000);
+    const res = await composeAndCreateAd({ ...BASE_INPUT, dailyBudgetMinor: 20000 });
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('composeAndCreateAd — asset ownership assert (S7)', () => {
+  it('rejects a storagePath that does not belong to propertyId', async () => {
+    const res = await composeAndCreateAd({
+      ...BASE_INPUT,
+      assetRef: { ...BASE_INPUT.assetRef, storagePath: 'properties/some-other-property/images/a.jpg' },
+    });
+    expect(res).toEqual({ ok: false, error: 'asset-ownership-mismatch', stage: 'validation' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported assetRef.kind', async () => {
+    const res = await composeAndCreateAd({
+      ...BASE_INPUT,
+      assetRef: { ...BASE_INPUT.assetRef, kind: 'catalog' as 'gallery' },
+    });
+    expect(res).toEqual({ ok: false, error: 'unsupported-asset-kind:catalog', stage: 'validation' });
+  });
+});
+
+describe('composeAndCreateAd — required-field runtime guards', () => {
+  it('rejects a missing/invalid endTime', async () => {
+    const res = await composeAndCreateAd({ ...BASE_INPUT, endTime: 'not-a-date' });
+    expect(res).toEqual({ ok: false, error: 'invalid-end-time', stage: 'validation' });
+  });
+
+  it('rejects an empty copy array', async () => {
+    const res = await composeAndCreateAd({ ...BASE_INPUT, copy: [] });
+    expect(res).toEqual({ ok: false, error: 'no-copy-variant', stage: 'validation' });
+  });
+
+  it('rejects an unknown CTA', async () => {
+    const res = await composeAndCreateAd({
+      ...BASE_INPUT,
+      copy: [{ primary: 'x', cta: 'nonsense' as 'learn_more' }],
+    });
+    expect(res).toEqual({ ok: false, error: 'unknown-cta:nonsense', stage: 'validation' });
+  });
+});
+
+describe('composeAndCreateAd — landing URL / UTM link building', () => {
+  it('appends UTM params safely when the landing URL already carries a query string (no double "?")', async () => {
+    const { db } = makeDb('gen-id-1');
+    mockGetAdminDb.mockResolvedValue(db);
+    await composeAndCreateAd({ ...BASE_INPUT, landingBaseUrl: 'https://prahova-chalet.ro/book?ref=hero' });
+    const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+    expect(chainSpec.creative.link).toBe(
+      'https://prahova-chalet.ro/book?ref=hero&utm_source=facebook&utm_medium=paid&utm_campaign=gen-id-1'
+    );
+  });
+
+  it('rejects an unparseable landing URL with invalid-landing-url, before any upload', async () => {
+    const { db } = makeDb('gen-id-1');
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await composeAndCreateAd({ ...BASE_INPUT, landingBaseUrl: 'not a url' });
+    expect(res).toEqual({ ok: false, error: 'invalid-landing-url', stage: 'validation' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+});
+
+describe('composeAndCreateAd — happy path: neutral → Meta mapping stays out of the public surface', () => {
+  it('allocates the id with NO Firestore write, threads utm_campaign into the link, uploads, and maps neutral→Meta before calling createCampaignChain', async () => {
+    const { db, docMock } = makeDb('gen-id-1');
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await composeAndCreateAd(BASE_INPUT);
+
+    expect(res).toEqual({
+      ok: true,
+      adCampaignId: 'gen-id-1',
+      metaCampaignId: 'meta-campaign-1',
+      metaAdSetId: 'meta-adset-1',
+      metaAdId: 'meta-ad-1',
+      creativeId: 'meta-creative-1',
+    });
+
+    // id allocation is pure — .doc() with NO argument, no .set()/.add()/.create() called by adComposer itself.
+    expect(docMock).toHaveBeenCalledWith();
+
+    expect(mockUploadImageToAccount).toHaveBeenCalledWith(PROPERTY, {
+      storagePath: BASE_INPUT.assetRef.storagePath,
+      contentHash: BASE_INPUT.assetRef.contentHash,
+    });
+
+    expect(mockCreateCampaignChain).toHaveBeenCalledTimes(1);
+    const [calledPropertyId, chainSpec, calledAdCampaignId] = mockCreateCampaignChain.mock.calls[0];
+    expect(calledPropertyId).toBe(PROPERTY);
+    expect(calledAdCampaignId).toBe('gen-id-1');
+
+    // NO cities anywhere in the spec (S1).
+    expect(JSON.stringify(chainSpec)).not.toContain('cities');
+
+    expect(chainSpec.campaign.objective).toBe('OUTCOME_SALES'); // neutral 'sales' -> Meta
+    expect(chainSpec.adSet.dailyBudgetMinor).toBe(BASE_INPUT.dailyBudgetMinor);
+    expect(chainSpec.adSet.endTime).toBe(BASE_INPUT.endTime);
+    expect(chainSpec.adSet.targeting).toEqual({
+      geo_locations: { countries: ['RO'] },
+      age_min: 30,
+      age_max: 45,
+    });
+    expect(chainSpec.creative.imageHash).toBe('img-hash-1');
+    expect(chainSpec.creative.message).toBe('Book your stay');
+    expect(chainSpec.creative.headline).toBe('Escape to the mountains');
+    expect(chainSpec.creative.callToActionType).toBe('LEARN_MORE'); // neutral 'learn_more' -> Meta
+    expect(chainSpec.creative.link).toBe(
+      'https://prahova-chalet.ro/book?utm_source=facebook&utm_medium=paid&utm_campaign=gen-id-1'
+    );
+  });
+
+  it('maps every declared neutral CTA to a Meta CTA string', async () => {
+    for (const [neutral, meta] of [
+      ['learn_more', 'LEARN_MORE'],
+      ['book_now', 'BOOK_TRAVEL'],
+      ['contact_us', 'CONTACT_US'],
+    ] as const) {
+      mockCreateCampaignChain.mockClear();
+      await composeAndCreateAd({ ...BASE_INPUT, copy: [{ primary: 'x', cta: neutral }] });
+      const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+      expect(chainSpec.creative.callToActionType).toBe(meta);
+    }
+  });
+});
+
+describe('composeAndCreateAd — id allocation failure', () => {
+  it('returns a typed failure (never throws) when getAdminDb itself fails', async () => {
+    mockGetAdminDb.mockRejectedValue(new Error('admin sdk unavailable'));
+    const res = await composeAndCreateAd(BASE_INPUT);
+    expect(res).toEqual({ ok: false, error: 'id-allocation-failed', stage: 'chain' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+});
+
+describe('composeAndCreateAd — upload failure', () => {
+  it('surfaces the upload error and never calls createCampaignChain', async () => {
+    mockUploadImageToAccount.mockResolvedValue({ ok: false, error: 'image-too-narrow' });
+    const res = await composeAndCreateAd(BASE_INPUT);
+    expect(res).toEqual({ ok: false, error: 'upload-failed:image-too-narrow', stage: 'upload' });
+    expect(mockCreateCampaignChain).not.toHaveBeenCalled();
+  });
+});
+
+describe('composeAndCreateAd — chain failure', () => {
+  it('surfaces the chain stage+error', async () => {
+    mockCreateCampaignChain.mockResolvedValue({ ok: false, error: 'no-pixel', stage: 'adSet' });
+    const res = await composeAndCreateAd(BASE_INPUT);
+    expect(res).toEqual({ ok: false, error: 'adSet:no-pixel', stage: 'chain' });
+  });
+});
+
+describe('validateDailyBudget — neutral policy helper', () => {
+  beforeEach(() => mockGetMaxDailyBudgetMinor.mockReturnValue(20000));
+
+  it('accepts a positive budget within the max', () => {
+    expect(validateDailyBudget(5000)).toEqual({ ok: true });
+  });
+  it('rejects zero/negative budgets', () => {
+    expect(validateDailyBudget(0).ok).toBe(false);
+    expect(validateDailyBudget(-1).ok).toBe(false);
+  });
+  it('rejects a budget over the max', () => {
+    expect(validateDailyBudget(20001).ok).toBe(false);
+  });
+});
+
+describe('validateApprovalCap — B2 spend-bound arithmetic (Fable OD6, neutral policy)', () => {
+  it('passes when dailyBudget × days × 1.25 <= spendCap', () => {
+    const endTime = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(); // ~3 days out
+    // 5000 * 3 * 1.25 = 18750 <= 20000
+    const res = validateApprovalCap({ dailyBudgetMinor: 5000, spendCapMinor: 20000, endTime });
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('rejects when the spend cap is too low for the daily budget and duration', () => {
+    const endTime = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+    // 5000 * 3 * 1.25 = 18750 > 10000
+    const res = validateApprovalCap({ dailyBudgetMinor: 5000, spendCapMinor: 10000, endTime });
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a non-positive spend cap', () => {
+    const endTime = new Date(Date.now() + 86400000).toISOString();
+    expect(validateApprovalCap({ dailyBudgetMinor: 5000, spendCapMinor: 0, endTime }).ok).toBe(false);
+  });
+
+  it('rejects an end time in the past', () => {
+    const endTime = new Date(Date.now() - 86400000).toISOString();
+    const res = validateApprovalCap({ dailyBudgetMinor: 5000, spendCapMinor: 999999, endTime });
+    expect(res).toEqual({ ok: false, reason: 'end-time-not-in-future' });
+  });
+
+  it('rejects an unparseable end time', () => {
+    const res = validateApprovalCap({ dailyBudgetMinor: 5000, spendCapMinor: 999999, endTime: 'garbage' });
+    expect(res).toEqual({ ok: false, reason: 'invalid-end-time' });
+  });
+});

--- a/src/services/growth/__tests__/adExecutionGateway.test.ts
+++ b/src/services/growth/__tests__/adExecutionGateway.test.ts
@@ -6,17 +6,22 @@ jest.mock('@/lib/firebaseAdminSafe', () => ({
   FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
 }));
 jest.mock('@/services/growth/metaAds/adContext', () => ({ resolveAdContext: jest.fn() }));
-jest.mock('@/services/growth/metaAds/client', () => ({ metaGraph: jest.fn(), activateResource: jest.fn() }));
+jest.mock('@/services/growth/metaAds/client', () => ({
+  metaGraph: jest.fn(),
+  activateResource: jest.fn(),
+  pauseResource: jest.fn(),
+}));
 
 import { activateCampaign } from '../adExecutionGateway';
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { resolveAdContext } from '@/services/growth/metaAds/adContext';
-import { metaGraph, activateResource } from '@/services/growth/metaAds/client';
+import { metaGraph, activateResource, pauseResource } from '@/services/growth/metaAds/client';
 
 const mockGetAdminDb = getAdminDb as jest.Mock;
 const mockResolveAdContext = resolveAdContext as jest.Mock;
 const mockMetaGraph = metaGraph as jest.Mock;
 const mockActivateResource = activateResource as jest.Mock;
+const mockPauseResource = pauseResource as jest.Mock;
 
 function chainableGet(result: unknown) {
   const q: Record<string, jest.Mock> = {};
@@ -39,6 +44,12 @@ function makeDb(adCampaignsResult: unknown) {
   return { db, addMock };
 }
 
+/**
+ * `docs[0].ref.update` is a FRESH jest.fn() per call — callers that need to
+ * assert on the Firestore status write grab it straight off the returned
+ * snapshot object (`snap.docs[0].ref.update`), same reference the gateway
+ * calls internally via `campaignDocSnap.ref.update(...)`.
+ */
 function approvedSnap(overrides: Record<string, unknown> = {}) {
   return {
     empty: false,
@@ -47,10 +58,13 @@ function approvedSnap(overrides: Record<string, unknown> = {}) {
         data: () => ({
           propertyId: 'prahova-mountain-chalet',
           metaCampaignId: 'camp-1',
+          metaAdSetIds: ['adset-1'],
+          metaAdIds: ['ad-1'],
           status: 'approved',
           spendCapMinor: 50000, // 500 RON
           ...overrides,
         }),
+        ref: { update: jest.fn().mockResolvedValue(undefined) },
       },
     ],
   };
@@ -59,6 +73,23 @@ function approvedSnap(overrides: Record<string, unknown> = {}) {
 const PROPERTY = 'prahova-mountain-chalet';
 const CAMPAIGN = 'camp-1';
 const AD_ACCOUNT = 'act_543311232953437';
+
+/** Ownership-fetch AND post-activation read-back both resolve from one mock, keyed by the `fields` requested. */
+function mockMetaGraphReadBacks(opts?: { accountId?: string; effectiveStatus?: string | false }) {
+  const accountId = opts?.accountId ?? '543311232953437';
+  const effectiveStatus = opts?.effectiveStatus ?? 'ACTIVE';
+  mockMetaGraph.mockImplementation(async (_id: string, callOpts: { params?: Record<string, unknown> }) => {
+    const fields = callOpts.params?.fields;
+    if (fields === 'id,account_id') {
+      return { ok: true, data: { id: CAMPAIGN, account_id: accountId } };
+    }
+    if (fields === 'id,effective_status') {
+      if (effectiveStatus === false) return { ok: false, error: 'read-back-failed' };
+      return { ok: true, data: { id: CAMPAIGN, effective_status: effectiveStatus } };
+    }
+    throw new Error(`unexpected metaGraph call in test, fields=${String(fields)}`);
+  });
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -170,28 +201,189 @@ describe('activateCampaign — live mode (both switches on)', () => {
     expect(mockActivateResource).not.toHaveBeenCalled();
   });
 
-  it('activates when every gate passes, normalizing the act_ prefix for the ownership check', async () => {
-    const { db, addMock } = makeDb(approvedSnap());
-    mockGetAdminDb.mockResolvedValue(db);
-    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
-    // Meta's read-back omits the "act_" prefix on account_id — must still match.
-    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: CAMPAIGN, account_id: '543311232953437' } });
-    mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
+  describe('B1 — activates ALL THREE hierarchy levels', () => {
+    it('activates campaign, then every ad set, then every ad (top-down, in order)', async () => {
+      const snap = approvedSnap();
+      const { db, addMock } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks();
+      mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
 
-    const res = await activateCampaign(PROPERTY, CAMPAIGN, { actor: 'operator-1' });
-    expect(res).toEqual({ status: 'activated' });
-    expect(mockActivateResource).toHaveBeenCalledWith(CAMPAIGN, 'tok', PROPERTY);
-    expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ result: 'activated', actor: 'operator-1' });
+      const res = await activateCampaign(PROPERTY, CAMPAIGN, { actor: 'operator-1' });
+
+      expect(res).toEqual({ status: 'activated' });
+      expect(mockActivateResource).toHaveBeenCalledTimes(3);
+      expect(mockActivateResource).toHaveBeenNthCalledWith(1, 'camp-1', 'tok', PROPERTY);
+      expect(mockActivateResource).toHaveBeenNthCalledWith(2, 'adset-1', 'tok', PROPERTY);
+      expect(mockActivateResource).toHaveBeenNthCalledWith(3, 'ad-1', 'tok', PROPERTY);
+      expect(mockPauseResource).not.toHaveBeenCalled(); // no rollback needed
+      expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ result: 'activated', actor: 'operator-1' });
+    });
+
+    it('activates every id across MULTIPLE ad sets/ads', async () => {
+      const snap = approvedSnap({ metaAdSetIds: ['as-1', 'as-2'], metaAdIds: ['ad-1', 'ad-2'] });
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks();
+      mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+      expect(res).toEqual({ status: 'activated' });
+      expect(mockActivateResource).toHaveBeenCalledTimes(5);
+      const idsInOrder = mockActivateResource.mock.calls.map((c) => c[0]);
+      expect(idsInOrder).toEqual(['camp-1', 'as-1', 'as-2', 'ad-1', 'ad-2']);
+    });
+
+    it('a failure at the AD-SET level rolls back (re-pauses) only the campaign, reverse order, then rejects', async () => {
+      const snap = approvedSnap();
+      const { db, addMock } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks();
+      mockActivateResource.mockImplementation(async (id: string) => {
+        if (id === 'camp-1') return { ok: true, data: { success: true } };
+        return { ok: false, error: 'adset-rejected' }; // adset-1 fails
+      });
+      mockPauseResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+
+      expect(res).toEqual({ status: 'rejected', reason: 'activate-failed:adSet:adset-1:adset-rejected' });
+      expect(mockPauseResource).toHaveBeenCalledTimes(1);
+      expect(mockPauseResource).toHaveBeenCalledWith('camp-1', 'tok', PROPERTY); // rolled back
+      expect(mockActivateResource).toHaveBeenCalledTimes(2); // campaign (succeeded) + adset-1 (failed); ad-1 never attempted
+      expect(snap.docs[0].ref.update).not.toHaveBeenCalled(); // never claims 'active'
+      expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        result: 'rejected',
+        reason: 'activate-failed:adSet:adset-1:adset-rejected',
+      });
+    });
+
+    it('a failure at the AD level rolls back the ad set then the campaign (reverse order)', async () => {
+      const snap = approvedSnap();
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks();
+      mockActivateResource.mockImplementation(async (id: string) => {
+        if (id === 'ad-1') return { ok: false, error: 'ad-rejected' };
+        return { ok: true, data: { success: true } };
+      });
+      mockPauseResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+
+      expect(res).toEqual({ status: 'rejected', reason: 'activate-failed:ad:ad-1:ad-rejected' });
+      expect(mockPauseResource).toHaveBeenCalledTimes(2);
+      // reverse order: most-recently-activated (adset) first, then campaign
+      expect(mockPauseResource).toHaveBeenNthCalledWith(1, 'adset-1', 'tok', PROPERTY);
+      expect(mockPauseResource).toHaveBeenNthCalledWith(2, 'camp-1', 'tok', PROPERTY);
+    });
+
+    it('a rollback pause failure surfaces a louder ROLLBACK-INCOMPLETE reason (chain left partially active) but still resolves and rejects', async () => {
+      const snap = approvedSnap();
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks();
+      mockActivateResource.mockImplementation(async (id: string) => {
+        if (id === 'ad-1') return { ok: false, error: 'ad-rejected' };
+        return { ok: true, data: { success: true } };
+      });
+      mockPauseResource.mockResolvedValue({ ok: false, error: 'pause-also-failed' });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+      // campaign + adset were flipped, ad failed, and BOTH re-pauses failed → 2 still active.
+      expect(res).toEqual({
+        status: 'rejected',
+        reason: 'activate-failed-ROLLBACK-INCOMPLETE(2-still-active):ad:ad-1:ad-rejected',
+      });
+    });
   });
 
-  it('rejects (does not throw) when the un-pause call itself fails', async () => {
+  describe('incomplete-chain guard — refuse to activate a campaign that cannot deliver', () => {
+    it('rejects with incomplete-chain when the doc has no adSet ids (would activate only the campaign)', async () => {
+      const snap = approvedSnap({ metaAdSetIds: [], metaAdIds: ['ad-1'] });
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+      expect(res).toEqual({ status: 'rejected', reason: 'incomplete-chain:missing-adset-or-ad-ids' });
+      // fails before touching Meta (no ownership fetch, no activate)
+      expect(mockActivateResource).not.toHaveBeenCalled();
+    });
+
+    it('rejects with incomplete-chain when the doc has no ad ids', async () => {
+      const snap = approvedSnap({ metaAdSetIds: ['adset-1'], metaAdIds: [] });
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+      expect(res).toEqual({ status: 'rejected', reason: 'incomplete-chain:missing-adset-or-ad-ids' });
+      expect(mockActivateResource).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('B1/S2 — status truth: activation writes adCampaigns.status + effectiveStatus', () => {
+    it('on full success, reads back effective_status and writes status=active + effectiveStatus on the doc', async () => {
+      const snap = approvedSnap();
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks({ effectiveStatus: 'IN_PROCESS' });
+      mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+
+      expect(res).toEqual({ status: 'activated' });
+      expect(snap.docs[0].ref.update).toHaveBeenCalledWith({
+        status: 'active',
+        effectiveStatus: 'IN_PROCESS',
+        updatedAt: 'server-ts',
+      });
+    });
+
+    it('a failed effective_status read-back does NOT flip a successful activation to rejected (best-effort)', async () => {
+      const snap = approvedSnap();
+      const { db } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks({ effectiveStatus: false });
+      mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+
+      expect(res).toEqual({ status: 'activated' });
+      expect(snap.docs[0].ref.update).toHaveBeenCalledWith({ status: 'active', updatedAt: 'server-ts' });
+    });
+
+    it('a failed Firestore status update does NOT flip a successful activation to rejected (Meta already activated)', async () => {
+      const snap = approvedSnap();
+      snap.docs[0].ref.update = jest.fn().mockRejectedValue(new Error('firestore unavailable'));
+      const { db, addMock } = makeDb(snap);
+      mockGetAdminDb.mockResolvedValue(db);
+      mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+      mockMetaGraphReadBacks();
+      mockActivateResource.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const res = await activateCampaign(PROPERTY, CAMPAIGN);
+
+      expect(res).toEqual({ status: 'activated' });
+      expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ result: 'activated' });
+    });
+  });
+
+  it('rejects (does not throw) when the very first un-pause call (the campaign) itself fails', async () => {
     const { db } = makeDb(approvedSnap());
     mockGetAdminDb.mockResolvedValue(db);
     mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
-    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: CAMPAIGN, account_id: '543311232953437' } });
+    mockMetaGraphReadBacks();
     mockActivateResource.mockResolvedValue({ ok: false, error: 'meta-down' });
 
     const res = await activateCampaign(PROPERTY, CAMPAIGN);
-    expect(res).toEqual({ status: 'rejected', reason: 'activate-failed:meta-down' });
+    expect(res).toEqual({ status: 'rejected', reason: 'activate-failed:campaign:camp-1:meta-down' });
+    expect(mockPauseResource).not.toHaveBeenCalled(); // nothing had been activated yet to roll back
   });
 });

--- a/src/services/growth/adComposer.ts
+++ b/src/services/growth/adComposer.ts
@@ -1,0 +1,335 @@
+/**
+ * adComposer — the platform-NEUTRAL compose boundary (Phase 2a Build A, plan
+ * "The seam" + REVISIONS §4/S1/S7/B2/B5/OD6).
+ *
+ * ```
+ * admin/ads (console UI, Build B)  ──►  adComposer (NEUTRAL, this file)  ──►  metaAds/* (Meta ADAPTER)
+ * ```
+ *
+ * `composeAndCreateAd` is the ONLY place a neutral compose request turns into
+ * a Meta-shaped one. Nothing Meta-specific (Graph field names, Meta enum
+ * values, `object_story_spec`) may appear in this file's PUBLIC surface — the
+ * input/output types live in `@/types` (`ComposeAndCreateAdInput`,
+ * `AdObjective`, `AdCallToAction`, `CopyVariant`) and are deliberately generic
+ * so a future TikTok adapter could implement the same neutral contract without
+ * this file changing. The neutral→Meta MAPPING (objective/CTA enums) is
+ * private to this module — it's the one place allowed to know both vocabularies.
+ *
+ * This module also owns the MONEY POLICY that isn't platform-specific (Fable
+ * OD6: "keep approve/activate POLICY — cap arithmetic, MAX budget — in the
+ * neutral layer; only the un-pause MECHANICS are adapter"):
+ *  - `validateDailyBudget` — the server-side `MAX_DAILY_BUDGET_MINOR` ceiling
+ *    (B2), enforced here at compose time. Build B's approve action should
+ *    call the same exported policy helpers rather than re-implement them.
+ *  - `validateApprovalCap` — the approve-time spend-bound invariant (B2):
+ *    `dailyBudgetMinor × ceil(daysToEndTime) × 1.25 ≤ spendCapMinor`. NOT
+ *    called by `composeAndCreateAd` itself (there is no spend cap yet at
+ *    compose time — that's set at approval, Build B); exported for Build B's
+ *    `approveCampaign` action to call.
+ *
+ * `composeAndCreateAd` NEVER touches Firestore for the `adCampaigns` doc
+ * itself (B5) — it only ALLOCATES the id (a pure client-side id generation,
+ * no network write) so it can embed `utm_campaign=<id>` into the creative's
+ * link BEFORE the creative is created, then hands the pre-allocated id to
+ * `createCampaignChain`, which remains the ONE writer of that doc.
+ *
+ * `actor` (who composed this ad) is NOT a parameter here — Build B's server
+ * action must derive it from the authenticated session (`requireSuperAdmin()`
+ * or equivalent), never from a client-supplied value (plan REVISIONS S4).
+ * This module doesn't record an actor at all; `adCampaigns.createdAt` +
+ * Firebase/Next.js server-action auth logs are the provenance trail for the
+ * compose step, and `adExecutionGateway`'s audit log covers activate.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + async functions.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import { isAdsEngineEnabled, getMaxDailyBudgetMinor } from '@/config/growth-ads';
+import type { AdCallToAction, AdObjective, ComposeAndCreateAdInput } from '@/types';
+import { uploadImageToAccount } from './metaAds/adImages';
+import { createCampaignChain, type CreateCampaignChainSpec } from './metaAds/campaignBuilder';
+
+const logger = loggers.ads;
+
+// ---------------------------------------------------------------------------
+// Neutral → Meta mapping (private to this module — the one place allowed to
+// know both vocabularies, S1/S6).
+// ---------------------------------------------------------------------------
+
+/** `'sales'` is 2a's only neutral objective; maps to Meta's OUTCOME_SALES (live-verified, §9c). */
+const OBJECTIVE_TO_META: Record<AdObjective, string> = {
+  sales: 'OUTCOME_SALES',
+};
+
+/**
+ * Only `learn_more` is LIVE-VERIFIED against this account (§9c — it's
+ * `createCreative`'s own default). `book_now`/`contact_us` map to Meta's
+ * documented CTA type constants but have NOT been spike-tested against this
+ * specific ad account — verify before relying on them in production (S6).
+ */
+const CTA_TO_META: Record<AdCallToAction, string> = {
+  learn_more: 'LEARN_MORE',
+  book_now: 'BOOK_TRAVEL',
+  contact_us: 'CONTACT_US',
+};
+
+// ---------------------------------------------------------------------------
+// Neutral money policy (Fable OD6 — lives here, not in the Meta adapter).
+// ---------------------------------------------------------------------------
+
+export type PolicyResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Server-side hard ceiling on daily ad spend (`MAX_DAILY_BUDGET_MINOR`, B2).
+ * A compose form's own "max budget" field is UX only — THIS is the actual
+ * gate, and Build B's approve action should re-check it too (form limits are
+ * never a security boundary).
+ */
+export function validateDailyBudget(dailyBudgetMinor: number): PolicyResult {
+  if (!Number.isFinite(dailyBudgetMinor) || dailyBudgetMinor <= 0) {
+    return { ok: false, reason: 'invalid-daily-budget' };
+  }
+  const max = getMaxDailyBudgetMinor();
+  if (dailyBudgetMinor > max) {
+    return { ok: false, reason: `daily-budget-exceeds-max:${dailyBudgetMinor}>${max}` };
+  }
+  return { ok: true };
+}
+
+export interface ValidateApprovalCapInput {
+  dailyBudgetMinor: number;
+  spendCapMinor: number;
+  /** ISO 8601 — the adset's `end_time`. */
+  endTime: string;
+}
+
+/**
+ * Over-delivery margin applied to the naive `dailyBudget × days` projection
+ * (B2). Meta's EXACT over-delivery behavior is unverified against this
+ * account — 1.25x is a deliberately conservative buffer, not a measured
+ * figure; revisit once real delivery data exists.
+ */
+const OVER_DELIVERY_MARGIN = 1.25;
+
+/**
+ * The approve-time invariant that makes `spendCapMinor` mean something (B2):
+ * `dailyBudgetMinor × ceil(daysToEndTime) × 1.25 ≤ spendCapMinor`. Exported
+ * for Build B's `approveCampaign` action — NOT called by `composeAndCreateAd`
+ * (there is no spend cap to check yet at compose time; the cap is set at
+ * approval).
+ */
+export function validateApprovalCap(input: ValidateApprovalCapInput): PolicyResult {
+  if (!Number.isFinite(input.dailyBudgetMinor) || input.dailyBudgetMinor <= 0) {
+    return { ok: false, reason: 'invalid-daily-budget' };
+  }
+  if (!Number.isFinite(input.spendCapMinor) || input.spendCapMinor <= 0) {
+    return { ok: false, reason: 'invalid-spend-cap' };
+  }
+  const endTimeMs = Date.parse(input.endTime);
+  if (Number.isNaN(endTimeMs)) {
+    return { ok: false, reason: 'invalid-end-time' };
+  }
+  const daysToEndTime = Math.ceil((endTimeMs - Date.now()) / (24 * 60 * 60 * 1000));
+  if (daysToEndTime <= 0) {
+    return { ok: false, reason: 'end-time-not-in-future' };
+  }
+  const projectedSpendMinor = input.dailyBudgetMinor * daysToEndTime * OVER_DELIVERY_MARGIN;
+  if (projectedSpendMinor > input.spendCapMinor) {
+    return { ok: false, reason: `spend-cap-too-low:projected=${projectedSpendMinor}>cap=${input.spendCapMinor}` };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// composeAndCreateAd
+// ---------------------------------------------------------------------------
+
+export type ComposeAndCreateAdStage = 'gate' | 'validation' | 'upload' | 'chain';
+
+export interface ComposeAndCreateAdSuccess {
+  ok: true;
+  adCampaignId: string;
+  metaCampaignId: string;
+  metaAdSetId: string;
+  metaAdId: string;
+  creativeId: string;
+}
+
+export interface ComposeAndCreateAdFailure {
+  ok: false;
+  error: string;
+  stage: ComposeAndCreateAdStage;
+}
+
+export type ComposeAndCreateAdResult = ComposeAndCreateAdSuccess | ComposeAndCreateAdFailure;
+
+/**
+ * Compose a neutral ad request into a full PAUSED Meta chain (draft, zero
+ * spend). Steps (plan §4):
+ *  1. Master-switch gate (`isAdsEngineEnabled`) — same discipline as
+ *     `createCampaignChain`'s own gate; checked here too so a disabled engine
+ *     fails BEFORE any Storage/Meta call, not just before the Firestore write.
+ *  2. `MAX_DAILY_BUDGET_MINOR` policy (B2).
+ *  3. Asset ownership assert — `assetRef.storagePath` MUST live under
+ *     `properties/${propertyId}/` (S7) — refuses to upload/attribute spend to
+ *     an image from a DIFFERENT property's gallery.
+ *  4. Allocate the `adCampaigns` doc id (no Firestore WRITE, B5) and build the
+ *     `utm_campaign=<id>` link — the ROAS join key (H1).
+ *  5. `uploadImageToAccount` — resolves (or reuses, cache-first) the Meta
+ *     `image_hash`.
+ *  6. Map neutral → Meta (objective, CTA, copy[0]) and call
+ *     `createCampaignChain` with the pre-allocated id — IT is the one writer
+ *     of the `adCampaigns` doc.
+ *
+ * Never throws — every stage returns a typed failure with a `stage` tag so a
+ * caller/UI can report precisely where composition stopped.
+ */
+export async function composeAndCreateAd(input: ComposeAndCreateAdInput): Promise<ComposeAndCreateAdResult> {
+  // (1) master-switch gate.
+  if (!isAdsEngineEnabled()) {
+    logger.info('composeAndCreateAd: ads engine disabled — refusing to compose', { propertyId: input.propertyId });
+    return { ok: false, error: 'ads-engine-disabled', stage: 'gate' };
+  }
+
+  // (2) MAX_DAILY_BUDGET_MINOR policy (B2) — server-side, not just the form.
+  const budgetCheck = validateDailyBudget(input.dailyBudgetMinor);
+  if (!budgetCheck.ok) {
+    logger.warn('composeAndCreateAd: daily budget rejected by policy', {
+      propertyId: input.propertyId,
+      dailyBudgetMinor: input.dailyBudgetMinor,
+      reason: budgetCheck.reason,
+    });
+    return { ok: false, error: budgetCheck.reason, stage: 'validation' };
+  }
+
+  // (3) asset ownership assert (S7) — the asset picker in Build B's console
+  // should already filter to this property's own gallery, but a client is
+  // untrusted input; refuse server-side regardless of what the form sent.
+  if (input.assetRef.kind !== 'gallery') {
+    return { ok: false, error: `unsupported-asset-kind:${input.assetRef.kind}`, stage: 'validation' };
+  }
+  const expectedStoragePrefix = `properties/${input.propertyId}/`;
+  if (!input.assetRef.storagePath.startsWith(expectedStoragePrefix)) {
+    logger.warn('composeAndCreateAd: assetRef.storagePath does not belong to propertyId — refusing', {
+      propertyId: input.propertyId,
+      storagePath: input.assetRef.storagePath,
+    });
+    return { ok: false, error: 'asset-ownership-mismatch', stage: 'validation' };
+  }
+
+  // (3b) required-field sanity (TypeScript enforces this at compile time for
+  // in-repo callers; a server action deserializing an external request is not
+  // compile-time-checked, so verify at runtime too).
+  if (!input.endTime || Number.isNaN(Date.parse(input.endTime))) {
+    return { ok: false, error: 'invalid-end-time', stage: 'validation' };
+  }
+  if (!input.copy?.length) {
+    return { ok: false, error: 'no-copy-variant', stage: 'validation' };
+  }
+  const copy = input.copy[0];
+  const metaCta = CTA_TO_META[copy.cta];
+  if (!metaCta) {
+    return { ok: false, error: `unknown-cta:${copy.cta}`, stage: 'validation' };
+  }
+  const metaObjective = OBJECTIVE_TO_META[input.objective];
+  if (!metaObjective) {
+    return { ok: false, error: `unknown-objective:${input.objective}`, stage: 'validation' };
+  }
+
+  // (4) allocate the doc id — NO Firestore write, just id generation (B5) —
+  // so `utm_campaign` can be embedded in the link before the creative exists.
+  let adCampaignId: string;
+  try {
+    const db = await getAdminDb();
+    adCampaignId = db.collection('adCampaigns').doc().id;
+  } catch (error) {
+    logger.warn('composeAndCreateAd: failed to allocate adCampaignId', {
+      propertyId: input.propertyId,
+      error: String(error),
+    });
+    return { ok: false, error: 'id-allocation-failed', stage: 'chain' };
+  }
+
+  // Build the UTM link via the URL API so a landingBaseUrl that ALREADY carries
+  // a query string doesn't produce a malformed `...?a=b?utm_...` link (which
+  // would break the landing page and the ROAS attribution). Also validates the
+  // URL up front.
+  let link: string;
+  try {
+    const u = new URL(input.landingBaseUrl);
+    u.searchParams.set('utm_source', 'facebook');
+    u.searchParams.set('utm_medium', 'paid');
+    u.searchParams.set('utm_campaign', adCampaignId);
+    link = u.toString();
+  } catch {
+    return { ok: false, error: 'invalid-landing-url', stage: 'validation' };
+  }
+
+  // (5) resolve the Meta image_hash (cache-first, per-account dedup).
+  const uploaded = await uploadImageToAccount(input.propertyId, {
+    storagePath: input.assetRef.storagePath,
+    contentHash: input.assetRef.contentHash,
+  });
+  if (!uploaded.ok) {
+    logger.warn('composeAndCreateAd: image upload failed', {
+      propertyId: input.propertyId,
+      adCampaignId,
+      error: uploaded.error,
+    });
+    return { ok: false, error: `upload-failed:${uploaded.error}`, stage: 'upload' };
+  }
+
+  // (6) map neutral → Meta and delegate the whole chain (incl. the ONE
+  // Firestore write) to createCampaignChain.
+  const chainSpec: CreateCampaignChainSpec = {
+    campaign: {
+      name: `${input.propertyId} — ${adCampaignId}`,
+      objective: metaObjective,
+    },
+    adSet: {
+      name: `${input.propertyId} — ${adCampaignId} — ad set`,
+      dailyBudgetMinor: input.dailyBudgetMinor,
+      landingUrl: input.landingBaseUrl,
+      targeting: {
+        geo_locations: { countries: input.targeting.countries },
+        age_min: input.targeting.ageMin,
+        age_max: input.targeting.ageMax,
+      },
+      endTime: input.endTime,
+    },
+    creative: {
+      name: `${input.propertyId} — ${adCampaignId} — creative`,
+      link,
+      message: copy.primary,
+      headline: copy.headline,
+      imageHash: uploaded.data.imageHash,
+      callToActionType: metaCta,
+    },
+    ad: { name: `${input.propertyId} — ${adCampaignId} — ad` },
+  };
+
+  const chainResult = await createCampaignChain(input.propertyId, chainSpec, adCampaignId);
+  if (!chainResult.ok) {
+    logger.warn('composeAndCreateAd: chain creation failed', {
+      propertyId: input.propertyId,
+      adCampaignId,
+      chainStage: chainResult.stage,
+      error: chainResult.error,
+    });
+    return { ok: false, error: `${chainResult.stage}:${chainResult.error}`, stage: 'chain' };
+  }
+
+  logger.info('composeAndCreateAd: created draft ad chain', {
+    propertyId: input.propertyId,
+    adCampaignId: chainResult.adCampaignId,
+  });
+
+  return {
+    ok: true,
+    adCampaignId: chainResult.adCampaignId,
+    metaCampaignId: chainResult.campaignId,
+    metaAdSetId: chainResult.adSetId,
+    metaAdId: chainResult.adId,
+    creativeId: chainResult.creativeId,
+  };
+}

--- a/src/services/growth/adExecutionGateway.ts
+++ b/src/services/growth/adExecutionGateway.ts
@@ -17,10 +17,35 @@
  *     MUST equal the property's resolved ad account. Under a SHARED agency
  *     token, auth alone does not stop `activate(propA, campaignOfB)` from
  *     succeeding — this is the check that does (Fable H2).
+ *  4. **Activate ALL THREE hierarchy levels** (plan REVISIONS B1 — the
+ *     critical fix over Phase 1, which only un-paused the campaign). Meta's
+ *     `effective_status` is a hierarchy ROLLUP: campaign, ad set(s), and
+ *     ad(s) are each independently PAUSED at creation (`createResource`'s
+ *     uniform enforcement), and un-pausing only the campaign leaves the
+ *     ad set(s)/ad(s) PAUSED underneath it — nothing delivers. So this gate
+ *     activates `metaCampaignId` + every id in the trusted `adCampaigns` doc's
+ *     `metaAdSetIds[]` + `metaAdIds[]`, top-down, auditing the whole attempt.
+ *     If ANY activate call fails partway through, it FAILS CLOSED: best-effort
+ *     re-pauses everything already flipped (reverse order) before rejecting —
+ *     the chain must never be left half-active. Un-pausing children ids that
+ *     don't belong to this property is not a NEW risk beyond what step 3
+ *     already covers: they come from the SAME `adCampaigns` doc whose
+ *     `metaCampaignId` just passed the ownership assert, and `createCampaignChain`
+ *     is the only writer of that doc (never user input).
+ *
+ * `lifecycle.pauseCampaign` deliberately stays CAMPAIGN-ONLY and is NOT
+ * mirrored here with a multi-level pause: pausing an ancestor already gates
+ * every descendant (the same rollup, working in the STOP direction) — pausing
+ * only the campaign is sufficient to stop spend, so the STOP primitive is kept
+ * simple. Only the START direction needs every level flipped.
  *
  * Every activation attempt (dry-run, rejected, or activated) writes an audit
  * doc to `adAuditLog` so the money path has a complete trail regardless of
- * outcome — same discipline as `executionGateway`'s messageLog writes.
+ * outcome — same discipline as `executionGateway`'s messageLog writes. On full
+ * success this gateway ALSO writes `adCampaigns.status='active'` (+
+ * `effectiveStatus` from a post-activation read-back) — the gateway, not the
+ * console, owns the money-state truth (plan REVISIONS S2, pulled forward into
+ * this Build-A gateway since Build B's console doesn't exist yet).
  *
  * Plain server module (NOT `'use server'`) — exports types + async functions.
  */
@@ -29,7 +54,7 @@ import { loggers } from '@/lib/logger';
 import type { AdCampaignStatus } from '@/types';
 import { isAdsLiveAllowed } from '@/config/growth-ads';
 import { resolveAdContext } from './metaAds/adContext';
-import { metaGraph, activateResource } from './metaAds/client';
+import { metaGraph, activateResource, pauseResource } from './metaAds/client';
 
 const logger = loggers.ads;
 
@@ -50,6 +75,8 @@ export interface ActivateOptions {
 interface AdCampaignDoc {
   propertyId?: string;
   metaCampaignId?: string;
+  metaAdSetIds?: string[];
+  metaAdIds?: string[];
   status?: AdCampaignStatus;
   spendCapMinor?: number;
 }
@@ -57,6 +84,13 @@ interface AdCampaignDoc {
 interface MetaCampaignReadBack {
   id: string;
   account_id?: string;
+  effective_status?: string;
+}
+
+/** One Meta object to activate/roll-back — `kind` is audit/log context only, Meta doesn't care. */
+interface ActivationTarget {
+  kind: 'campaign' | 'adSet' | 'ad';
+  id: string;
 }
 
 /**
@@ -79,6 +113,9 @@ async function writeAudit(
     result: ActivateStatus;
     reason?: string;
     actor?: string;
+    /** On an `activated` result, the child ids that were flipped — a complete money trail (Fable "audit each"). */
+    adSetIds?: string[];
+    adIds?: string[];
   }
 ): Promise<void> {
   try {
@@ -89,6 +126,8 @@ async function writeAudit(
       result: entry.result,
       reason: entry.reason ?? null,
       actor: entry.actor ?? null,
+      adSetIds: entry.adSetIds ?? null,
+      adIds: entry.adIds ?? null,
       at: FieldValue.serverTimestamp(),
     });
   } catch (error) {
@@ -99,6 +138,39 @@ async function writeAudit(
       error: String(error),
     });
   }
+}
+
+/**
+ * Best-effort re-pause of everything already activated before a mid-chain
+ * failure (B1's fail-closed requirement), in the order given by the caller
+ * (most-recently-activated first). Never throws — mirrors
+ * `campaignBuilder.rollback()`'s "log and continue" discipline exactly: the
+ * ORIGINAL activation failure is what the caller sees, this is best-effort
+ * housekeeping on top of it. A rollback pause failure here is NOT silent,
+ * though — it means a chain could be left partially active, so it's logged at
+ * a level an operator should notice.
+ */
+async function rollbackActivated(
+  propertyId: string,
+  token: string,
+  targets: ActivationTarget[]
+): Promise<number> {
+  let failures = 0;
+  for (const target of targets) {
+    const result = await pauseResource(target.id, token, propertyId);
+    if (result.ok) {
+      logger.info('activateCampaign: rollback pause succeeded', { propertyId, kind: target.kind, id: target.id });
+    } else {
+      failures += 1;
+      logger.error('activateCampaign: rollback pause FAILED — chain may be left partially active', undefined, {
+        propertyId,
+        kind: target.kind,
+        id: target.id,
+        error: result.error,
+      });
+    }
+  }
+  return failures;
 }
 
 async function reject(
@@ -145,12 +217,23 @@ export async function activateCampaign(
   if (snap.empty) {
     return reject(db, propertyId, metaCampaignId, 'no-adCampaigns-doc', actor);
   }
-  const campaignDoc = snap.docs[0].data() as AdCampaignDoc;
+  const campaignDocSnap = snap.docs[0];
+  const campaignDoc = campaignDocSnap.data() as AdCampaignDoc;
   if (campaignDoc.status !== 'approved') {
     return reject(db, propertyId, metaCampaignId, `not-approved:${campaignDoc.status ?? 'unknown'}`, actor);
   }
   if (!campaignDoc.spendCapMinor || campaignDoc.spendCapMinor <= 0) {
     return reject(db, propertyId, metaCampaignId, 'no-spend-cap', actor);
+  }
+
+  // Doc-integrity guard: a campaign doc with no recorded ad set(s)/ad(s) would
+  // activate ONLY the campaign — the exact B1 no-deliver bug, but silent. Refuse
+  // to activate something that provably cannot deliver (createCampaignChain
+  // always records both on success, so an empty array means a malformed doc).
+  const adSetIds = campaignDoc.metaAdSetIds ?? [];
+  const adIds = campaignDoc.metaAdIds ?? [];
+  if (adSetIds.length === 0 || adIds.length === 0) {
+    return reject(db, propertyId, metaCampaignId, 'incomplete-chain:missing-adset-or-ad-ids', actor);
   }
 
   // Resolve context (needed for both the ownership assert and the token).
@@ -185,13 +268,83 @@ export async function activateCampaign(
     return reject(db, propertyId, metaCampaignId, 'ownership-mismatch', actor);
   }
 
-  // All gates passed — activate (un-PAUSE).
-  const activated = await activateResource(metaCampaignId, ctx.token, propertyId);
-  if (!activated.ok) {
-    return reject(db, propertyId, metaCampaignId, `activate-failed:${activated.error}`, actor);
+  // (d) all gates passed — activate ALL THREE hierarchy levels (B1). Top-down:
+  // campaign, then every ad set, then every ad. On the FIRST failure, best-
+  // effort re-pause everything already flipped (reverse order) and reject —
+  // never leave a half-active chain.
+  const targets: ActivationTarget[] = [
+    { kind: 'campaign', id: metaCampaignId },
+    ...adSetIds.map((id): ActivationTarget => ({ kind: 'adSet', id })),
+    ...adIds.map((id): ActivationTarget => ({ kind: 'ad', id })),
+  ];
+
+  const activated: ActivationTarget[] = [];
+  for (const target of targets) {
+    const result = await activateResource(target.id, ctx.token, propertyId);
+    if (!result.ok) {
+      logger.warn('activateCampaign: activation failed mid-chain — rolling back everything flipped so far', {
+        propertyId,
+        metaCampaignId,
+        failedKind: target.kind,
+        failedId: target.id,
+        error: result.error,
+      });
+      const rollbackFailures = await rollbackActivated(propertyId, ctx.token, [...activated].reverse());
+      // If any re-pause failed, the chain is left partially ACTIVE (spending)
+      // while we report a rejection — make that unmistakable in the reason +
+      // audit so an operator manually pauses (the account-level spend limit is
+      // the backstop until they do).
+      const reason =
+        rollbackFailures > 0
+          ? `activate-failed-ROLLBACK-INCOMPLETE(${rollbackFailures}-still-active):${target.kind}:${target.id}:${result.error}`
+          : `activate-failed:${target.kind}:${target.id}:${result.error}`;
+      return reject(db, propertyId, metaCampaignId, reason, actor);
+    }
+    activated.push(target);
   }
 
-  await writeAudit(db, { propertyId, metaCampaignId, result: 'activated', actor });
-  logger.info('activateCampaign: activated', { propertyId, metaCampaignId });
+  // (e) status truth — the gateway owns it, not just Meta (S2). Best-effort:
+  // the Meta-side activation above already fully succeeded, so neither a
+  // failed read-back nor a failed Firestore write may flip the outcome back
+  // to a rejection — that would misreport a real activation as failed.
+  let effectiveStatus: string | undefined;
+  const readBack = await metaGraph<MetaCampaignReadBack>(metaCampaignId, {
+    method: 'GET',
+    params: { fields: 'id,effective_status' },
+    token: ctx.token,
+    propertyId,
+  });
+  if (readBack.ok) {
+    effectiveStatus = readBack.data.effective_status;
+  } else {
+    logger.warn('activateCampaign: post-activation effective_status read-back failed (non-fatal)', {
+      propertyId,
+      metaCampaignId,
+      error: readBack.error,
+    });
+  }
+
+  try {
+    await campaignDocSnap.ref.update({
+      status: 'active',
+      ...(effectiveStatus ? { effectiveStatus } : {}),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  } catch (error) {
+    logger.warn('activateCampaign: Firestore status update failed (Meta-side activation already succeeded)', {
+      propertyId,
+      metaCampaignId,
+      error: String(error),
+    });
+  }
+
+  await writeAudit(db, { propertyId, metaCampaignId, result: 'activated', actor, adSetIds, adIds });
+  logger.info('activateCampaign: activated all levels', {
+    propertyId,
+    metaCampaignId,
+    adSetIds,
+    adIds,
+    effectiveStatus,
+  });
   return { status: 'activated' };
 }

--- a/src/services/growth/metaAds/__tests__/adImages.test.ts
+++ b/src/services/growth/metaAds/__tests__/adImages.test.ts
@@ -1,0 +1,291 @@
+/** @jest-environment node */
+
+jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
+jest.mock('../client', () => ({ uploadImage: jest.fn() }));
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  getAdminStorage: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'server-ts') },
+}));
+
+import { createHash } from 'crypto';
+import { uploadImageToAccount, getImageWidthPx } from '../adImages';
+import { resolveAdContext } from '../adContext';
+import { uploadImage } from '../client';
+import { getAdminDb, getAdminStorage } from '@/lib/firebaseAdminSafe';
+
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockUploadImage = uploadImage as jest.Mock;
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockGetAdminStorage = getAdminStorage as jest.Mock;
+
+const PROPERTY = 'prahova-mountain-chalet';
+const AD_ACCOUNT = 'act_543311232953437';
+
+// ---------------------------------------------------------------------------
+// Synthetic JPEG/PNG byte builders — just enough header for getImageWidthPx
+// to parse; no real pixel data (the parser never looks past the header).
+// ---------------------------------------------------------------------------
+
+function u16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeUInt16BE(n, 0);
+  return b;
+}
+
+function makeJpegBytes(width: number, height: number): Buffer {
+  const payload = Buffer.concat([
+    Buffer.from([8]), // precision
+    u16(height),
+    u16(width),
+    Buffer.from([1]), // num components
+    Buffer.from([1, 0x11, 0]), // one component: id, sampling, quant table
+  ]);
+  const sof0 = Buffer.concat([Buffer.from([0xff, 0xc0]), u16(payload.length + 2), payload]);
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), sof0, Buffer.from([0xff, 0xd9])]);
+}
+
+function makePngBytes(width: number, height: number): Buffer {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(13, 0);
+  const type = Buffer.from('IHDR', 'ascii');
+  const w = Buffer.alloc(4);
+  w.writeUInt32BE(width, 0);
+  const h = Buffer.alloc(4);
+  h.writeUInt32BE(height, 0);
+  const rest = Buffer.from([8, 6, 0, 0, 0]); // depth, color type, compression, filter, interlace
+  const crc = Buffer.alloc(4);
+  return Buffer.concat([sig, len, type, w, h, rest, crc]);
+}
+
+// ---------------------------------------------------------------------------
+// Fake Admin SDK layers
+// ---------------------------------------------------------------------------
+
+function makeFakeDb() {
+  const store = new Map<string, Record<string, unknown>>();
+  const db = {
+    collection: jest.fn((name: string) => {
+      if (name !== 'adImageCache') throw new Error(`unexpected collection in test: ${name}`);
+      return {
+        doc: jest.fn((id: string) => ({
+          get: jest.fn(async () => ({
+            exists: store.has(id),
+            data: () => store.get(id),
+          })),
+          set: jest.fn(async (data: Record<string, unknown>) => {
+            store.set(id, data);
+          }),
+        })),
+      };
+    }),
+  };
+  return { db, store };
+}
+
+function makeFakeStorage(bytesOrError: Buffer | Error) {
+  const download = jest.fn(async () => {
+    if (bytesOrError instanceof Error) throw bytesOrError;
+    return [bytesOrError];
+  });
+  const file = jest.fn(() => ({ download }));
+  const storage = { bucket: jest.fn(() => ({ file })) };
+  return { storage, file, download };
+}
+
+const REAL_JPEG = makeJpegBytes(2048, 1536); // matches the §9d spike image
+const REAL_HASH = createHash('sha256').update(REAL_JPEG).digest('hex');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, token: 'tok' });
+});
+
+describe('getImageWidthPx — minimal JPEG/PNG header parser', () => {
+  it('reads width from a JPEG SOF0 marker', () => {
+    expect(getImageWidthPx(makeJpegBytes(2048, 1536))).toBe(2048);
+  });
+
+  it('reads width from a PNG IHDR chunk', () => {
+    expect(getImageWidthPx(makePngBytes(1200, 800))).toBe(1200);
+  });
+
+  it('returns undefined for bytes that are neither JPEG nor PNG', () => {
+    expect(getImageWidthPx(Buffer.from('not an image'))).toBeUndefined();
+  });
+});
+
+describe('uploadImageToAccount — no ad context', () => {
+  it('returns {ok:false,error:"no-ad-context"} without touching Storage/Firestore/Meta', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/x/images/a.jpg' });
+    expect(res).toEqual({ ok: false, error: 'no-ad-context' });
+    expect(mockGetAdminDb).not.toHaveBeenCalled();
+    expect(mockGetAdminStorage).not.toHaveBeenCalled();
+    expect(mockUploadImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadImageToAccount — cache hit (pre-download fast path)', () => {
+  it('returns the cached hash and never touches Storage or Meta', async () => {
+    const { db, store } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    store.set(`meta_543311232953437_${REAL_HASH}`, { imageHash: 'cached-hash-1' });
+
+    const res = await uploadImageToAccount(PROPERTY, {
+      storagePath: 'properties/prahova-mountain-chalet/images/a.jpg',
+      contentHash: REAL_HASH,
+    });
+
+    expect(res).toEqual({ ok: true, data: { imageHash: 'cached-hash-1' } });
+    expect(mockGetAdminStorage).not.toHaveBeenCalled();
+    expect(mockUploadImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadImageToAccount — cache miss, upload, and cache write', () => {
+  it('downloads, guards, uploads via the client, and writes the cache under the VERIFIED hash', async () => {
+    const { db, store } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const { storage, file } = makeFakeStorage(REAL_JPEG);
+    mockGetAdminStorage.mockResolvedValue(storage);
+    mockUploadImage.mockResolvedValue({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+
+    const res = await uploadImageToAccount(PROPERTY, {
+      storagePath: 'properties/prahova-mountain-chalet/images/a.jpg',
+    });
+
+    expect(res).toEqual({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+    expect(file).toHaveBeenCalledWith('properties/prahova-mountain-chalet/images/a.jpg');
+    expect(mockUploadImage).toHaveBeenCalledTimes(1);
+    expect(mockUploadImage).toHaveBeenCalledWith(
+      AD_ACCOUNT,
+      'tok',
+      expect.objectContaining({ bytes: REAL_JPEG, filename: 'a.jpg', contentType: 'image/jpeg' }),
+      PROPERTY
+    );
+    // cache written under the accountId-normalized (no "act_"), verified-hash key
+    expect(store.get(`meta_543311232953437_${REAL_HASH}`)).toMatchObject({
+      platform: 'meta',
+      accountId: '543311232953437',
+      contentHash: REAL_HASH,
+      imageHash: 'fresh-hash-1',
+    });
+  });
+
+  it('dedups: a second upload of the SAME bytes (no pre-given hash) hits the post-download cache and never re-calls Meta', async () => {
+    const { db } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const { storage } = makeFakeStorage(REAL_JPEG);
+    mockGetAdminStorage.mockResolvedValue(storage);
+    mockUploadImage.mockResolvedValue({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+
+    const first = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.jpg' });
+    const second = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/b.jpg' });
+
+    expect(first).toEqual({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+    expect(second).toEqual({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+    expect(mockUploadImage).toHaveBeenCalledTimes(1); // second call was a cache hit
+  });
+
+  it('a stale/wrong caller-supplied contentHash does not prevent finding the real cached entry post-download', async () => {
+    const { db, store } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    store.set(`meta_543311232953437_${REAL_HASH}`, { imageHash: 'already-cached-hash' });
+    const { storage } = makeFakeStorage(REAL_JPEG);
+    mockGetAdminStorage.mockResolvedValue(storage);
+
+    const res = await uploadImageToAccount(PROPERTY, {
+      storagePath: 'properties/prahova-mountain-chalet/images/a.jpg',
+      contentHash: 'not-the-real-hash',
+    });
+
+    expect(res).toEqual({ ok: true, data: { imageHash: 'already-cached-hash' } });
+    expect(mockUploadImage).not.toHaveBeenCalled(); // recovered via the post-download verified-hash check
+  });
+});
+
+describe('uploadImageToAccount — size guard (30MB)', () => {
+  it('rejects an oversized image before calling Meta', async () => {
+    const { db } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const oversized = Buffer.alloc(30 * 1024 * 1024 + 1);
+    const { storage } = makeFakeStorage(oversized);
+    mockGetAdminStorage.mockResolvedValue(storage);
+
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.jpg' });
+    expect(res).toEqual({ ok: false, error: 'image-too-large' });
+    expect(mockUploadImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadImageToAccount — width guard (min 600px)', () => {
+  it('rejects an image narrower than 600px before calling Meta', async () => {
+    const { db } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const narrow = makeJpegBytes(400, 300);
+    const { storage } = makeFakeStorage(narrow);
+    mockGetAdminStorage.mockResolvedValue(storage);
+
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.jpg' });
+    expect(res).toEqual({ ok: false, error: 'image-too-narrow' });
+    expect(mockUploadImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file whose width cannot be determined (unsupported format)', async () => {
+    const { db } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const { storage } = makeFakeStorage(Buffer.from('not an image, no header'));
+    mockGetAdminStorage.mockResolvedValue(storage);
+
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.gif' });
+    expect(res).toEqual({ ok: false, error: 'image-too-narrow' });
+    expect(mockUploadImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadImageToAccount — Storage failure', () => {
+  it('returns a typed failure (never throws) when the Storage download fails', async () => {
+    const { db } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const { storage } = makeFakeStorage(new Error('bucket unreachable'));
+    mockGetAdminStorage.mockResolvedValue(storage);
+
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.jpg' });
+    expect(res).toEqual({ ok: false, error: 'storage-download-failed' });
+    expect(mockUploadImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadImageToAccount — Meta upload failure', () => {
+  it('propagates the client GraphResult failure as-is', async () => {
+    const { db } = makeFakeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const { storage } = makeFakeStorage(REAL_JPEG);
+    mockGetAdminStorage.mockResolvedValue(storage);
+    mockUploadImage.mockResolvedValue({ ok: false, error: 'meta-down' });
+
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.jpg' });
+    expect(res).toEqual({ ok: false, error: 'meta-down' });
+  });
+});
+
+describe('uploadImageToAccount — cache write failure is best-effort', () => {
+  it('still returns ok:true with the imageHash even if writing the cache doc throws', async () => {
+    mockGetAdminDb.mockResolvedValue({
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({
+          get: jest.fn().mockResolvedValue({ exists: false, data: () => undefined }),
+          set: jest.fn().mockRejectedValue(new Error('firestore unavailable')),
+        })),
+      })),
+    });
+    const { storage } = makeFakeStorage(REAL_JPEG);
+    mockGetAdminStorage.mockResolvedValue(storage);
+    mockUploadImage.mockResolvedValue({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+
+    const res = await uploadImageToAccount(PROPERTY, { storagePath: 'properties/prahova-mountain-chalet/images/a.jpg' });
+    expect(res).toEqual({ ok: true, data: { imageHash: 'fresh-hash-1' } });
+  });
+});

--- a/src/services/growth/metaAds/__tests__/campaignBuilder.test.ts
+++ b/src/services/growth/metaAds/__tests__/campaignBuilder.test.ts
@@ -59,13 +59,15 @@ function mockMetaResponses() {
 
 function makeAdminDb() {
   const addMock = jest.fn().mockResolvedValue({ id: 'adcamp-doc-1' });
+  const createMock = jest.fn().mockResolvedValue(undefined);
+  const docMock = jest.fn((_id: string) => ({ create: createMock }));
   const db = {
     collection: jest.fn((name: string) => {
-      if (name === 'adCampaigns') return { add: addMock };
+      if (name === 'adCampaigns') return { add: addMock, doc: docMock };
       throw new Error(`unexpected collection read in test: ${name}`);
     }),
   };
-  return { db, addMock };
+  return { db, addMock, createMock, docMock };
 }
 
 const CHAIN_SPEC = {
@@ -165,6 +167,7 @@ describe('createCampaignChain — engine enabled', () => {
         message: CHAIN_SPEC.creative.message,
         image_hash: 'abc123hash',
         call_to_action: { type: 'LEARN_MORE' },
+        use_flexible_image_aspect_ratio: true,
       },
     });
 
@@ -293,5 +296,134 @@ describe('createCampaignChain — engine enabled', () => {
     expect(String(deletes[1][0])).toContain('meta-creative-1');
     expect(String(deletes[2][0])).toContain('meta-adset-1');
     expect(String(deletes[3][0])).toContain('meta-campaign-1');
+  });
+
+  it('threads instagram_user_id + headline (link_data.name) when the context/spec provide them (§9d)', async () => {
+    mockResolveAdContext.mockResolvedValue({
+      adAccountId: AD_ACCOUNT,
+      pageId: PAGE_ID,
+      instagramActorId: '17841435421272996',
+      token: 'tok',
+    });
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const specWithHeadline = { ...CHAIN_SPEC, creative: { ...CHAIN_SPEC.creative, headline: 'Book your escape' } };
+    await createCampaignChain(PROPERTY, specWithHeadline);
+
+    const [, creativeInit] = findCall('adcreatives');
+    const creativeBody = new URLSearchParams(creativeInit.body as string);
+    expect(JSON.parse(creativeBody.get('object_story_spec') as string)).toEqual({
+      page_id: PAGE_ID,
+      instagram_user_id: '17841435421272996',
+      link_data: {
+        link: CHAIN_SPEC.creative.link,
+        message: CHAIN_SPEC.creative.message,
+        image_hash: 'abc123hash',
+        call_to_action: { type: 'LEARN_MORE' },
+        use_flexible_image_aspect_ratio: true,
+        name: 'Book your escape',
+      },
+    });
+  });
+
+  it('threads adSet end_time/start_time when supplied (§9d — the 2a spend bound, B2)', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const specWithEndTime = {
+      ...CHAIN_SPEC,
+      adSet: { ...CHAIN_SPEC.adSet, startTime: '2026-07-10T00:00:00Z', endTime: '2026-07-17T00:00:00Z' },
+    };
+    await createCampaignChain(PROPERTY, specWithEndTime);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    expect(adSetBody.get('start_time')).toBe('2026-07-10T00:00:00Z');
+    expect(adSetBody.get('end_time')).toBe('2026-07-17T00:00:00Z');
+  });
+
+  it('omits end_time/start_time entirely when not supplied (backward compatible)', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    await createCampaignChain(PROPERTY, CHAIN_SPEC);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    expect(adSetBody.has('start_time')).toBe(false);
+    expect(adSetBody.has('end_time')).toBe(false);
+  });
+
+  it('threads a caller-supplied campaign objective (defaults to OUTCOME_SALES otherwise)', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const specWithObjective = { ...CHAIN_SPEC, campaign: { ...CHAIN_SPEC.campaign, objective: 'OUTCOME_TRAFFIC' } };
+    await createCampaignChain(PROPERTY, specWithObjective);
+
+    const [, campaignInit] = findCall('campaigns');
+    const campaignBody = new URLSearchParams(campaignInit.body as string);
+    expect(campaignBody.get('objective')).toBe('OUTCOME_TRAFFIC');
+  });
+});
+
+describe('createCampaignChain — optional pre-allocated adCampaignId (plan REVISIONS B5)', () => {
+  beforeEach(() => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, pageId: PAGE_ID, token: 'tok' });
+    mockGetPixelIdForProperty.mockResolvedValue('pixel-123');
+    mockMetaResponses();
+  });
+
+  it('writes via db.collection("adCampaigns").doc(id).create() — NOT .add() — when an id is supplied', async () => {
+    const { db, addMock, createMock, docMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC, 'pre-allocated-id-1');
+
+    expect(res).toMatchObject({ ok: true, adCampaignId: 'pre-allocated-id-1' });
+    expect(docMock).toHaveBeenCalledWith('pre-allocated-id-1');
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(createMock.mock.calls[0][0]).toMatchObject({
+      propertyId: PROPERTY,
+      metaCampaignId: 'meta-campaign-1',
+      status: 'draft',
+    });
+    expect(addMock).not.toHaveBeenCalled(); // never falls back to .add() when an id is given
+  });
+
+  it('keeps the exact .add() behavior when NO id is supplied (backward-compatible, Phase-1 harness)', async () => {
+    const { db, addMock, createMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC);
+
+    expect(res).toMatchObject({ ok: true, adCampaignId: 'adcamp-doc-1' });
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('a double-submit (.create() rejects with already-exists) rolls back the full Meta chain like any other Firestore-stage failure', async () => {
+    const addMock = jest.fn();
+    const createMock = jest.fn().mockRejectedValue(new Error('ALREADY_EXISTS: document already exists'));
+    const docMock = jest.fn(() => ({ create: createMock }));
+    const db = {
+      collection: jest.fn((name: string) => {
+        if (name === 'adCampaigns') return { add: addMock, doc: docMock };
+        throw new Error(`unexpected collection read in test: ${name}`);
+      }),
+    };
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await createCampaignChain(PROPERTY, CHAIN_SPEC, 'retried-id');
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.stage).toBe('firestore');
+      expect(res.error).toContain('ALREADY_EXISTS');
+    }
+
+    const deletes = findDeleteCalls();
+    expect(deletes).toHaveLength(4); // full chain rolled back, same as any other Firestore-stage failure
   });
 });

--- a/src/services/growth/metaAds/__tests__/client.test.ts
+++ b/src/services/growth/metaAds/__tests__/client.test.ts
@@ -1,5 +1,13 @@
 /** @jest-environment node */
-import { metaGraph, createResource, pauseResource, activateResource, deleteResource, GRAPH_API_VERSION } from '../client';
+import {
+  metaGraph,
+  createResource,
+  pauseResource,
+  activateResource,
+  deleteResource,
+  uploadImage,
+  GRAPH_API_VERSION,
+} from '../client';
 
 const mockFetch = global.fetch as jest.Mock;
 
@@ -106,6 +114,65 @@ describe('pauseResource / activateResource — status transitions', () => {
     expect(String(url)).toContain('120210000000001');
     const body = new URLSearchParams(init.body as string);
     expect(body.get('status')).toBe('ACTIVE');
+  });
+});
+
+describe('uploadImage — multipart upload (plan REVISIONS B4, contract §9d)', () => {
+  const FILE = { bytes: Buffer.from([1, 2, 3, 4]), filename: 'a.jpg', contentType: 'image/jpeg' };
+
+  it('POSTs multipart/form-data to <adAccountId>/adimages with the token in the header, never the URL/body', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ images: { source: { hash: 'img-hash-1' } } }) });
+    await uploadImage('act_543311232953437', 'SECRET-TOKEN', FILE, 'prahova-mountain-chalet');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain(`act_543311232953437/adimages`);
+    expect(String(url)).toContain(`graph.facebook.com/${GRAPH_API_VERSION}/`);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer SECRET-TOKEN');
+    expect(String(url)).not.toContain('SECRET-TOKEN');
+    expect(init.body).toBeInstanceOf(FormData);
+  });
+
+  it('extracts the hash from whatever single field key Meta echoes back', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ images: { 'some-field-name': { hash: 'img-hash-2', width: 2048, height: 1536 } } }),
+    });
+    const result = await uploadImage('act_1', 'tok', FILE);
+    expect(result).toEqual({ ok: true, data: { imageHash: 'img-hash-2' } });
+  });
+
+  it('never returns the temporary `url` field — only the hash', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ images: { source: { hash: 'img-hash-3', url: 'https://temp.example/img.jpg' } } }),
+    });
+    const result = await uploadImage('act_1', 'tok', FILE);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ imageHash: 'img-hash-3' });
+      expect(result.data).not.toHaveProperty('url');
+    }
+  });
+
+  it('returns {ok:false} without throwing when the response has no hash', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ images: {} }) });
+    const result = await uploadImage('act_1', 'tok', FILE);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('no-hash-in-response');
+  });
+
+  it('returns a typed {ok:false,error} on a non-OK response, never throws', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, text: async () => 'bad image' });
+    const result = await uploadImage('act_1', 'tok', FILE);
+    expect(result).toEqual({ ok: false, error: 'bad image', status: 400 });
+  });
+
+  it('returns a typed {ok:false,error} on a network error, never throws', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    const result = await uploadImage('act_1', 'tok', FILE);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('network down');
   });
 });
 

--- a/src/services/growth/metaAds/__tests__/insights.test.ts
+++ b/src/services/growth/metaAds/__tests__/insights.test.ts
@@ -3,7 +3,7 @@
 jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
 jest.mock('../client', () => ({ metaGraph: jest.fn() }));
 
-import { getInsights } from '../insights';
+import { getInsights, getEffectiveStatus } from '../insights';
 import { resolveAdContext } from '../adContext';
 import { metaGraph } from '../client';
 
@@ -169,5 +169,43 @@ describe('getInsights — parsing', () => {
       ok: true,
       data: { spend: 0, impressions: 0, clicks: 0, purchases: 0, purchaseValue: 0, roas: 0 },
     });
+  });
+});
+
+describe('getEffectiveStatus — OD4 on-demand drift/REJECTED read-back', () => {
+  it('returns {ok:false,error:"no-ad-context"} without calling Meta for an unconfigured property', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await getEffectiveStatus(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({ ok: false, error: 'no-ad-context' });
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+  });
+
+  it('GETs the object with fields=id,effective_status and returns the parsed value', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: OBJECT_ID, effective_status: 'REJECTED' } });
+
+    const res = await getEffectiveStatus(PROPERTY, OBJECT_ID);
+
+    expect(mockMetaGraph).toHaveBeenCalledWith(OBJECT_ID, {
+      method: 'GET',
+      params: { fields: 'id,effective_status' },
+      token: 'tok',
+      propertyId: PROPERTY,
+    });
+    expect(res).toEqual({ ok: true, data: { effectiveStatus: 'REJECTED' } });
+  });
+
+  it('falls back to "UNKNOWN" when Meta omits effective_status on an otherwise-ok response', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+    mockMetaGraph.mockResolvedValue({ ok: true, data: { id: OBJECT_ID } });
+    const res = await getEffectiveStatus(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({ ok: true, data: { effectiveStatus: 'UNKNOWN' } });
+  });
+
+  it('propagates a Graph API failure without throwing', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'tok' });
+    mockMetaGraph.mockResolvedValue({ ok: false, error: 'timeout' });
+    const res = await getEffectiveStatus(PROPERTY, OBJECT_ID);
+    expect(res).toEqual({ ok: false, error: 'timeout' });
   });
 });

--- a/src/services/growth/metaAds/adImages.ts
+++ b/src/services/growth/metaAds/adImages.ts
@@ -1,0 +1,289 @@
+/**
+ * Per-account image upload + dedup cache — Phase 2a Build A (plan REVISIONS
+ * B4; contract verified live-PAUSED against the account, docs/meta-ads-
+ * infrastructure-2026.md §9d/§10).
+ *
+ * `uploadImageToAccount` is the ONLY caller of `client.ts`'s `uploadImage`
+ * helper. It owns three responsibilities the low-level upload call doesn't:
+ *
+ *  1. **Per-(platform, ad account, content hash) cache** in Firestore
+ *     `adImageCache` — `image_hash` is (very likely) ACCOUNT-SCOPED (§10), so
+ *     the cache key includes the ad account id (with any `act_` prefix
+ *     normalized off), not just the image bytes. A cache hit skips BOTH the
+ *     Storage read and the Meta upload entirely.
+ *  2. **The size/width guard** (§10: max 30MB, min width 600px) — applied to
+ *     the ACTUAL downloaded bytes, before any upload attempt. Meta's own
+ *     limits exist regardless of what we check, but failing closed here means
+ *     a bad asset never reaches a live API call.
+ *  3. **Computing the real `contentHash`** (sha256 of the downloaded bytes).
+ *     A caller (adComposer) may pass a `contentHash` it already knows, and
+ *     that is used as a FAST pre-download cache probe — but it is never
+ *     trusted as the record of truth: after downloading, this module always
+ *     recomputes sha256 from the actual bytes and uses THAT for the final
+ *     cache write (and a second cache probe, in case the caller's hash was
+ *     stale/wrong but the real bytes were already cached under the correct
+ *     one). This mirrors the "never trust a caller-supplied identity for a
+ *     security/dedup-relevant decision" discipline used throughout this
+ *     module tree (e.g. `adExecutionGateway`'s ownership assert).
+ *
+ * Never throws (`GraphResult` discipline, same as the rest of `metaAds/*`) —
+ * a Storage hiccup, a malformed image, or a Firestore cache-write failure
+ * must never crash `adComposer`'s critical path. A cache-write failure after
+ * a SUCCESSFUL Meta upload is logged and swallowed (best-effort) rather than
+ * turned into a failure — the image already exists in the ad account; losing
+ * the cache entry only costs a redundant future upload, never correctness.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + async functions.
+ */
+import { createHash } from 'crypto';
+import { getAdminDb, getAdminStorage, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import { resolveAdContext } from './adContext';
+import { uploadImage, type GraphResult } from './client';
+
+const logger = loggers.ads;
+
+const PLATFORM = 'meta' as const;
+
+/** Max upload size — 30MB (docs/meta-ads-infrastructure-2026.md §10). Checked against the RAW bytes, before any base64 inflation (we don't base64 — multipart — but the byte-count ceiling is the same limit). */
+const MAX_IMAGE_BYTES = 30 * 1024 * 1024;
+
+/** Min accepted width in px (§10). Applied to whatever width we can determine from the file's own header — an image we can't parse is rejected rather than assumed valid. */
+const MIN_IMAGE_WIDTH_PX = 600;
+
+export interface UploadImageInput {
+  /** Full Firebase Storage path — NEVER a thumbnail (plan REVISIONS B4). */
+  storagePath: string;
+  /**
+   * Optional caller-known sha256 of the same bytes — used ONLY as a fast
+   * pre-download cache probe. The authoritative hash is always recomputed
+   * from the downloaded bytes (see module doc comment).
+   */
+  contentHash?: string;
+}
+
+/** Meta returns `account_id` without the `act_` prefix; our config carries it with. Normalize both to the same bare form for the cache key (mirrors `adExecutionGateway`'s `normalizeAccountId`). */
+function normalizeAccountId(id: string): string {
+  return id.startsWith('act_') ? id.slice(4) : id;
+}
+
+function cacheDocId(accountId: string, contentHash: string): string {
+  return `${PLATFORM}_${normalizeAccountId(accountId)}_${contentHash}`;
+}
+
+type AdminDb = Awaited<ReturnType<typeof getAdminDb>>;
+
+async function readCachedImageHash(
+  db: AdminDb,
+  accountId: string,
+  contentHash: string
+): Promise<string | undefined> {
+  try {
+    const snap = await db.collection('adImageCache').doc(cacheDocId(accountId, contentHash)).get();
+    if (!snap.exists) return undefined;
+    const imageHash = (snap.data() as { imageHash?: string } | undefined)?.imageHash;
+    return imageHash || undefined;
+  } catch (error) {
+    // Fail OPEN to "cache miss" (not to an error) — a cache read failure must
+    // never block the upload path; worst case we re-upload an already-cached
+    // image, which is wasteful but not incorrect.
+    logger.warn('uploadImageToAccount: cache read failed — treating as a miss', { error: String(error) });
+    return undefined;
+  }
+}
+
+async function writeCachedImageHash(
+  db: AdminDb,
+  accountId: string,
+  contentHash: string,
+  imageHash: string,
+  propertyId: string
+): Promise<void> {
+  try {
+    await db
+      .collection('adImageCache')
+      .doc(cacheDocId(accountId, contentHash))
+      .set({
+        platform: PLATFORM,
+        accountId: normalizeAccountId(accountId),
+        contentHash,
+        imageHash,
+        uploadedAt: FieldValue.serverTimestamp(),
+      });
+  } catch (error) {
+    // Best-effort — the Meta upload already succeeded; losing the cache write
+    // only costs a redundant future upload, never correctness (see module doc).
+    logger.warn('uploadImageToAccount: cache write failed (upload already succeeded, continuing)', {
+      propertyId,
+      error: String(error),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal image-width readers — JPEG/PNG only (the two formats Meta accepts,
+// §10). Deliberately NOT a full decoder/dependency: we only need the pixel
+// width out of the header to enforce the 600px floor before ever uploading.
+// ---------------------------------------------------------------------------
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function readPngWidth(bytes: Buffer): number | undefined {
+  if (bytes.length < 24 || !bytes.subarray(0, 8).equals(PNG_SIGNATURE)) return undefined;
+  // IHDR is always the first chunk: [len(4)][type(4)="IHDR"][width(4)][height(4)]...
+  if (bytes.toString('ascii', 12, 16) !== 'IHDR') return undefined;
+  return bytes.readUInt32BE(16);
+}
+
+// SOFn (Start Of Frame) markers that carry width/height — excludes 0xC4 (DHT),
+// 0xC8 (JPG extension, unused), 0xCC (DAC) which are numerically in-range but
+// are NOT frame markers.
+const JPEG_SOF_MARKERS = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+
+function readJpegWidth(bytes: Buffer): number | undefined {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return undefined; // SOI
+
+  let offset = 2;
+  while (offset + 1 < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset += 1; // resync — not a marker boundary
+      continue;
+    }
+    const marker = bytes[offset + 1];
+    // Markers with no length/payload: SOI, standalone (TEM/RSTn).
+    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      offset += 2;
+      continue;
+    }
+    if (marker === 0xd9) return undefined; // EOI — reached the end without a SOF
+    if (offset + 3 >= bytes.length) return undefined;
+
+    const segmentLength = bytes.readUInt16BE(offset + 2); // includes the 2 length bytes themselves
+    if (JPEG_SOF_MARKERS.has(marker)) {
+      if (offset + 8 >= bytes.length) return undefined;
+      // [FF][marker][len:2][precision:1][height:2][width:2]...
+      return bytes.readUInt16BE(offset + 7);
+    }
+    offset += 2 + segmentLength;
+  }
+  return undefined;
+}
+
+/** Best-effort pixel width from a JPEG or PNG header. Returns undefined for anything else or a malformed/truncated file — treated as "can't verify, reject" by the caller. */
+export function getImageWidthPx(bytes: Buffer): number | undefined {
+  return readPngWidth(bytes) ?? readJpegWidth(bytes);
+}
+
+function contentTypeForPath(storagePath: string): string {
+  return storagePath.toLowerCase().endsWith('.png') ? 'image/png' : 'image/jpeg';
+}
+
+/**
+ * Resolve (upload-or-reuse) a Meta `image_hash` for a gallery image, scoped to
+ * the property's ad account. Never throws. See module doc comment for the
+ * cache-then-download-then-verify sequencing.
+ */
+export async function uploadImageToAccount(
+  propertyId: string,
+  image: UploadImageInput
+): Promise<GraphResult<{ imageHash: string }>> {
+  try {
+    const ctx = await resolveAdContext(propertyId);
+    if (!ctx) {
+      logger.warn('uploadImageToAccount: no ad context for property — refusing to upload', { propertyId });
+      return { ok: false, error: 'no-ad-context' };
+    }
+
+    const db = await getAdminDb();
+
+    // Fast path: a caller-supplied hash lets us skip the Storage download
+    // entirely on a hit (plan: "cache-check FIRST ... BEFORE uploading").
+    if (image.contentHash) {
+      const cached = await readCachedImageHash(db, ctx.adAccountId, image.contentHash);
+      if (cached) {
+        logger.info('uploadImageToAccount: cache hit (pre-download)', { propertyId, storagePath: image.storagePath });
+        return { ok: true, data: { imageHash: cached } };
+      }
+    }
+
+    // Miss (or no hash given up front) — every downstream decision (the real
+    // cache key, the size/width guard) is derived from the ACTUAL bytes, never
+    // from an unverified caller-supplied hash.
+    let bytes: Buffer;
+    try {
+      const storage = await getAdminStorage();
+      const [downloaded] = await storage.bucket().file(image.storagePath).download();
+      bytes = downloaded;
+    } catch (error) {
+      logger.warn('uploadImageToAccount: Storage download failed', {
+        propertyId,
+        storagePath: image.storagePath,
+        error: String(error),
+      });
+      return { ok: false, error: 'storage-download-failed' };
+    }
+
+    if (bytes.length > MAX_IMAGE_BYTES) {
+      logger.warn('uploadImageToAccount: image exceeds 30MB — refusing to upload', {
+        propertyId,
+        storagePath: image.storagePath,
+        bytes: bytes.length,
+      });
+      return { ok: false, error: 'image-too-large' };
+    }
+
+    const width = getImageWidthPx(bytes);
+    if (!width || width < MIN_IMAGE_WIDTH_PX) {
+      logger.warn('uploadImageToAccount: image narrower than 600px (or width undeterminable) — refusing to upload', {
+        propertyId,
+        storagePath: image.storagePath,
+        width,
+      });
+      return { ok: false, error: 'image-too-narrow' };
+    }
+
+    const contentHash = createHash('sha256').update(bytes).digest('hex');
+
+    // Re-check the cache under the VERIFIED hash — catches the case where the
+    // caller's hash (checked above, if any) was stale/wrong but these exact
+    // bytes are already cached under their real hash.
+    const verifiedHit = await readCachedImageHash(db, ctx.adAccountId, contentHash);
+    if (verifiedHit) {
+      logger.info('uploadImageToAccount: cache hit (post-download, verified hash)', {
+        propertyId,
+        storagePath: image.storagePath,
+      });
+      return { ok: true, data: { imageHash: verifiedHit } };
+    }
+
+    const filename = image.storagePath.split('/').pop() || 'image.jpg';
+    const uploaded = await uploadImage(
+      ctx.adAccountId,
+      ctx.token,
+      { bytes, filename, contentType: contentTypeForPath(image.storagePath) },
+      propertyId
+    );
+    if (!uploaded.ok) {
+      logger.warn('uploadImageToAccount: Meta upload failed', {
+        propertyId,
+        storagePath: image.storagePath,
+        error: uploaded.error,
+      });
+      return uploaded;
+    }
+
+    await writeCachedImageHash(db, ctx.adAccountId, contentHash, uploaded.data.imageHash, propertyId);
+
+    logger.info('uploadImageToAccount: uploaded and cached', {
+      propertyId,
+      storagePath: image.storagePath,
+      imageHash: uploaded.data.imageHash,
+    });
+    return { ok: true, data: { imageHash: uploaded.data.imageHash } };
+  } catch (error) {
+    // Safety net — every expected failure above already returns cleanly; this
+    // only catches something genuinely unexpected (never throw, plan-wide rule).
+    logger.warn('uploadImageToAccount: unexpected error', { propertyId, error: String(error) });
+    return { ok: false, error: `unexpected:${String(error)}` };
+  }
+}

--- a/src/services/growth/metaAds/campaignBuilder.ts
+++ b/src/services/growth/metaAds/campaignBuilder.ts
@@ -43,6 +43,15 @@ const logger = loggers.ads;
 
 export interface CreateCampaignSpec {
   name: string;
+  /**
+   * Meta objective string, e.g. `'OUTCOME_SALES'` — defaults to `'OUTCOME_SALES'`
+   * (2a's only supported objective). This module is the Meta ADAPTER, so this
+   * field is deliberately Meta-shaped; the neutral→Meta mapping (`'sales'` →
+   * `'OUTCOME_SALES'`) happens one layer up, in `adComposer` (plan REVISIONS S1)
+   * — nothing neutral should leak down here, and nothing Meta-shaped should leak
+   * up there.
+   */
+  objective?: string;
 }
 
 export interface AdSetTargeting {
@@ -57,6 +66,17 @@ export interface CreateAdSetSpec {
   /** The page the ad ultimately sends traffic to — used ONLY to derive `conversion_domain`; the actual click-through link is set on the creative. */
   landingUrl: string;
   targeting: AdSetTargeting;
+  /**
+   * ISO 8601 — bounds the ad set's run; verified accepted alongside
+   * `daily_budget` (docs/meta-ads-infrastructure-2026.md §9d). REQUIRED by
+   * policy in 2a (plan REVISIONS B2 — Meta's campaign-level spend-cap floor is
+   * 500 RON, too high to bound a small first test, so `end_time` + daily
+   * budget are the real spend bound instead). Optional at THIS layer because
+   * this module is the low-level Meta adapter, not the policy owner — the
+   * requiredness is enforced by `adComposer`'s input type (Fable OD6).
+   */
+  endTime?: string;
+  startTime?: string;
 }
 
 export interface CreateCreativeSpec {
@@ -64,10 +84,12 @@ export interface CreateCreativeSpec {
   /** Click-through link — should already carry `?utm_source=facebook&utm_campaign=<adCampaigns.id>` (Fable H1); this module does not append UTMs itself. */
   link: string;
   message: string;
-  /** Image hash from `/act_<id>/adimages` — image upload is out of scope for Phase 1; caller supplies it. */
+  /** Image hash from `/act_<id>/adimages` (`metaAds/adImages.uploadImageToAccount`, plan REVISIONS B4). */
   imageHash: string;
   /** Defaults to 'LEARN_MORE', the only CTA verified against the live account (§9c). */
   callToActionType?: string;
+  /** `link_data.name` — the ad's headline. Verified accepted + read back correctly (§9d); optional (S6: be ready to drop it from the form if it turns out not to render everywhere). */
+  headline?: string;
 }
 
 export interface CreateAdSpec {
@@ -102,7 +124,7 @@ export async function createCampaign(
     ctx.token,
     {
       name: spec.name,
-      objective: 'OUTCOME_SALES',
+      objective: spec.objective ?? 'OUTCOME_SALES',
       special_ad_categories: [],
       is_adset_budget_sharing_enabled: false,
     },
@@ -187,6 +209,8 @@ export async function createAdSet(
       conversion_domain: conversionDomain,
       targeting: spec.targeting,
       bid_strategy: 'LOWEST_COST_WITHOUT_CAP',
+      ...(spec.startTime ? { start_time: spec.startTime } : {}),
+      ...(spec.endTime ? { end_time: spec.endTime } : {}),
     },
     propertyId
   );
@@ -196,9 +220,17 @@ export async function createAdSet(
  * Create a PAUSED ad creative. Requires the property to have a configured
  * Meta Page (`ctx.pageId` — multi-property config); returns
  * `{ok:false,error:'no-page'}` without calling Meta if none is configured.
- * `object_story_spec` shape matches the live-verified contract exactly
- * (§9c) — `page_id` + `link_data` with `image_hash` (Phase 1 does not upload
- * images; the caller supplies an already-uploaded hash).
+ * `object_story_spec` shape matches the live-verified contract (§9c), extended
+ * with three fields verified in the Phase-2a spike (§9d):
+ *  - `instagram_user_id` (`ctx.instagramActorId`, when the property has one
+ *    configured) — WITHOUT it the ad is FB-only; Meta's IG placements need it
+ *    (plan REVISIONS S5).
+ *  - `link_data.use_flexible_image_aspect_ratio: true` — always on; lets Meta
+ *    auto-fit the single supplied image to each placement's aspect ratio
+ *    (2a ships one photo, no per-placement crops yet — plan §2 "Non-goals").
+ *  - `link_data.name` — the headline, only when the caller supplies one (S6:
+ *    unverified whether it renders on every placement; keep it optional so a
+ *    2a form can drop it without a code change).
  */
 export async function createCreative(
   propertyId: string,
@@ -222,11 +254,14 @@ export async function createCreative(
       name: spec.name,
       object_story_spec: {
         page_id: ctx.pageId,
+        ...(ctx.instagramActorId ? { instagram_user_id: ctx.instagramActorId } : {}),
         link_data: {
           link: spec.link,
           message: spec.message,
           image_hash: spec.imageHash,
           call_to_action: { type: spec.callToActionType ?? 'LEARN_MORE' },
+          use_flexible_image_aspect_ratio: true,
+          ...(spec.headline ? { name: spec.headline } : {}),
         },
       },
     },
@@ -340,10 +375,23 @@ async function rollback(propertyId: string, token: string, targets: RollbackTarg
  * (H5/M3/M4). Setting either field here would make a freshly-created
  * campaign activatable straight out of creation, defeating that gate — never
  * do it, even by convenience/default.
+ *
+ * `adCampaignId` (plan REVISIONS B5, optional, backward-compatible): when the
+ * caller (`adComposer`) has PRE-ALLOCATED a Firestore doc id (so it can embed
+ * `utm_campaign=<id>` into the creative's link BEFORE this chain runs), pass
+ * it here — the Firestore write uses `.doc(adCampaignId).create()` instead of
+ * `.add()`. `.create()` (not `.set()`) is deliberate: a retry/double-submit of
+ * the SAME pre-allocated id becomes a detectable `ALREADY_EXISTS` error
+ * instead of silently overwriting or creating a second doc for one Meta
+ * chain (S11). `createCampaignChain` remains the ONLY writer of this doc
+ * either way (B5) — `adComposer` never touches Firestore directly. Omitting
+ * `adCampaignId` keeps the original `.add()` behavior exactly (the Phase-1
+ * validation harness and existing tests rely on this).
  */
 export async function createCampaignChain(
   propertyId: string,
-  spec: CreateCampaignChainSpec
+  spec: CreateCampaignChainSpec,
+  adCampaignId?: string
 ): Promise<CreateCampaignChainResult> {
   // (a) master-switch gate — creating PAUSED objects is zero-spend, so this
   // is the ONLY gate creation needs. Live mode (isAdsLiveAllowed) guards
@@ -410,18 +458,29 @@ export async function createCampaignChain(
   // status/spendCapMinor are deliberately NOT set to anything activatable.
   try {
     const db = await getAdminDb();
-    const ref = await db.collection('adCampaigns').add({
+    const docData = {
       propertyId,
       metaCampaignId: campaignId,
       metaAdSetIds: [adSetId],
       metaAdIds: [adId],
-      objective: 'OUTCOME_SALES',
+      objective: spec.campaign.objective ?? 'OUTCOME_SALES',
       dailyBudgetMinor: spec.adSet.dailyBudgetMinor,
       creativeRef: creativeId,
       status: 'draft',
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
-    });
+    };
+
+    let resolvedAdCampaignId: string;
+    if (adCampaignId) {
+      // Pre-allocated id (B5) — `.create()` so a double-submit is a detectable
+      // already-exists error, never a silent overwrite/duplicate.
+      await db.collection('adCampaigns').doc(adCampaignId).create(docData);
+      resolvedAdCampaignId = adCampaignId;
+    } else {
+      const ref = await db.collection('adCampaigns').add(docData);
+      resolvedAdCampaignId = ref.id;
+    }
 
     logger.info('createCampaignChain: full chain created', {
       propertyId,
@@ -429,10 +488,10 @@ export async function createCampaignChain(
       adSetId,
       creativeId,
       adId,
-      adCampaignId: ref.id,
+      adCampaignId: resolvedAdCampaignId,
     });
 
-    return { ok: true, campaignId, adSetId, creativeId, adId, adCampaignId: ref.id };
+    return { ok: true, campaignId, adSetId, creativeId, adId, adCampaignId: resolvedAdCampaignId };
   } catch (error) {
     // The Meta-side chain is valid (PAUSED, zero spend) but unrecorded — an
     // unrecorded campaign is invisible to the approval workflow and can

--- a/src/services/growth/metaAds/campaignBuilder.ts
+++ b/src/services/growth/metaAds/campaignBuilder.ts
@@ -465,6 +465,9 @@ export async function createCampaignChain(
       metaAdIds: [adId],
       objective: spec.campaign.objective ?? 'OUTCOME_SALES',
       dailyBudgetMinor: spec.adSet.dailyBudgetMinor,
+      // Persist the ad set's end_time so the approve step can run the spend-cap
+      // arithmetic (dailyBudget × days × margin ≤ cap) without a Meta read-back.
+      endTime: spec.adSet.endTime ?? null,
       creativeRef: creativeId,
       status: 'draft',
       createdAt: FieldValue.serverTimestamp(),

--- a/src/services/growth/metaAds/client.ts
+++ b/src/services/growth/metaAds/client.ts
@@ -207,6 +207,83 @@ export async function activateResource(
   });
 }
 
+/** A raw file to upload — bytes already read into memory by the caller (adImages.ts). */
+export interface UploadableFile {
+  bytes: Buffer;
+  filename: string;
+  contentType: string;
+}
+
+/**
+ * Upload an image to an ad account's image library — the one exception to
+ * "every Meta call is `metaGraph()`": the Marketing API's `/adimages` edge
+ * takes `multipart/form-data`, not the urlencoded body `metaGraph` builds, so
+ * this is a SEPARATE fetch call rather than a shoehorned `metaGraph` option
+ * (plan REVISIONS B4). It still lives in `client.ts` — the single module that
+ * calls `graph.facebook.com` — and keeps the same safety properties as every
+ * other helper here: Bearer-only token (never in the URL), never throws
+ * (network/parse/non-OK all resolve to `{ok:false,error}`), and is the ONLY
+ * place that builds this request so a future caller can't grow a second
+ * upload path with different guarantees.
+ *
+ * Verified contract (docs/meta-ads-infrastructure-2026.md §9d, live PAUSED
+ * spike): `POST /act_<id>/adimages` with a file field →
+ * `{ images: { "<field>": { hash, width, height, ... } } }`. The field name is
+ * caller-chosen and echoed back as the response key — we don't depend on it
+ * being anything specific, just read whichever single entry comes back. The
+ * `url` Meta also returns is TEMPORARY (§10) — this helper deliberately does
+ * NOT return it; only the permanent `hash` is meaningful to store.
+ *
+ * Callers (adImages.ts) are responsible for the size/width guard BEFORE
+ * calling this — this helper uploads whatever bytes it's given, no policy.
+ */
+export async function uploadImage(
+  adAccountId: string,
+  token: string,
+  file: UploadableFile,
+  propertyId?: string
+): Promise<GraphResult<{ imageHash: string }>> {
+  const url = `${GRAPH_BASE_URL}/${adAccountId}/adimages`;
+
+  const form = new FormData();
+  form.append('source', new Blob([file.bytes], { type: file.contentType }), file.filename);
+
+  try {
+    // NOTE: no Content-Type header set manually — fetch/undici computes the
+    // multipart boundary from the FormData body itself; setting one by hand
+    // would omit/mismatch the boundary and break the upload.
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      logger.warn('uploadImage: non-OK response', {
+        adAccountId,
+        propertyId,
+        status: response.status,
+        body: text,
+      });
+      return { ok: false, error: text, status: response.status };
+    }
+    const data = (await response.json()) as { images?: Record<string, { hash?: string }> };
+    const entry = data.images ? Object.values(data.images)[0] : undefined;
+    if (!entry?.hash) {
+      logger.warn('uploadImage: response missing image hash', { adAccountId, propertyId, data });
+      return { ok: false, error: 'no-hash-in-response' };
+    }
+    return { ok: true, data: { imageHash: entry.hash } };
+  } catch (error) {
+    logger.warn('uploadImage: fetch error', {
+      adAccountId,
+      propertyId,
+      error: String(error),
+    });
+    return { ok: false, error: String(error) };
+  }
+}
+
 /**
  * Delete a resource by id (campaign/ad set/ad/creative) — the rollback
  * primitive for `campaignBuilder.createCampaignChain` (plan §9 Phase 1): a

--- a/src/services/growth/metaAds/insights.ts
+++ b/src/services/growth/metaAds/insights.ts
@@ -115,3 +115,40 @@ export async function getInsights(
 
   return { ok: true, data: { spend, impressions, clicks, purchases, purchaseValue, roas } };
 }
+
+interface MetaEffectiveStatusReadBack {
+  id: string;
+  effective_status?: string;
+}
+
+/**
+ * Read-only `effective_status` look-up for a single Meta object (campaign, ad
+ * set, or ad) — Phase 2a Build B (plan REVISIONS OD4: "on-demand `effective_status`
+ * read-back in the console detail view", in lieu of a reconciliation cron in
+ * 2a). Exists so the admin console can detect drift/REJECTED/WITH_ISSUES on a
+ * manual "Refresh insights" click without any caller reaching into
+ * `metaGraph`/`graph.facebook.com` directly — this file (and the rest of
+ * `metaAds/*`) stays the ONLY place that does. Purely a GET, same
+ * no-precondition-but-a-resolved-context discipline as `getInsights`. Never
+ * throws.
+ */
+export async function getEffectiveStatus(
+  propertyId: string,
+  objectId: string
+): Promise<GraphResult<{ effectiveStatus: string }>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('getEffectiveStatus: no ad context for property', { propertyId, objectId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  const result = await metaGraph<MetaEffectiveStatusReadBack>(objectId, {
+    method: 'GET',
+    params: { fields: 'id,effective_status' },
+    token: ctx.token,
+    propertyId,
+  });
+  if (!result.ok) return result;
+
+  return { ok: true, data: { effectiveStatus: result.data.effective_status ?? 'UNKNOWN' } };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -522,8 +522,15 @@ export interface ComposeAndCreateAdInput {
     kind: 'gallery';
     /** Full Firebase Storage path — NEVER a thumbnail. Asserted to start with `properties/${propertyId}/` (ownership, S7). */
     storagePath: string;
-    /** sha256 of the image bytes — used as a cache probe; re-verified from the actual downloaded bytes (`metaAds/adImages`). */
-    contentHash: string;
+    /**
+     * sha256 of the image bytes — OPTIONAL. Used only as a fast pre-download
+     * cache probe (`metaAds/adImages.uploadImageToAccount`'s `UploadImageInput.contentHash`
+     * is itself optional); the authoritative hash is always recomputed from the
+     * actual downloaded bytes, so a caller (e.g. the console compose form,
+     * which only knows a gallery image's `storagePath`) never needs to compute
+     * this up front.
+     */
+    contentHash?: string;
   };
   /** Exactly 1 element in 2a (S1). */
   copy: CopyVariant[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -457,6 +457,7 @@ export interface AdCampaign {
   audienceRef?: string;
   objective?: string;              // e.g. 'OUTCOME_SALES'
   dailyBudgetMinor?: number;       // bani
+  endTime?: string;                // ISO 8601 — the ad set's end_time; used by the approve-step spend-cap arithmetic
   spendCapMinor?: number;          // bani — required (snapshotted) before activation
   status: AdCampaignStatus;
   effectiveStatus?: string;        // Meta's effective_status, mirrored by the Phase-2 reconciliation cron

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -480,6 +480,81 @@ export interface AdCampaign {
   updatedAt?: SerializableTimestamp;
 }
 
+/**
+ * Growth Ad Engine — platform-NEUTRAL copy for one ad (Phase 2a Build A, plan
+ * REVISIONS S1). 2a composes with exactly ONE variant (`ComposeAndCreateAdInput.copy.length === 1`)
+ * — the array shape is future-proofed for 2b's `asset_feed_spec` multi-variant
+ * creative so that change doesn't need a schema migration later.
+ */
+export interface CopyVariant {
+  primary: string;
+  headline?: string;
+  cta: AdCallToAction;
+}
+
+/**
+ * Neutral ad objective — the Meta adapter (`metaAds/campaignBuilder`) maps
+ * this to the platform's real objective enum (`'sales'` → `'OUTCOME_SALES'`,
+ * plan REVISIONS S1). 2a supports only `'sales'`.
+ */
+export type AdObjective = 'sales';
+
+/**
+ * Neutral call-to-action — the Meta adapter maps this to Meta's CTA enum.
+ * Only `'learn_more'` is LIVE-VERIFIED against the account
+ * (docs/meta-ads-infrastructure-2026.md §9c); the others are UNVERIFIED —
+ * spike-test before relying on them in production (plan REVISIONS S6).
+ */
+export type AdCallToAction = 'learn_more' | 'book_now' | 'contact_us';
+
+/**
+ * `adComposer.composeAndCreateAd` input — the platform-NEUTRAL compose
+ * boundary (plan "The seam"). Nothing Meta-specific may leak in here (S1) —
+ * everything platform-specific lives downstream, in `metaAds/*`. Deliberately
+ * has NO `cities` field — cut from 2a (S1: Meta's `adgeolocation` city keys
+ * aren't verified yet); only `countries[]` + age range.
+ */
+export interface ComposeAndCreateAdInput {
+  propertyId: string;
+  assetRef: {
+    /** 2a only supports the existing property gallery; `kind:'catalog'` is an additive 2b concept (S7). */
+    kind: 'gallery';
+    /** Full Firebase Storage path — NEVER a thumbnail. Asserted to start with `properties/${propertyId}/` (ownership, S7). */
+    storagePath: string;
+    /** sha256 of the image bytes — used as a cache probe; re-verified from the actual downloaded bytes (`metaAds/adImages`). */
+    contentHash: string;
+  };
+  /** Exactly 1 element in 2a (S1). */
+  copy: CopyVariant[];
+  objective: AdObjective;
+  /** Should be the property's canonical custom domain, not a `*.hosted.app` URL — a mismatch breaks `conversion_domain` attribution (plan REVISIONS S8). */
+  landingBaseUrl: string;
+  /** Bani (minor units) — NEVER major-unit RON (plan §13 M3). Enforced ≤ `MAX_DAILY_BUDGET_MINOR` server-side (B2). */
+  dailyBudgetMinor: number;
+  targeting: {
+    countries: string[];
+    ageMin: number;
+    ageMax: number;
+  };
+  /** ISO 8601 — REQUIRED in 2a (plan REVISIONS B2): bounds the ad set's real spend window (Meta's 500 RON campaign-level spend-cap floor is too high for a small first test). */
+  endTime: string;
+}
+
+/**
+ * `adImageCache` collection doc — per-(platform, ad account, content hash)
+ * dedup cache for uploaded creative images (plan REVISIONS B4). Doc id is
+ * `${platform}_${accountId}_${contentHash}` (`accountId` WITHOUT the `act_`
+ * prefix). Written only by `metaAds/adImages.uploadImageToAccount`; Firestore
+ * rules make it Admin-SDK-only (`write: if false`).
+ */
+export interface AdImageCacheDoc {
+  platform: 'meta';
+  accountId: string;
+  contentHash: string;
+  imageHash: string;
+  uploadedAt?: SerializableTimestamp;
+}
+
 export interface Inquiry {
   id: string; // Document ID from Firestore
   propertySlug: string;


### PR DESCRIPTION
## What
Phase 2a of the Growth Ad Engine: an operator can compose a real Meta (FB+IG) ad from a property photo, approve it, activate it, and read its ROAS — **end-to-end through our own code**. This is the *machinery validation* (the owner already knows ads work; what's unproven is our pipeline). Builds on Phase 1 (#145).

Ships **dark** (`GROWTH_ADS_ENABLED` unset) and **zero-spend by construction** — every ad is created PAUSED, and nothing activates without the two switches + operator approval + a spend cap.

## Process (this PR is the output of plan → adversarial review → verify → build → review)
- **Plan** (Opus) → **Fable adversarial review** caught a critical bug: activation only un-paused the *campaign*, so the ad would never deliver (Meta `effective_status` is a rollup). Plus real money-safety gaps. All folded in.
- **Contract spike** (zero spend) verified the previously-unverified Meta writes: multipart image upload, ad-set start/end-time bounding, `instagram_user_id`, `use_flexible_image_aspect_ratio`, `link_data.name`.
- **Build A** (backend) + **Opus money-path review** (found + fixed 4 issues) → **Build B** (console) + **Opus review** of the approve/activate actions.

## Safety (why this can't spend)
- **PAUSED-enforced** on every create (one choke point).
- **Activation gateway** (`adExecutionGateway`): two-switch dry-run gate → approved-status + positive spend-cap gate → ownership assert → **activate all 3 hierarchy levels** (the B1 fix) with reverse re-pause rollback on any partial failure; a failed rollback screams `ROLLBACK-INCOMPLETE`. Incomplete-chain docs refused. Every path audited.
- **Real spend bounds**: server-side `MAX_DAILY_BUDGET_MINOR`, required end-date, approve-time `dailyBudget × days × 1.25 ≤ spendCap` arithmetic. Approve is draft-guarded; actor always from the authenticated session.
- **Platform-neutral core + Meta adapter** — no Meta enums leak into the neutral layer, so TikTok is a later adapter, not a rewrite.

## Not in this PR (later phases)
Asset catalog / variants / LLM descriptions / crops (2b), generation gateway (2c), the Brain proposal seam (2d), reconciliation cron (2b) — a console on-demand `effective_status` read-back covers drift/REJECTED detection for the 2a live test.

## The live test (owner-gated, after merge)
Deploy dark → verify the gate blocks compose → flip `GROWTH_ADS_ENABLED` (dry-run activation = the no-spend validation) → set an account-level spend limit → flip `GROWTH_ADS_MODE=live` → activate one ~5-RON/day, end-date-bounded ad → measure via Pixel/CAPI + UTM → pause.

Tests: 136 growth+ads pass. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)