### PR TITLE
fix: bundle full public/ into standalone output (restore image serving)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,16 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 const nextConfig: NextConfig = {
   /* config options here */
-  // NOTE: Do NOT set `output: 'standalone'` here. Firebase App Hosting's
-  // Next.js adapter produces its own deployable output and copies the full
-  // `public/` folder. With a manual `output: 'standalone'`, recent adapter
-  // builds only shipped public assets that were referenced in build-time code
-  // (e.g. og-image.jpg via resolveOgImage), and dropped every image referenced
-  // only through runtime Firestore data — causing all /images/** to 404 in
-  // production. Letting the adapter manage output restores full public serving.
+  output: 'standalone',
+  // Firebase App Hosting deploys the traced standalone output. Next only copies
+  // files it can trace into that bundle, so public/ assets referenced ONLY via
+  // runtime Firestore data (every property photo) were dropped and 404'd in
+  // production — while code-referenced ones survived (e.g. og-image.jpg, which
+  // og-image.ts fs.existsSync-checks, got traced in). Force the whole public/
+  // tree into the traced output so the server serves every static image.
+  outputFileTracingIncludes: {
+    '/**': ['./public/**/*'],
+  },
   typescript: {
     ignoreBuildErrors: false,
   },


### PR DESCRIPTION
## Follow-up to #151 — the real fix for the image 404 outage

#151 (remove `output: 'standalone'`) deployed as revision `-009` but did **not** restore the images. Root cause confirmed:

Firebase App Hosting's adapter (`@apphosting/adapter-nextjs@14.0.21`) deploys Next's **traced standalone output**, which only includes `public/` files Next can trace from code. Every property photo is referenced **solely via runtime Firestore data**, so none get traced → all `/images/**` 404. The only survivor, `og-image.jpg`, is traced because `src/lib/og-image.ts` calls `fs.existsSync()` on its path.

## Fix

Restore `output: 'standalone'` and add `outputFileTracingIncludes` to force the entire `public/` tree into the traced bundle:

```ts
output: 'standalone',
outputFileTracingIncludes: {
  '/**': ['./public/**/*'],
},
```

## Verified locally (before deploy)

Built and inspected `.next/standalone/public`:
- **31 source public files → 31 in standalone bundle → 0 missing**
- Previously-404'd `comarnic-hero-1.jpg`, `comarnic-position.jpg`, `castelul-bran.jpg`, template defaults: all present
- `npm run build` passes

Post-deploy I'll curl every hero + property image to confirm 200 before closing the incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)