### PR TITLE
fix: restore public/images serving on App Hosting (remove output:standalone)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,13 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 const nextConfig: NextConfig = {
   /* config options here */
-  output: 'standalone',
+  // NOTE: Do NOT set `output: 'standalone'` here. Firebase App Hosting's
+  // Next.js adapter produces its own deployable output and copies the full
+  // `public/` folder. With a manual `output: 'standalone'`, recent adapter
+  // builds only shipped public assets that were referenced in build-time code
+  // (e.g. og-image.jpg via resolveOgImage), and dropped every image referenced
+  // only through runtime Firestore data — causing all /images/** to 404 in
+  // production. Letting the adapter manage output restores full public serving.
   typescript: {
     ignoreBuildErrors: false,
   },


### PR DESCRIPTION
## Production incident: all local property images 404

Every `public/images/**` asset — **both properties'** photos, template defaults, `logo.png`, `placeholder.jpg`, and all page heroes — returned **404 in production**, while `public/` root files (`favicon.ico`, `next.svg`) and the single build-referenced image (`og-image.jpg`, path computed in `resolveOgImage()`) served fine. The 404s came from the app itself (Cloud Run), i.e. the files were **not in the deployed bundle**.

## Root cause

`next.config.ts` set `output: 'standalone'`. With standalone output, `public/` is not auto-included; Firebase App Hosting's `@apphosting/adapter-nextjs` must copy it. Recent adapter builds only shipped public assets **traced from build-time code**, so the only property image referenced in code (`og-image.jpg`) survived, while every image referenced solely through **runtime Firestore data** (all the property photos) was dropped. The adapter version is resolved at build time (not pinned), so the regression surfaced on rebuild despite `next.config.ts` being unchanged for weeks.

## Fix

Remove `output: 'standalone'`. App Hosting's adapter produces its own deployable output and copies the full `public/` folder in its default path, so the manual setting was redundant and was the trigger.

## Test
- `npm run build` passes.
- Post-deploy verification: `curl` every hero + property image → expect 200 (will confirm on the PR before closing the incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)