### PR TITLE
fix: localize review dates on RO pages (P1-7)

### DIFF
--- a/src/components/property/property-page-renderer.tsx
+++ b/src/components/property/property-page-renderer.tsx
@@ -99,6 +99,7 @@ import { LegalContent } from '@/components/property/legal-content';
 import { AreaGuideSection } from '@/components/property/area-guide-section';
 import { ReviewsListSection } from '@/components/property/reviews-list-section';
 import { useLanguage } from '@/hooks/useLanguage';
+import { languageToLocale } from '@/lib/utils';
 
 // Map of block types to their rendering components
 const blockComponents: Record<string, React.FC<{ content: any; language?: string }>> = {
@@ -611,12 +612,14 @@ export function PropertyPageRenderer({
               : undefined,
           };
         } else if (type === 'testimonials') {
-          // Convert date from various Firestore formats (string, Timestamp, Date)
+          // Convert date from various Firestore formats (string, Timestamp, Date),
+          // localized to the current language (e.g. "ian. 2026" on the RO page).
+          const dateLocale = languageToLocale(language);
           const convertReviewDate = (d: any): string | undefined => {
             if (!d) return undefined;
-            if (typeof d === 'string') return new Date(d).toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
-            if (d._seconds) return new Date(d._seconds * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
-            if (d instanceof Date) return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+            if (typeof d === 'string') return new Date(d).toLocaleDateString(dateLocale, { year: 'numeric', month: 'short' });
+            if (d._seconds) return new Date(d._seconds * 1000).toLocaleDateString(dateLocale, { year: 'numeric', month: 'short' });
+            if (d instanceof Date) return d.toLocaleDateString(dateLocale, { year: 'numeric', month: 'short' });
             return undefined;
           };
 

--- a/src/components/property/review-card.tsx
+++ b/src/components/property/review-card.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Star, StarHalf, ChevronDown, ChevronUp, UserCircle, ThumbsUp, ThumbsDown, Globe } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { cn } from '@/lib/utils';
+import { cn, languageToLocale } from '@/lib/utils';
 import { useLanguage } from '@/hooks/useLanguage';
 import type { RichReview } from '@/types';
 
@@ -82,7 +82,7 @@ export function ReviewCard({ review }: ReviewCardProps) {
   const reviewDate = (() => {
     if (!review.date) return undefined;
     if (typeof review.date === 'string') {
-      return new Date(review.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+      return new Date(review.date).toLocaleDateString(languageToLocale(lang), { year: 'numeric', month: 'short' });
     }
     return undefined;
   })();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,6 +48,19 @@ export function formatPrice(price: number, currency: string = 'USD'): string {
 }
 
 /**
+ * Maps an app language code (e.g. 'ro') to an Intl locale for date/number
+ * formatting. Property-agnostic; extend the map as new languages are added.
+ */
+export function languageToLocale(language?: string): string {
+  switch (language) {
+    case 'ro':
+      return 'ro-RO';
+    default:
+      return 'en-US';
+  }
+}
+
+/**
  * Formats a date as a localized string
  */
 export function formatDate(date: Date | string, options: Intl.DateTimeFormatOptions = {}): string {


### PR DESCRIPTION
## What

Review dates on the Romanian site were formatted with a hardcoded `en-US` locale, so RO visitors saw **"Jan 2026"** instead of **"ian. 2026"**. This was the P1-7 item from the Prahova website audit (`docs/website-audit-prahova.md`).

Two call sites, both fixed:
- **Homepage testimonials carousel** — `property-page-renderer.tsx` `convertReviewDate()` (had `en-US` hardcoded in all three date-format branches)
- **`/reviews` page cards** — `review-card.tsx` (second occurrence found during verification, same bug)

## How

Added a small property-agnostic helper `languageToLocale(language)` in `src/lib/utils.ts` (`'ro'` → `'ro-RO'`, else `'en-US'`) and used it at both call sites with the language already in scope. Multi-property safe — no property-specific logic.

Output verified via `Intl`:
- `ian. 2026`, `aug. 2026`, `dec. 2025` (RO)  ·  `Jan 2026`, `Aug 2026`, `Dec 2025` (EN)

## Test
- `npm run build` passes.

## Notes
- Sibling audit items **P1-4** (distances table English-only) and **P1-8** (`homepage.features.description.ro` empty) are **Firestore data**, not code — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)