### PR TITLE
feat: Meta ads Phase 2b — city targeting + Advantage+ multi-image creative

### DIFF
--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -235,3 +235,15 @@ Ran `composeAndCreateAd` (the real console path: Storage image upload → neutra
 - **Storage bucket:** `admin.storage().bucket()` (no-arg) throws "Bucket name not specified or invalid" — the Admin SDK isn't initialized with a `storageBucket`. Fix: pass the bucket name explicitly from `FIREBASE_STORAGE_BUCKET`/`NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (set locally + in apphosting.yaml). `adImages.ts`.
 - **Advantage+ Audience flag REQUIRED:** ad set create with audience targeting (age/interests) → error **100 / subcode 1870227** "Advantage Audience Flag Required" — must set `targeting.targeting_automation.advantage_audience` to 0 or 1. (The §9b/§9c spikes used geo-only, so never hit it.) Fix: `createAdSet` injects `targeting_automation:{advantage_audience:0}` (respect exact targeting; caller can override). `campaignBuilder.ts`.
 - Everything else worked: image dedup cache hit on re-run, full PAUSED chain, `adCampaigns` draft doc (no spendCap = un-activatable), `activateCampaign`→`dry-run` (two-switch gate), clean delete. Zero spend. Validator: `scripts/growth-validate-compose.ts`.
+
+### 9f. Phase-2b contract spike (city targeting + Advantage+ audience + multi-image, 10 Jul 2026)
+All verified live PAUSED + deleted, zero spend. This is the contract for the richer targeting/creative build.
+
+**City name→key resolution:** `GET /search?type=adgeolocation&location_types=["city"]&q=<name>&country_code=RO&limit=1` → `data[].{key,name,region,region_id,country_code}`. Verified keys: **București=1910415, Ploiești=1925836, Constanța=1913456**. Cities MUST be targeted by `key`, never name.
+
+**City targeting (ad set):** `targeting.geo_locations.cities:[{key, radius, distance_unit:"kilometer"}]` + `location_types:["home","recent"]`. Read-back confirms.
+
+**Advantage+ audience OWNS demographics (KEY design fact):** with `targeting_automation.advantage_audience:1` you CANNOT hard-set `age_min` > 25 (err 100/1870188) nor `age_max` < 65 (err 100/1870189) — age becomes a *suggestion* only; **only geo is a hard control**. So: `advantage_audience:1` (Meta's conversion recommendation, best cold-start) ⇒ drop hard age, rely on GEO + ad copy to qualify. Use `advantage_audience:0` only when you need exact age/gender/interest control (then age is honored). The two are mutually exclusive on age.
+
+**Multi-image = Dynamic Creative (`asset_feed_spec`):** creative = `object_story_spec:{page_id, instagram_user_id}` (NO link_data) + `asset_feed_spec:{images:[{hash},…], bodies:[{text},…], titles:[{text}], descriptions:[{text}], link_urls:[{website_url}], call_to_action_types:["LEARN_MORE"], ad_formats:["AUTOMATIC_FORMAT"]}`. Meta mixes assets + picks per placement.
+**GOTCHA:** a Dynamic-Creative ad fails on a normal ad set — err 100/**1885998** "Cannot Create Dynamic Creative ad In Non-Dynamic Creative Ad Set". The AD SET must be created with **`is_dynamic_creative:true`**. Single-image `object_story_spec` creatives stay on normal (non-dynamic) ad sets. So the composer picks the path by asset count: 1 image → object_story_spec/normal adset; 2+ images or copy variants → asset_feed_spec + `is_dynamic_creative:true` adset.

--- a/scripts/growth-validate-compose.ts
+++ b/scripts/growth-validate-compose.ts
@@ -34,12 +34,14 @@ const STORAGE_PATH = 'properties/prahova-mountain-chalet/images/70ae67f4-603a-4f
   const endTime = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
   const res = await composeAndCreateAd({
     propertyId: P,
-    assetRef: { kind: 'gallery', storagePath: STORAGE_PATH },
+    assetRefs: [{ kind: 'gallery', storagePath: STORAGE_PATH }],
     copy: [{ primary: 'Escape to the Carpathians — a cozy mountain chalet in Comarnic.', headline: 'Your mountain escape', cta: 'learn_more' }],
     objective: 'sales',
     landingBaseUrl: 'https://prahova-chalet.ro/ro', // the /ro decision — RO landing
     dailyBudgetMinor: 500, // 5 RON/day (PAUSED — never spends)
-    targeting: { countries: ['RO'], ageMin: 30, ageMax: 55 },
+    // Phase 2b (§9f): no age targeting — advantage_audience:1 owns
+    // demographics. Countries-only fallback (no city picked) still works.
+    targeting: { cities: [], countries: ['RO'] },
     endTime,
   });
 

--- a/src/app/admin/ads/__tests__/actions.test.ts
+++ b/src/app/admin/ads/__tests__/actions.test.ts
@@ -94,12 +94,12 @@ beforeEach(() => {
 describe('composeAdAction', () => {
   const INPUT: ComposeAndCreateAdInput = {
     propertyId: PROPERTY,
-    assetRef: { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/a.jpg` },
+    assetRefs: [{ kind: 'gallery', storagePath: `properties/${PROPERTY}/images/a.jpg` }],
     copy: [{ primary: 'Book your stay', cta: 'learn_more' }],
     objective: 'sales',
     landingBaseUrl: 'https://prahova-chalet.ro',
     dailyBudgetMinor: 5000,
-    targeting: { countries: ['RO'], ageMin: 25, ageMax: 65 },
+    targeting: { cities: [], countries: ['RO'] },
     endTime: '2099-01-01T00:00:00Z',
   };
 

--- a/src/app/admin/ads/__tests__/actions.test.ts
+++ b/src/app/admin/ads/__tests__/actions.test.ts
@@ -30,12 +30,15 @@ jest.mock('@/services/growth/metaAds/insights', () => ({
 
 jest.mock('@/services/growth/metaAds/adContext', () => ({ resolveAdContext: jest.fn() }));
 
+jest.mock('@/services/growth/metaAds/geo', () => ({ searchCities: jest.fn() }));
+
 import {
   composeAdAction,
   approveAdAction,
   activateAdAction,
   pauseAdAction,
   refreshAdInsightsAction,
+  searchCitiesAction,
 } from '../actions';
 import { requireSuperAdmin, AuthorizationError } from '@/lib/authorization';
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
@@ -43,6 +46,7 @@ import { composeAndCreateAd, validateApprovalCap } from '@/services/growth/adCom
 import { activateCampaign } from '@/services/growth/adExecutionGateway';
 import { pauseCampaign } from '@/services/growth/metaAds/lifecycle';
 import { getInsights, getEffectiveStatus } from '@/services/growth/metaAds/insights';
+import { searchCities } from '@/services/growth/metaAds/geo';
 import type { ComposeAndCreateAdInput } from '@/types';
 
 const mockRequireSuperAdmin = requireSuperAdmin as jest.Mock;
@@ -53,6 +57,7 @@ const mockActivateCampaign = activateCampaign as jest.Mock;
 const mockPauseCampaign = pauseCampaign as jest.Mock;
 const mockGetInsights = getInsights as jest.Mock;
 const mockGetEffectiveStatus = getEffectiveStatus as jest.Mock;
+const mockSearchCities = searchCities as jest.Mock;
 
 const ACTOR = { uid: 'uid-1', email: 'operator@rentalspot.test', role: 'super_admin', managedProperties: [] };
 const ADCAMPAIGN_ID = 'campaign-doc-1';
@@ -314,6 +319,39 @@ describe('pauseAdAction', () => {
     const res = await pauseAdAction(ADCAMPAIGN_ID);
     expect(res).toEqual({ success: false, campaignId: META_CAMPAIGN_ID, error: 'no-ad-context' });
     expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchCitiesAction — city typeahead backing the compose form's picker (2b)
+// ---------------------------------------------------------------------------
+
+describe('searchCitiesAction', () => {
+  it('gates on super-admin — returns [] without calling searchCities', async () => {
+    mockRequireSuperAdmin.mockRejectedValue(new AuthorizationError('nope', 'NOT_SUPER_ADMIN'));
+
+    const res = await searchCitiesAction(PROPERTY, 'Ploiesti');
+
+    expect(res).toEqual([]);
+    expect(mockSearchCities).not.toHaveBeenCalled();
+  });
+
+  it('returns the matches from searchCities verbatim', async () => {
+    const matches = [{ key: '1925836', name: 'Ploiești', region: 'Prahova' }];
+    mockSearchCities.mockResolvedValue({ ok: true, data: matches });
+
+    const res = await searchCitiesAction(PROPERTY, 'Ploiesti');
+
+    expect(mockSearchCities).toHaveBeenCalledWith(PROPERTY, 'Ploiesti');
+    expect(res).toEqual(matches);
+  });
+
+  it('returns [] (not a throw) when searchCities fails', async () => {
+    mockSearchCities.mockResolvedValue({ ok: false, error: 'no-ad-context' });
+
+    const res = await searchCitiesAction(PROPERTY, 'Ploiesti');
+
+    expect(res).toEqual([]);
   });
 });
 

--- a/src/app/admin/ads/_components/compose-form.tsx
+++ b/src/app/admin/ads/_components/compose-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useState, useTransition, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
@@ -8,26 +8,32 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Check, ImageOff } from 'lucide-react';
+import { Loader2, Check, ImageOff, Plus, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { AdCallToAction, ComposeAndCreateAdInput } from '@/types';
-import { composeAdAction } from '../actions';
+import type { AdCallToAction, CityTarget, ComposeAndCreateAdInput } from '@/types';
+import type { CityMatch } from '@/services/growth/metaAds/geo';
+import { composeAdAction, searchCitiesAction } from '../actions';
 
-// A short, curated list — a Romanian vacation-rental audience realistically
-// targets these; the neutral compose input takes an arbitrary countries[]
-// array so this list is a UX convenience, not a platform limit.
-const COUNTRY_OPTIONS = [
-  { code: 'RO', label: 'Romania' },
-  { code: 'GB', label: 'United Kingdom' },
-  { code: 'DE', label: 'Germany' },
-  { code: 'FR', label: 'France' },
-  { code: 'IT', label: 'Italy' },
-  { code: 'NL', label: 'Netherlands' },
-  { code: 'US', label: 'United States' },
-];
+/**
+ * Mirrors `adComposer`'s `MAX_IMAGES`/`MAX_COPY_VARIANTS` ceilings (Meta's
+ * `asset_feed_spec.images[]`/`bodies[]`/`titles[]` limits,
+ * docs/meta-ads-infrastructure-2026.md §10). UI-side guard only — `adComposer`
+ * re-checks both server-side regardless of what this form sends.
+ */
+const MAX_IMAGES = 10;
+const MAX_COPY_VARIANTS = 5;
+
+/** Default radius (km) applied to a newly-picked city — operator can edit per-chip. */
+const DEFAULT_CITY_RADIUS_KM = 40;
+
+/** Debounce delay before firing `searchCitiesAction` on keystroke. */
+const CITY_SEARCH_DEBOUNCE_MS = 300;
+
+/** Minimum trimmed query length before searching — avoids a Graph call per single keystroke. */
+const CITY_SEARCH_MIN_CHARS = 2;
 
 const CTA_OPTIONS: Array<{ value: AdCallToAction; label: string; verified: boolean }> = [
   { value: 'learn_more', label: 'Learn more', verified: true },
@@ -63,24 +69,92 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
   const router = useRouter();
   const [pending, startTransition] = useTransition();
 
-  const [storagePath, setStoragePath] = useState<string>(images[0]?.storagePath ?? '');
-  const [primary, setPrimary] = useState('');
+  // ---- photos (multi-select, 1-MAX_IMAGES) ---------------------------------
+  const [selectedPaths, setSelectedPaths] = useState<string[]>(images[0] ? [images[0].storagePath] : []);
+
+  // ---- copy (1-MAX_COPY_VARIANTS primary-text variants, shared headline+CTA) ----
+  const [primaryTexts, setPrimaryTexts] = useState<string[]>(['']);
   const [headline, setHeadline] = useState('');
   const [cta, setCta] = useState<AdCallToAction>('learn_more');
+
+  // ---- city targeting (typeahead -> chips with per-city radius) ------------
+  const [cityQuery, setCityQuery] = useState('');
+  const [cityResults, setCityResults] = useState<CityMatch[]>([]);
+  const [citySearchPending, setCitySearchPending] = useState(false);
+  const [showCityDropdown, setShowCityDropdown] = useState(false);
+  const [selectedCities, setSelectedCities] = useState<CityTarget[]>([]);
+  const latestCityQueryRef = useRef('');
+
+  // ---- rest of the form ------------------------------------------------
   const [landingBaseUrl, setLandingBaseUrl] = useState(defaultLandingUrl);
   const [dailyBudgetRon, setDailyBudgetRon] = useState<string>('20');
-  const [countries, setCountries] = useState<string[]>(['RO']);
   const [endDate, setEndDate] = useState('');
 
   const maxDailyBudgetRon = maxDailyBudgetMinor / 100;
 
-  const toggleCountry = (code: string) => {
-    setCountries((prev) => (prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code]));
+  // Debounced city search — a stale-response guard (`latestCityQueryRef`)
+  // discards a slow/out-of-order response for a query the operator has since
+  // typed past, same discipline as any race-prone autocomplete.
+  useEffect(() => {
+    const trimmed = cityQuery.trim();
+    latestCityQueryRef.current = trimmed;
+    if (trimmed.length < CITY_SEARCH_MIN_CHARS) {
+      setCityResults([]);
+      setCitySearchPending(false);
+      return;
+    }
+    setCitySearchPending(true);
+    const handle = setTimeout(async () => {
+      const matches = await searchCitiesAction(propertyId, trimmed);
+      if (latestCityQueryRef.current === trimmed) {
+        setCityResults(matches);
+        setCitySearchPending(false);
+      }
+    }, CITY_SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [cityQuery, propertyId]);
+
+  const toggleImage = (path: string) => {
+    setSelectedPaths((prev) => {
+      if (prev.includes(path)) return prev.filter((p) => p !== path);
+      if (prev.length >= MAX_IMAGES) {
+        toast({ title: 'Too many photos', description: `Select up to ${MAX_IMAGES} photos.`, variant: 'destructive' });
+        return prev;
+      }
+      return [...prev, path];
+    });
+  };
+
+  const updatePrimaryText = (idx: number, value: string) => {
+    setPrimaryTexts((prev) => prev.map((t, i) => (i === idx ? value : t)));
+  };
+  const addPrimaryText = () => {
+    setPrimaryTexts((prev) => (prev.length >= MAX_COPY_VARIANTS ? prev : [...prev, '']));
+  };
+  const removePrimaryText = (idx: number) => {
+    setPrimaryTexts((prev) => (prev.length <= 1 ? prev : prev.filter((_, i) => i !== idx)));
+  };
+
+  const selectCity = (match: CityMatch) => {
+    setSelectedCities((prev) => {
+      if (prev.some((c) => c.key === match.key)) return prev;
+      return [...prev, { key: match.key, name: match.name, region: match.region, radius: DEFAULT_CITY_RADIUS_KM }];
+    });
+    setCityQuery('');
+    setCityResults([]);
+    setShowCityDropdown(false);
+  };
+  const removeCity = (key: string) => setSelectedCities((prev) => prev.filter((c) => c.key !== key));
+  const updateCityRadius = (key: string, radius: number) => {
+    setSelectedCities((prev) => prev.map((c) => (c.key === key ? { ...c, radius } : c)));
   };
 
   const validate = (): string | null => {
-    if (!storagePath) return 'Select a photo.';
-    if (!primary.trim()) return 'Primary text is required.';
+    if (selectedPaths.length === 0) return 'Select at least one photo.';
+    if (selectedPaths.length > MAX_IMAGES) return `Select at most ${MAX_IMAGES} photos.`;
+    const trimmedTexts = primaryTexts.map((t) => t.trim()).filter(Boolean);
+    if (trimmedTexts.length === 0) return 'Add at least one primary text.';
+    if (trimmedTexts.length > MAX_COPY_VARIANTS) return `Add at most ${MAX_COPY_VARIANTS} primary text variants.`;
     if (!landingBaseUrl.trim()) return 'Landing URL is required.';
     try {
       new URL(landingBaseUrl);
@@ -89,7 +163,10 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
     }
     const budget = Number(dailyBudgetRon);
     if (!Number.isFinite(budget) || budget <= 0) return 'Daily budget must be a positive number.';
-    if (countries.length === 0) return 'Select at least one country.';
+    if (selectedCities.length === 0) return 'Add at least one city to target.';
+    for (const c of selectedCities) {
+      if (!Number.isFinite(c.radius) || c.radius <= 0) return `Radius for ${c.name} must be a positive number (km).`;
+    }
     const endIso = endOfDayIso(endDate);
     if (!endIso) return 'End date is required.';
     if (Date.parse(endIso) <= Date.now()) return 'End date must be in the future.';
@@ -103,18 +180,24 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
       return;
     }
 
+    const trimmedTexts = primaryTexts.map((t) => t.trim()).filter(Boolean);
+    const trimmedHeadline = headline.trim() || undefined;
+
     const input: ComposeAndCreateAdInput = {
       propertyId,
-      // Phase 2b widened this to an array (multi-image Dynamic Creative) and
-      // dropped age targeting (Advantage+ Audience owns demographics now) —
-      // this form still only offers single-photo/country-only selection; a
-      // city picker + multi-photo picker is Build B's job for 2b, not done here.
-      assetRefs: [{ kind: 'gallery', storagePath }],
-      copy: [{ primary: primary.trim(), headline: headline.trim() || undefined, cta }],
+      // Phase 2b: 1 photo -> single-image object_story_spec; 2+ -> Dynamic
+      // Creative (adComposer/campaignBuilder decide the branch from lengths).
+      assetRefs: selectedPaths.map((storagePath) => ({ kind: 'gallery', storagePath })),
+      // Each primary-text variant shares the one headline + CTA — Meta A/B
+      // tests the primary-text variants against each other.
+      copy: trimmedTexts.map((primary) => ({ primary, headline: trimmedHeadline, cta })),
       objective: 'sales',
       landingBaseUrl: landingBaseUrl.trim(),
       dailyBudgetMinor: Math.round(Number(dailyBudgetRon) * 100),
-      targeting: { cities: [], countries },
+      // No countries fallback in this UI (2b makes cities the primary/only
+      // control here) — `adComposer` requires at least one city or country;
+      // `validate()` above already enforces >=1 city.
+      targeting: { cities: selectedCities },
       endTime: endOfDayIso(endDate)!,
     };
 
@@ -135,51 +218,227 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
 
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_420px]">
-      <Card>
-        <CardHeader>
-          <CardTitle>Photo</CardTitle>
-          <CardDescription>Pick one photo from this property&apos;s gallery. Meta auto-fits it to each placement.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {images.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
-              <ImageOff className="h-8 w-8" />
-              <p className="text-sm">No gallery images with a stored file found for this property.</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
-              {images.map((img) => (
-                <button
-                  key={img.storagePath}
-                  type="button"
-                  onClick={() => setStoragePath(img.storagePath)}
-                  className={cn(
-                    'relative aspect-square rounded-md overflow-hidden border-2 transition-all',
-                    storagePath === img.storagePath
-                      ? 'border-primary ring-2 ring-primary/30'
-                      : 'border-transparent hover:border-muted-foreground/30'
-                  )}
-                >
-                  <Image
-                    src={img.thumbnailUrl || img.url}
-                    alt={img.alt || ''}
-                    fill
-                    className="object-cover"
-                    sizes="150px"
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Photos</CardTitle>
+            <CardDescription>
+              Pick 1–{MAX_IMAGES} photos from this property&apos;s gallery. Selecting 2 or more lets Meta run Dynamic
+              Creative — it auto-tests image/copy combinations for you.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {images.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground">
+                <ImageOff className="h-8 w-8" />
+                <p className="text-sm">No gallery images with a stored file found for this property.</p>
+              </div>
+            ) : (
+              <>
+                <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+                  {images.map((img) => {
+                    const selected = selectedPaths.includes(img.storagePath);
+                    return (
+                      <button
+                        key={img.storagePath}
+                        type="button"
+                        onClick={() => toggleImage(img.storagePath)}
+                        className={cn(
+                          'relative aspect-square rounded-md overflow-hidden border-2 transition-all',
+                          selected
+                            ? 'border-primary ring-2 ring-primary/30'
+                            : 'border-transparent hover:border-muted-foreground/30'
+                        )}
+                      >
+                        <Image
+                          src={img.thumbnailUrl || img.url}
+                          alt={img.alt || ''}
+                          fill
+                          className="object-cover"
+                          sizes="150px"
+                        />
+                        {selected && (
+                          <div className="absolute inset-0 bg-primary/20 flex items-center justify-center">
+                            <div className="rounded-full bg-primary p-1">
+                              <Check className="h-4 w-4 text-primary-foreground" />
+                            </div>
+                          </div>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {selectedPaths.length} of {MAX_IMAGES} selected
+                  {selectedPaths.length >= 2 ? ' — Dynamic Creative will test them.' : '.'}
+                </p>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Copy</CardTitle>
+            <CardDescription>
+              Add 1–{MAX_COPY_VARIANTS} primary-text variants. Meta will A/B-test them against each other
+              automatically.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              <Label>Primary text</Label>
+              {primaryTexts.map((text, idx) => (
+                <div key={idx} className="flex gap-2 items-start">
+                  <Textarea
+                    value={text}
+                    onChange={(e) => updatePrimaryText(idx, e.target.value)}
+                    placeholder={
+                      idx === 0
+                        ? 'e.g. Escape to the mountains — book your stay at Prahova Chalet'
+                        : `Variant ${idx + 1}`
+                    }
+                    rows={2}
+                    className="flex-1"
                   />
-                  {storagePath === img.storagePath && (
-                    <div className="absolute inset-0 bg-primary/20 flex items-center justify-center">
-                      <div className="rounded-full bg-primary p-1">
-                        <Check className="h-4 w-4 text-primary-foreground" />
-                      </div>
-                    </div>
+                  {primaryTexts.length > 1 && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removePrimaryText(idx)}
+                      aria-label={`Remove variant ${idx + 1}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
                   )}
-                </button>
+                </div>
               ))}
+              {primaryTexts.length < MAX_COPY_VARIANTS && (
+                <Button type="button" variant="outline" size="sm" onClick={addPrimaryText}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Add variant
+                </Button>
+              )}
             </div>
-          )}
-        </CardContent>
-      </Card>
+
+            <div className="space-y-2">
+              <Label htmlFor="headline">Headline (optional)</Label>
+              <Input
+                id="headline"
+                value={headline}
+                onChange={(e) => setHeadline(e.target.value)}
+                placeholder="e.g. Prahova Mountain Chalet"
+              />
+              <p className="text-xs text-muted-foreground">Shared across every primary-text variant above.</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Call to action</Label>
+              <Select value={cta} onValueChange={(v) => setCta(v as AdCallToAction)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CTA_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                      {!o.verified ? ' (unverified against this account)' : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>City targeting</CardTitle>
+            <CardDescription>
+              Search a city, pick it, then set a radius. Meta&apos;s Advantage+ audience finds the right people
+              within these areas — for exact age or interests, edit the ad in Ads Manager.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="relative">
+              <Input
+                value={cityQuery}
+                onChange={(e) => {
+                  setCityQuery(e.target.value);
+                  setShowCityDropdown(true);
+                }}
+                onFocus={() => setShowCityDropdown(true)}
+                onBlur={() => setShowCityDropdown(false)}
+                placeholder="Search a city, e.g. Ploiești"
+              />
+              {showCityDropdown && cityQuery.trim().length >= CITY_SEARCH_MIN_CHARS && (
+                <div
+                  className="absolute z-10 mt-1 w-full max-h-60 overflow-y-auto rounded-md border bg-popover shadow-md"
+                  // Prevents the input's blur (which would close this dropdown
+                  // before the click below fires) when clicking inside it.
+                  onMouseDown={(e) => e.preventDefault()}
+                >
+                  {citySearchPending ? (
+                    <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      Searching…
+                    </div>
+                  ) : cityResults.length === 0 ? (
+                    <div className="p-3 text-sm text-muted-foreground">No matches.</div>
+                  ) : (
+                    cityResults.map((match) => (
+                      <button
+                        key={match.key}
+                        type="button"
+                        className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent"
+                        onClick={() => selectCity(match)}
+                      >
+                        <span>{match.name}</span>
+                        {match.region && <span className="text-xs text-muted-foreground">{match.region}</span>}
+                      </button>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+
+            {selectedCities.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No cities selected yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {selectedCities.map((c) => (
+                  <div key={c.key} className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary" className="flex items-center gap-1">
+                      {c.name}
+                      {c.region ? `, ${c.region}` : ''}
+                      <button
+                        type="button"
+                        onClick={() => removeCity(c.key)}
+                        aria-label={`Remove ${c.name}`}
+                        className="ml-1"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                    <div className="flex items-center gap-1">
+                      <Input
+                        type="number"
+                        min={1}
+                        step="1"
+                        className="h-7 w-16"
+                        value={c.radius}
+                        onChange={(e) => updateCityRadius(c.key, Number(e.target.value))}
+                      />
+                      <span className="text-xs text-muted-foreground">km radius</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
 
       <Card className="h-fit">
         <CardHeader>
@@ -188,47 +447,11 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="primary">Primary text</Label>
-            <Textarea
-              id="primary"
-              value={primary}
-              onChange={(e) => setPrimary(e.target.value)}
-              placeholder="e.g. Escape to the mountains — book your stay at Prahova Chalet"
-              rows={3}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="headline">Headline (optional)</Label>
-            <Input id="headline" value={headline} onChange={(e) => setHeadline(e.target.value)} placeholder="e.g. Prahova Mountain Chalet" />
-          </div>
-
-          <div className="space-y-2">
-            <Label>Call to action</Label>
-            <Select value={cta} onValueChange={(v) => setCta(v as AdCallToAction)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {CTA_OPTIONS.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>
-                    {o.label}
-                    {!o.verified ? ' (unverified against this account)' : ''}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
             <Label htmlFor="landing-url">Landing URL</Label>
-            <Input
-              id="landing-url"
-              value={landingBaseUrl}
-              onChange={(e) => setLandingBaseUrl(e.target.value)}
-            />
+            <Input id="landing-url" value={landingBaseUrl} onChange={(e) => setLandingBaseUrl(e.target.value)} />
             <p className="text-xs text-muted-foreground">
-              Defaults to the property&apos;s canonical custom domain — keep it that way so Meta&apos;s conversion tracking matches the pixel domain.
+              Defaults to the property&apos;s canonical custom domain — keep it that way so Meta&apos;s conversion
+              tracking matches the pixel domain.
             </p>
           </div>
 
@@ -245,23 +468,6 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
             />
             <p className="text-xs text-muted-foreground">Max {maxDailyBudgetRon} RON/day (server-enforced, this is a display hint only).</p>
           </div>
-
-          <div className="space-y-2">
-            <Label>Countries</Label>
-            <div className="grid grid-cols-2 gap-2">
-              {COUNTRY_OPTIONS.map((c) => (
-                <label key={c.code} className="flex items-center gap-2 text-sm">
-                  <Checkbox checked={countries.includes(c.code)} onCheckedChange={() => toggleCountry(c.code)} />
-                  {c.label}
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {/* Age targeting removed (Phase 2b, §9f): the baked-in Advantage+
-              Audience default owns demographics and rejects a hard age range
-              outright — GEO (countries/cities) + copy qualify the audience
-              instead. A city + radius picker is Build B's job for 2b. */}
 
           <div className="space-y-2">
             <Label htmlFor="end-date">End date (required)</Label>

--- a/src/app/admin/ads/_components/compose-form.tsx
+++ b/src/app/admin/ads/_components/compose-form.tsx
@@ -70,8 +70,6 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
   const [landingBaseUrl, setLandingBaseUrl] = useState(defaultLandingUrl);
   const [dailyBudgetRon, setDailyBudgetRon] = useState<string>('20');
   const [countries, setCountries] = useState<string[]>(['RO']);
-  const [ageMin, setAgeMin] = useState('25');
-  const [ageMax, setAgeMax] = useState('65');
   const [endDate, setEndDate] = useState('');
 
   const maxDailyBudgetRon = maxDailyBudgetMinor / 100;
@@ -92,11 +90,6 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
     const budget = Number(dailyBudgetRon);
     if (!Number.isFinite(budget) || budget <= 0) return 'Daily budget must be a positive number.';
     if (countries.length === 0) return 'Select at least one country.';
-    const min = Number(ageMin);
-    const max = Number(ageMax);
-    if (!Number.isFinite(min) || !Number.isFinite(max) || min < 13 || max > 65 || min > max) {
-      return 'Age range must be between 13 and 65, min ≤ max.';
-    }
     const endIso = endOfDayIso(endDate);
     if (!endIso) return 'End date is required.';
     if (Date.parse(endIso) <= Date.now()) return 'End date must be in the future.';
@@ -112,12 +105,16 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
 
     const input: ComposeAndCreateAdInput = {
       propertyId,
-      assetRef: { kind: 'gallery', storagePath },
+      // Phase 2b widened this to an array (multi-image Dynamic Creative) and
+      // dropped age targeting (Advantage+ Audience owns demographics now) —
+      // this form still only offers single-photo/country-only selection; a
+      // city picker + multi-photo picker is Build B's job for 2b, not done here.
+      assetRefs: [{ kind: 'gallery', storagePath }],
       copy: [{ primary: primary.trim(), headline: headline.trim() || undefined, cta }],
       objective: 'sales',
       landingBaseUrl: landingBaseUrl.trim(),
       dailyBudgetMinor: Math.round(Number(dailyBudgetRon) * 100),
-      targeting: { countries, ageMin: Number(ageMin), ageMax: Number(ageMax) },
+      targeting: { cities: [], countries },
       endTime: endOfDayIso(endDate)!,
     };
 
@@ -261,16 +258,10 @@ export function ComposeForm({ propertyId, images, defaultLandingUrl, maxDailyBud
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-2">
-              <Label htmlFor="age-min">Min age</Label>
-              <Input id="age-min" type="number" min={13} max={65} value={ageMin} onChange={(e) => setAgeMin(e.target.value)} />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="age-max">Max age</Label>
-              <Input id="age-max" type="number" min={13} max={65} value={ageMax} onChange={(e) => setAgeMax(e.target.value)} />
-            </div>
-          </div>
+          {/* Age targeting removed (Phase 2b, §9f): the baked-in Advantage+
+              Audience default owns demographics and rejects a hard age range
+              outright — GEO (countries/cities) + copy qualify the audience
+              instead. A city + radius picker is Build B's job for 2b. */}
 
           <div className="space-y-2">
             <Label htmlFor="end-date">End date (required)</Label>

--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -41,6 +41,7 @@ import { activateCampaign, type ActivateResult } from '@/services/growth/adExecu
 import { pauseCampaign, type PauseResult } from '@/services/growth/metaAds/lifecycle';
 import { getInsights, getEffectiveStatus } from '@/services/growth/metaAds/insights';
 import { resolveAdContext } from '@/services/growth/metaAds/adContext';
+import { searchCities, type CityMatch } from '@/services/growth/metaAds/geo';
 
 const logger = loggers.ads;
 
@@ -183,6 +184,29 @@ export async function fetchComposeDataAction(propertyId: string): Promise<{
     logger.error('fetchComposeDataAction failed', error as Error, { propertyId });
     return null;
   }
+}
+
+/**
+ * City typeahead search backing the compose form's city picker (Phase 2b
+ * Build B). Super-admin gated like every other action here; read-only (no
+ * money-touch, no Firestore write) so it gets the lightweight
+ * `[]`-on-any-failure contract rather than a typed error union — an
+ * autocomplete field must degrade to "no results," never surface a toast on
+ * every keystroke.
+ */
+export async function searchCitiesAction(propertyId: string, query: string): Promise<CityMatch[]> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return [];
+    throw error;
+  }
+  const result = await searchCities(propertyId, query);
+  if (!result.ok) {
+    logger.warn('searchCitiesAction: searchCities failed', { propertyId, query, error: result.error });
+    return [];
+  }
+  return result.data;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/growth/__tests__/adComposer.test.ts
+++ b/src/services/growth/__tests__/adComposer.test.ts
@@ -23,18 +23,23 @@ const mockCreateCampaignChain = createCampaignChain as jest.Mock;
 
 const PROPERTY = 'prahova-mountain-chalet';
 
+// Phase 2b (§9f): `assetRef` (singular) -> `assetRefs` (array); `targeting`
+// dropped ageMin/ageMax and gained `cities` as the primary control, with
+// `countries` kept only as a fallback (S1).
 const BASE_INPUT: ComposeAndCreateAdInput = {
   propertyId: PROPERTY,
-  assetRef: {
-    kind: 'gallery',
-    storagePath: `properties/${PROPERTY}/images/a.jpg`,
-    contentHash: 'hash123',
-  },
+  assetRefs: [
+    {
+      kind: 'gallery',
+      storagePath: `properties/${PROPERTY}/images/a.jpg`,
+      contentHash: 'hash123',
+    },
+  ],
   copy: [{ primary: 'Book your stay', headline: 'Escape to the mountains', cta: 'learn_more' }],
   objective: 'sales',
   landingBaseUrl: 'https://prahova-chalet.ro/book',
   dailyBudgetMinor: 5000, // 50 RON
-  targeting: { countries: ['RO'], ageMin: 30, ageMax: 45 },
+  targeting: { cities: [], countries: ['RO'] },
   endTime: '2099-08-01T00:00:00Z',
 };
 
@@ -92,20 +97,48 @@ describe('composeAndCreateAd — MAX_DAILY_BUDGET_MINOR policy (B2)', () => {
   });
 });
 
-describe('composeAndCreateAd — asset ownership assert (S7)', () => {
+describe('composeAndCreateAd — asset presence/ownership assert (S7, 2b: multiple assetRefs)', () => {
+  it('rejects an empty assetRefs array', async () => {
+    const res = await composeAndCreateAd({ ...BASE_INPUT, assetRefs: [] });
+    expect(res).toEqual({ ok: false, error: 'no-asset-ref', stage: 'validation' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than MAX_IMAGES (10) assetRefs', async () => {
+    const tooMany = Array.from({ length: 11 }, (_, i) => ({
+      kind: 'gallery' as const,
+      storagePath: `properties/${PROPERTY}/images/${i}.jpg`,
+    }));
+    const res = await composeAndCreateAd({ ...BASE_INPUT, assetRefs: tooMany });
+    expect(res).toEqual({ ok: false, error: 'too-many-assets:11>10', stage: 'validation' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+
   it('rejects a storagePath that does not belong to propertyId', async () => {
     const res = await composeAndCreateAd({
       ...BASE_INPUT,
-      assetRef: { ...BASE_INPUT.assetRef, storagePath: 'properties/some-other-property/images/a.jpg' },
+      assetRefs: [{ ...BASE_INPUT.assetRefs[0], storagePath: 'properties/some-other-property/images/a.jpg' }],
     });
     expect(res).toEqual({ ok: false, error: 'asset-ownership-mismatch', stage: 'validation' });
     expect(mockUploadImageToAccount).not.toHaveBeenCalled();
   });
 
-  it('rejects an unsupported assetRef.kind', async () => {
+  it('rejects when a SECOND assetRef fails ownership, even if the first is fine', async () => {
     const res = await composeAndCreateAd({
       ...BASE_INPUT,
-      assetRef: { ...BASE_INPUT.assetRef, kind: 'catalog' as 'gallery' },
+      assetRefs: [
+        BASE_INPUT.assetRefs[0],
+        { kind: 'gallery', storagePath: 'properties/some-other-property/images/b.jpg' },
+      ],
+    });
+    expect(res).toEqual({ ok: false, error: 'asset-ownership-mismatch', stage: 'validation' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported assetRefs[].kind', async () => {
+    const res = await composeAndCreateAd({
+      ...BASE_INPUT,
+      assetRefs: [{ ...BASE_INPUT.assetRefs[0], kind: 'catalog' as 'gallery' }],
     });
     expect(res).toEqual({ ok: false, error: 'unsupported-asset-kind:catalog', stage: 'validation' });
   });
@@ -122,12 +155,74 @@ describe('composeAndCreateAd — required-field runtime guards', () => {
     expect(res).toEqual({ ok: false, error: 'no-copy-variant', stage: 'validation' });
   });
 
-  it('rejects an unknown CTA', async () => {
+  it('rejects more than MAX_COPY_VARIANTS (5) copy variants', async () => {
+    const tooMany = Array.from({ length: 6 }, (_, i) => ({ primary: `Variant ${i}`, cta: 'learn_more' as const }));
+    const res = await composeAndCreateAd({ ...BASE_INPUT, copy: tooMany });
+    expect(res).toEqual({ ok: false, error: 'too-many-copy-variants:6>5', stage: 'validation' });
+  });
+
+  it('rejects an unknown CTA on the first variant', async () => {
     const res = await composeAndCreateAd({
       ...BASE_INPUT,
       copy: [{ primary: 'x', cta: 'nonsense' as 'learn_more' }],
     });
     expect(res).toEqual({ ok: false, error: 'unknown-cta:nonsense', stage: 'validation' });
+  });
+
+  it('rejects an unknown CTA on a LATER variant too, not just the first', async () => {
+    const res = await composeAndCreateAd({
+      ...BASE_INPUT,
+      copy: [
+        { primary: 'Variant A', cta: 'learn_more' },
+        { primary: 'Variant B', cta: 'nonsense' as 'learn_more' },
+      ],
+    });
+    expect(res).toEqual({ ok: false, error: 'unknown-cta:nonsense', stage: 'validation' });
+  });
+});
+
+describe('composeAndCreateAd — geo targeting (2b, §9f): cities primary, countries fallback', () => {
+  it('rejects when neither cities nor countries are supplied', async () => {
+    const res = await composeAndCreateAd({ ...BASE_INPUT, targeting: { cities: [] } });
+    expect(res).toEqual({ ok: false, error: 'no-geo-targeting', stage: 'validation' });
+    expect(mockUploadImageToAccount).not.toHaveBeenCalled();
+  });
+
+  it('falls back to geo_locations.countries (no location_types) when cities is empty', async () => {
+    await composeAndCreateAd({ ...BASE_INPUT, targeting: { cities: [], countries: ['RO', 'GB'] } });
+    const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+    expect(chainSpec.adSet.targeting).toEqual({ geo_locations: { countries: ['RO', 'GB'] } });
+  });
+
+  it('maps cities to geo_locations.cities (key+radius, distance_unit:kilometer) + location_types:[home,recent], IGNORING countries when cities is non-empty', async () => {
+    await composeAndCreateAd({
+      ...BASE_INPUT,
+      targeting: {
+        cities: [
+          { key: '1910415', name: 'București', radius: 25 },
+          { key: '1925836', name: 'Ploiești', radius: 15 },
+        ],
+        countries: ['RO'], // present but must be ignored once cities is non-empty
+      },
+    });
+    const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+    expect(chainSpec.adSet.targeting).toEqual({
+      geo_locations: {
+        cities: [
+          { key: '1910415', radius: 25, distance_unit: 'kilometer' },
+          { key: '1925836', radius: 15, distance_unit: 'kilometer' },
+        ],
+        location_types: ['home', 'recent'],
+      },
+    });
+  });
+
+  it('NEVER sends age_min/age_max — advantage_audience:1 owns demographics (§9f), that default lives in campaignBuilder', async () => {
+    await composeAndCreateAd(BASE_INPUT);
+    const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+    expect(chainSpec.adSet.targeting).not.toHaveProperty('age_min');
+    expect(chainSpec.adSet.targeting).not.toHaveProperty('age_max');
+    expect(JSON.stringify(chainSpec.adSet.targeting)).not.toContain('advantage_audience'); // that default is campaignBuilder's job, not adComposer's
   });
 });
 
@@ -151,7 +246,7 @@ describe('composeAndCreateAd — landing URL / UTM link building', () => {
   });
 });
 
-describe('composeAndCreateAd — happy path: neutral → Meta mapping stays out of the public surface', () => {
+describe('composeAndCreateAd — happy path (single image, single copy): neutral → Meta mapping stays out of the public surface', () => {
   it('allocates the id with NO Firestore write, threads utm_campaign into the link, uploads, and maps neutral→Meta before calling createCampaignChain', async () => {
     const { db, docMock } = makeDb('gen-id-1');
     mockGetAdminDb.mockResolvedValue(db);
@@ -170,9 +265,10 @@ describe('composeAndCreateAd — happy path: neutral → Meta mapping stays out 
     // id allocation is pure — .doc() with NO argument, no .set()/.add()/.create() called by adComposer itself.
     expect(docMock).toHaveBeenCalledWith();
 
+    expect(mockUploadImageToAccount).toHaveBeenCalledTimes(1);
     expect(mockUploadImageToAccount).toHaveBeenCalledWith(PROPERTY, {
-      storagePath: BASE_INPUT.assetRef.storagePath,
-      contentHash: BASE_INPUT.assetRef.contentHash,
+      storagePath: BASE_INPUT.assetRefs[0].storagePath,
+      contentHash: BASE_INPUT.assetRefs[0].contentHash,
     });
 
     expect(mockCreateCampaignChain).toHaveBeenCalledTimes(1);
@@ -180,27 +276,21 @@ describe('composeAndCreateAd — happy path: neutral → Meta mapping stays out 
     expect(calledPropertyId).toBe(PROPERTY);
     expect(calledAdCampaignId).toBe('gen-id-1');
 
-    // NO cities anywhere in the spec (S1).
-    expect(JSON.stringify(chainSpec)).not.toContain('cities');
-
     expect(chainSpec.campaign.objective).toBe('OUTCOME_SALES'); // neutral 'sales' -> Meta
     expect(chainSpec.adSet.dailyBudgetMinor).toBe(BASE_INPUT.dailyBudgetMinor);
     expect(chainSpec.adSet.endTime).toBe(BASE_INPUT.endTime);
-    expect(chainSpec.adSet.targeting).toEqual({
-      geo_locations: { countries: ['RO'] },
-      age_min: 30,
-      age_max: 45,
-    });
-    expect(chainSpec.creative.imageHash).toBe('img-hash-1');
-    expect(chainSpec.creative.message).toBe('Book your stay');
-    expect(chainSpec.creative.headline).toBe('Escape to the mountains');
+    expect(chainSpec.adSet.targeting).toEqual({ geo_locations: { countries: ['RO'] } });
+
+    // campaignBuilder (not adComposer) decides single-vs-dynamic from these lengths.
+    expect(chainSpec.creative.imageHashes).toEqual(['img-hash-1']);
+    expect(chainSpec.creative.copy).toEqual([{ primary: 'Book your stay', headline: 'Escape to the mountains' }]);
     expect(chainSpec.creative.callToActionType).toBe('LEARN_MORE'); // neutral 'learn_more' -> Meta
     expect(chainSpec.creative.link).toBe(
       'https://prahova-chalet.ro/book?utm_source=facebook&utm_medium=paid&utm_campaign=gen-id-1'
     );
   });
 
-  it('maps every declared neutral CTA to a Meta CTA string', async () => {
+  it('maps every declared neutral CTA (of the FIRST copy variant) to a Meta CTA string', async () => {
     for (const [neutral, meta] of [
       ['learn_more', 'LEARN_MORE'],
       ['book_now', 'BOOK_TRAVEL'],
@@ -211,6 +301,77 @@ describe('composeAndCreateAd — happy path: neutral → Meta mapping stays out 
       const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
       expect(chainSpec.creative.callToActionType).toBe(meta);
     }
+  });
+});
+
+describe('composeAndCreateAd — multi-image (Dynamic Creative path, §9f)', () => {
+  it('uploads EVERY assetRef in order and collects all image hashes onto chainSpec.creative.imageHashes', async () => {
+    mockUploadImageToAccount
+      .mockResolvedValueOnce({ ok: true, data: { imageHash: 'hash-1' } })
+      .mockResolvedValueOnce({ ok: true, data: { imageHash: 'hash-2' } })
+      .mockResolvedValueOnce({ ok: true, data: { imageHash: 'hash-3' } });
+
+    const input: ComposeAndCreateAdInput = {
+      ...BASE_INPUT,
+      assetRefs: [
+        { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/1.jpg` },
+        { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/2.jpg` },
+        { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/3.jpg` },
+      ],
+    };
+    const res = await composeAndCreateAd(input);
+
+    expect(res.ok).toBe(true);
+    expect(mockUploadImageToAccount).toHaveBeenCalledTimes(3);
+    expect(mockUploadImageToAccount).toHaveBeenNthCalledWith(1, PROPERTY, {
+      storagePath: `properties/${PROPERTY}/images/1.jpg`,
+      contentHash: undefined,
+    });
+    expect(mockUploadImageToAccount).toHaveBeenNthCalledWith(3, PROPERTY, {
+      storagePath: `properties/${PROPERTY}/images/3.jpg`,
+      contentHash: undefined,
+    });
+
+    const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+    expect(chainSpec.creative.imageHashes).toEqual(['hash-1', 'hash-2', 'hash-3']);
+  });
+
+  it('fails fast (upload stage) on the SECOND image and never calls createCampaignChain', async () => {
+    mockUploadImageToAccount
+      .mockResolvedValueOnce({ ok: true, data: { imageHash: 'hash-1' } })
+      .mockResolvedValueOnce({ ok: false, error: 'image-too-narrow' });
+
+    const input: ComposeAndCreateAdInput = {
+      ...BASE_INPUT,
+      assetRefs: [
+        { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/1.jpg` },
+        { kind: 'gallery', storagePath: `properties/${PROPERTY}/images/2.jpg` },
+      ],
+    };
+    const res = await composeAndCreateAd(input);
+
+    expect(res).toEqual({ ok: false, error: 'upload-failed:image-too-narrow', stage: 'upload' });
+    expect(mockUploadImageToAccount).toHaveBeenCalledTimes(2);
+    expect(mockCreateCampaignChain).not.toHaveBeenCalled();
+  });
+
+  it('threads multiple copy variants through to chainSpec.creative.copy (primary/headline only, cta is NOT carried per-variant)', async () => {
+    const input: ComposeAndCreateAdInput = {
+      ...BASE_INPUT,
+      copy: [
+        { primary: 'Variant A', cta: 'learn_more' },
+        { primary: 'Variant B', headline: 'B headline', cta: 'book_now' },
+      ],
+    };
+    await composeAndCreateAd(input);
+    const [, chainSpec] = mockCreateCampaignChain.mock.calls[0];
+    expect(chainSpec.creative.copy).toEqual([
+      { primary: 'Variant A', headline: undefined },
+      { primary: 'Variant B', headline: 'B headline' },
+    ]);
+    // Only the FIRST variant's CTA becomes the ad's CTA (§9f's verified spike
+    // only exercised a one-element call_to_action_types array).
+    expect(chainSpec.creative.callToActionType).toBe('LEARN_MORE');
   });
 });
 

--- a/src/services/growth/adComposer.ts
+++ b/src/services/growth/adComposer.ts
@@ -163,21 +163,32 @@ export interface ComposeAndCreateAdFailure {
 
 export type ComposeAndCreateAdResult = ComposeAndCreateAdSuccess | ComposeAndCreateAdFailure;
 
+/** Meta's `asset_feed_spec.images[]` supports up to ~10 (docs/meta-ads-infrastructure-2026.md §10) — mirrored here as the neutral-layer ceiling. */
+const MAX_IMAGES = 10;
+/** Meta's `asset_feed_spec.bodies[]`/`titles[]` support up to 5 each (§10) — mirrored here as the neutral-layer ceiling. */
+const MAX_COPY_VARIANTS = 5;
+
 /**
  * Compose a neutral ad request into a full PAUSED Meta chain (draft, zero
- * spend). Steps (plan §4):
+ * spend). Steps (plan §4, widened for Phase 2b — §9f):
  *  1. Master-switch gate (`isAdsEngineEnabled`) — same discipline as
  *     `createCampaignChain`'s own gate; checked here too so a disabled engine
  *     fails BEFORE any Storage/Meta call, not just before the Firestore write.
  *  2. `MAX_DAILY_BUDGET_MINOR` policy (B2).
- *  3. Asset ownership assert — `assetRef.storagePath` MUST live under
- *     `properties/${propertyId}/` (S7) — refuses to upload/attribute spend to
- *     an image from a DIFFERENT property's gallery.
+ *  3. Per-asset ownership assert — EVERY `assetRefs[].storagePath` MUST live
+ *     under `properties/${propertyId}/` (S7) — refuses to upload/attribute
+ *     spend to an image from a DIFFERENT property's gallery. Also caps
+ *     `assetRefs`/`copy` at `MAX_IMAGES`/`MAX_COPY_VARIANTS`.
  *  4. Allocate the `adCampaigns` doc id (no Firestore WRITE, B5) and build the
  *     `utm_campaign=<id>` link — the ROAS join key (H1).
- *  5. `uploadImageToAccount` — resolves (or reuses, cache-first) the Meta
- *     `image_hash`.
- *  6. Map neutral → Meta (objective, CTA, copy[0]) and call
+ *  5. `uploadImageToAccount` for EACH asset ref, in order — resolves (or
+ *     reuses, cache-first) a Meta `image_hash` per image; fails fast (and
+ *     never calls `createCampaignChain`) on the first upload failure.
+ *  6. Map neutral → Meta: `targeting.cities` → `geo_locations.cities` (keys +
+ *     radius, `distance_unit:'kilometer'`, `location_types:['home','recent']`
+ *     — §9f), falling back to `targeting.countries` when no city is selected;
+ *     `copy[]` → the creative's `imageHashes`/`copy` (campaignBuilder decides
+ *     single-image vs Dynamic Creative from THEIR lengths, S1). Then calls
  *     `createCampaignChain` with the pre-allocated id — IT is the one writer
  *     of the `adCampaigns` doc.
  *
@@ -202,19 +213,28 @@ export async function composeAndCreateAd(input: ComposeAndCreateAdInput): Promis
     return { ok: false, error: budgetCheck.reason, stage: 'validation' };
   }
 
-  // (3) asset ownership assert (S7) — the asset picker in Build B's console
-  // should already filter to this property's own gallery, but a client is
-  // untrusted input; refuse server-side regardless of what the form sent.
-  if (input.assetRef.kind !== 'gallery') {
-    return { ok: false, error: `unsupported-asset-kind:${input.assetRef.kind}`, stage: 'validation' };
+  // (3) asset presence/ownership assert (S7) — the asset picker in Build B's
+  // console should already filter to this property's own gallery, but a
+  // client is untrusted input; refuse server-side regardless of what the form
+  // sent. Every ref is checked, not just the first (2b: multiple images).
+  if (!input.assetRefs?.length) {
+    return { ok: false, error: 'no-asset-ref', stage: 'validation' };
+  }
+  if (input.assetRefs.length > MAX_IMAGES) {
+    return { ok: false, error: `too-many-assets:${input.assetRefs.length}>${MAX_IMAGES}`, stage: 'validation' };
   }
   const expectedStoragePrefix = `properties/${input.propertyId}/`;
-  if (!input.assetRef.storagePath.startsWith(expectedStoragePrefix)) {
-    logger.warn('composeAndCreateAd: assetRef.storagePath does not belong to propertyId — refusing', {
-      propertyId: input.propertyId,
-      storagePath: input.assetRef.storagePath,
-    });
-    return { ok: false, error: 'asset-ownership-mismatch', stage: 'validation' };
+  for (const assetRef of input.assetRefs) {
+    if (assetRef.kind !== 'gallery') {
+      return { ok: false, error: `unsupported-asset-kind:${assetRef.kind}`, stage: 'validation' };
+    }
+    if (!assetRef.storagePath.startsWith(expectedStoragePrefix)) {
+      logger.warn('composeAndCreateAd: assetRefs[].storagePath does not belong to propertyId — refusing', {
+        propertyId: input.propertyId,
+        storagePath: assetRef.storagePath,
+      });
+      return { ok: false, error: 'asset-ownership-mismatch', stage: 'validation' };
+    }
   }
 
   // (3b) required-field sanity (TypeScript enforces this at compile time for
@@ -226,15 +246,36 @@ export async function composeAndCreateAd(input: ComposeAndCreateAdInput): Promis
   if (!input.copy?.length) {
     return { ok: false, error: 'no-copy-variant', stage: 'validation' };
   }
-  const copy = input.copy[0];
-  const metaCta = CTA_TO_META[copy.cta];
-  if (!metaCta) {
-    return { ok: false, error: `unknown-cta:${copy.cta}`, stage: 'validation' };
+  if (input.copy.length > MAX_COPY_VARIANTS) {
+    return { ok: false, error: `too-many-copy-variants:${input.copy.length}>${MAX_COPY_VARIANTS}`, stage: 'validation' };
+  }
+  for (const variant of input.copy) {
+    if (!CTA_TO_META[variant.cta]) {
+      return { ok: false, error: `unknown-cta:${variant.cta}`, stage: 'validation' };
+    }
   }
   const metaObjective = OBJECTIVE_TO_META[input.objective];
   if (!metaObjective) {
     return { ok: false, error: `unknown-objective:${input.objective}`, stage: 'validation' };
   }
+
+  // (3c) geo targeting: cities are the primary control (2b); countries is a
+  // fallback ONLY used when no city is selected (S1 — keeps 2a's
+  // whole-country targeting working). At least one of the two is required —
+  // an ad set with neither has no geo target at all.
+  const cities = input.targeting.cities ?? [];
+  const countries = input.targeting.countries ?? [];
+  if (!cities.length && !countries.length) {
+    return { ok: false, error: 'no-geo-targeting', stage: 'validation' };
+  }
+  // §9f verified shape: cities carry location_types; a countries-only
+  // targeting object does NOT (matches the pre-2b/§9c payload exactly).
+  const geoLocations = cities.length
+    ? {
+        cities: cities.map((c) => ({ key: c.key, radius: c.radius, distance_unit: 'kilometer' })),
+        location_types: ['home', 'recent'],
+      }
+    : { countries };
 
   // (4) allocate the doc id — NO Firestore write, just id generation (B5) —
   // so `utm_campaign` can be embedded in the link before the creative exists.
@@ -265,22 +306,32 @@ export async function composeAndCreateAd(input: ComposeAndCreateAdInput): Promis
     return { ok: false, error: 'invalid-landing-url', stage: 'validation' };
   }
 
-  // (5) resolve the Meta image_hash (cache-first, per-account dedup).
-  const uploaded = await uploadImageToAccount(input.propertyId, {
-    storagePath: input.assetRef.storagePath,
-    contentHash: input.assetRef.contentHash,
-  });
-  if (!uploaded.ok) {
-    logger.warn('composeAndCreateAd: image upload failed', {
-      propertyId: input.propertyId,
-      adCampaignId,
-      error: uploaded.error,
+  // (5) resolve the Meta image_hash for EVERY asset ref (cache-first,
+  // per-account dedup), in order — fails fast on the first upload failure;
+  // nothing to roll back (an uploaded-but-unused image in Meta's account
+  // library is harmless, same precedent as the pre-2b single-image path).
+  const imageHashes: string[] = [];
+  for (const assetRef of input.assetRefs) {
+    const uploaded = await uploadImageToAccount(input.propertyId, {
+      storagePath: assetRef.storagePath,
+      contentHash: assetRef.contentHash,
     });
-    return { ok: false, error: `upload-failed:${uploaded.error}`, stage: 'upload' };
+    if (!uploaded.ok) {
+      logger.warn('composeAndCreateAd: image upload failed', {
+        propertyId: input.propertyId,
+        adCampaignId,
+        storagePath: assetRef.storagePath,
+        error: uploaded.error,
+      });
+      return { ok: false, error: `upload-failed:${uploaded.error}`, stage: 'upload' };
+    }
+    imageHashes.push(uploaded.data.imageHash);
   }
 
   // (6) map neutral → Meta and delegate the whole chain (incl. the ONE
-  // Firestore write) to createCampaignChain.
+  // Firestore write) to createCampaignChain. `campaignBuilder` (not this
+  // module) decides single-image vs Dynamic Creative from `imageHashes`/`copy`
+  // lengths — this module only supplies Meta-shaped VALUES, not the branch.
   const chainSpec: CreateCampaignChainSpec = {
     campaign: {
       name: `${input.propertyId} — ${adCampaignId}`,
@@ -290,20 +341,22 @@ export async function composeAndCreateAd(input: ComposeAndCreateAdInput): Promis
       name: `${input.propertyId} — ${adCampaignId} — ad set`,
       dailyBudgetMinor: input.dailyBudgetMinor,
       landingUrl: input.landingBaseUrl,
-      targeting: {
-        geo_locations: { countries: input.targeting.countries },
-        age_min: input.targeting.ageMin,
-        age_max: input.targeting.ageMax,
-      },
+      // NO age_min/age_max: the default `advantage_audience:1` (set by
+      // campaignBuilder.createAdSet) OWNS demographics and rejects a hard age
+      // range outright (§9f) — GEO + copy qualify the audience instead.
+      targeting: { geo_locations: geoLocations },
       endTime: input.endTime,
     },
     creative: {
       name: `${input.propertyId} — ${adCampaignId} — creative`,
       link,
-      message: copy.primary,
-      headline: copy.headline,
-      imageHash: uploaded.data.imageHash,
-      callToActionType: metaCta,
+      imageHashes,
+      copy: input.copy.map((c) => ({ primary: c.primary, headline: c.headline })),
+      // §9f's verified spike only exercised a ONE-element CTA array — use the
+      // first variant's CTA for the whole ad rather than inventing an
+      // unverified multi-CTA mapping (see campaignBuilder.CreateCreativeSpec's
+      // doc comment).
+      callToActionType: CTA_TO_META[input.copy[0].cta],
     },
     ad: { name: `${input.propertyId} — ${adCampaignId} — ad` },
   };
@@ -322,6 +375,8 @@ export async function composeAndCreateAd(input: ComposeAndCreateAdInput): Promis
   logger.info('composeAndCreateAd: created draft ad chain', {
     propertyId: input.propertyId,
     adCampaignId: chainResult.adCampaignId,
+    imageCount: imageHashes.length,
+    copyVariantCount: input.copy.length,
   });
 
   return {

--- a/src/services/growth/metaAds/__tests__/campaignBuilder.test.ts
+++ b/src/services/growth/metaAds/__tests__/campaignBuilder.test.ts
@@ -81,8 +81,8 @@ const CHAIN_SPEC = {
   creative: {
     name: 'Test Creative',
     link: 'https://prahova-chalet.ro/book?utm_source=facebook&utm_campaign=abc',
-    message: 'Book your stay',
-    imageHash: 'abc123hash',
+    imageHashes: ['abc123hash'],
+    copy: [{ primary: 'Book your stay' }],
   },
   ad: { name: 'Test Ad' },
 };
@@ -164,7 +164,7 @@ describe('createCampaignChain — engine enabled', () => {
       page_id: PAGE_ID,
       link_data: {
         link: CHAIN_SPEC.creative.link,
-        message: CHAIN_SPEC.creative.message,
+        message: CHAIN_SPEC.creative.copy[0].primary,
         image_hash: 'abc123hash',
         call_to_action: { type: 'LEARN_MORE' },
         use_flexible_image_aspect_ratio: true,
@@ -189,6 +189,8 @@ describe('createCampaignChain — engine enabled', () => {
       objective: 'OUTCOME_SALES',
       dailyBudgetMinor: 5000,
       creativeRef: 'meta-creative-1',
+      assetHashes: ['abc123hash'],
+      imageCount: 1,
       status: 'draft',
     });
     // CRITICAL invariant: never activatable straight out of creation.
@@ -308,7 +310,10 @@ describe('createCampaignChain — engine enabled', () => {
     const { db } = makeAdminDb();
     mockGetAdminDb.mockResolvedValue(db);
 
-    const specWithHeadline = { ...CHAIN_SPEC, creative: { ...CHAIN_SPEC.creative, headline: 'Book your escape' } };
+    const specWithHeadline = {
+      ...CHAIN_SPEC,
+      creative: { ...CHAIN_SPEC.creative, copy: [{ primary: CHAIN_SPEC.creative.copy[0].primary, headline: 'Book your escape' }] },
+    };
     await createCampaignChain(PROPERTY, specWithHeadline);
 
     const [, creativeInit] = findCall('adcreatives');
@@ -318,7 +323,7 @@ describe('createCampaignChain — engine enabled', () => {
       instagram_user_id: '17841435421272996',
       link_data: {
         link: CHAIN_SPEC.creative.link,
-        message: CHAIN_SPEC.creative.message,
+        message: CHAIN_SPEC.creative.copy[0].primary,
         image_hash: 'abc123hash',
         call_to_action: { type: 'LEARN_MORE' },
         use_flexible_image_aspect_ratio: true,
@@ -425,5 +430,160 @@ describe('createCampaignChain — optional pre-allocated adCampaignId (plan REVI
 
     const deletes = findDeleteCalls();
     expect(deletes).toHaveLength(4); // full chain rolled back, same as any other Firestore-stage failure
+  });
+});
+
+describe('createCampaignChain — Phase 2b: advantage_audience default + single-vs-dynamic branch (§9f)', () => {
+  beforeEach(() => {
+    process.env.GROWTH_ADS_ENABLED = 'true';
+    mockResolveAdContext.mockResolvedValue({ adAccountId: AD_ACCOUNT, pageId: PAGE_ID, token: 'tok' });
+    mockGetPixelIdForProperty.mockResolvedValue('pixel-123');
+    mockMetaResponses();
+  });
+
+  it('defaults targeting_automation.advantage_audience to 1 (flipped from 0) and sends NO age fields', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    await createCampaignChain(PROPERTY, CHAIN_SPEC);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    const targeting = JSON.parse(adSetBody.get('targeting') as string);
+    expect(targeting.targeting_automation).toEqual({ advantage_audience: 1 });
+    expect(targeting).not.toHaveProperty('age_min');
+    expect(targeting).not.toHaveProperty('age_max');
+  });
+
+  it('a caller-supplied targeting_automation overrides the advantage_audience default', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const specWithOverride = {
+      ...CHAIN_SPEC,
+      adSet: {
+        ...CHAIN_SPEC.adSet,
+        targeting: {
+          geo_locations: { countries: ['RO'] },
+          targeting_automation: { advantage_audience: 0 },
+          age_min: 30,
+          age_max: 45,
+        },
+      },
+    };
+    await createCampaignChain(PROPERTY, specWithOverride);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    const targeting = JSON.parse(adSetBody.get('targeting') as string);
+    expect(targeting.targeting_automation).toEqual({ advantage_audience: 0 });
+    expect(targeting.age_min).toBe(30);
+    expect(targeting.age_max).toBe(45);
+  });
+
+  it('passes a caller-built geo_locations.cities + location_types through unchanged (§9f — campaignBuilder is opaque passthrough)', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const specWithCities = {
+      ...CHAIN_SPEC,
+      adSet: {
+        ...CHAIN_SPEC.adSet,
+        targeting: {
+          geo_locations: {
+            cities: [{ key: '1910415', radius: 25, distance_unit: 'kilometer' }],
+            location_types: ['home', 'recent'],
+          },
+        },
+      },
+    };
+    await createCampaignChain(PROPERTY, specWithCities);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    const targeting = JSON.parse(adSetBody.get('targeting') as string);
+    expect(targeting.geo_locations).toEqual({
+      cities: [{ key: '1910415', radius: 25, distance_unit: 'kilometer' }],
+      location_types: ['home', 'recent'],
+    });
+  });
+
+  it('single image + single copy variant: NO is_dynamic_creative on the ad set, object_story_spec/link_data on the creative (byte-for-byte pre-2b shape)', async () => {
+    const { db } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    await createCampaignChain(PROPERTY, CHAIN_SPEC);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    expect(adSetBody.has('is_dynamic_creative')).toBe(false);
+
+    const [, creativeInit] = findCall('adcreatives');
+    const creativeBody = new URLSearchParams(creativeInit.body as string);
+    expect(creativeBody.has('asset_feed_spec')).toBe(false);
+    const objectStorySpec = JSON.parse(creativeBody.get('object_story_spec') as string);
+    expect(objectStorySpec.link_data).toBeDefined();
+  });
+
+  it('2+ images: is_dynamic_creative:true on the ad set, asset_feed_spec (NO link_data) on the creative, ALL image hashes present, Firestore doc records them', async () => {
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const dynamicSpec = {
+      ...CHAIN_SPEC,
+      creative: {
+        ...CHAIN_SPEC.creative,
+        imageHashes: ['hash-1', 'hash-2', 'hash-3'],
+        copy: [{ primary: 'Escape to the mountains', headline: 'Mountain Chalet' }],
+      },
+    };
+    await createCampaignChain(PROPERTY, dynamicSpec);
+
+    const [, adSetInit] = findCall('adsets');
+    const adSetBody = new URLSearchParams(adSetInit.body as string);
+    expect(adSetBody.get('is_dynamic_creative')).toBe('true');
+
+    const [, creativeInit] = findCall('adcreatives');
+    const creativeBody = new URLSearchParams(creativeInit.body as string);
+    const objectStorySpec = JSON.parse(creativeBody.get('object_story_spec') as string);
+    expect(objectStorySpec).not.toHaveProperty('link_data');
+    const assetFeedSpec = JSON.parse(creativeBody.get('asset_feed_spec') as string);
+    expect(assetFeedSpec.images).toEqual([{ hash: 'hash-1' }, { hash: 'hash-2' }, { hash: 'hash-3' }]);
+    expect(assetFeedSpec.bodies).toEqual([{ text: 'Escape to the mountains' }]);
+    expect(assetFeedSpec.titles).toEqual([{ text: 'Mountain Chalet' }]);
+    expect(assetFeedSpec.link_urls).toEqual([{ website_url: CHAIN_SPEC.creative.link }]);
+    expect(assetFeedSpec.call_to_action_types).toEqual(['LEARN_MORE']);
+    expect(assetFeedSpec.ad_formats).toEqual(['AUTOMATIC_FORMAT']);
+
+    const doc = addMock.mock.calls[0][0];
+    expect(doc.assetHashes).toEqual(['hash-1', 'hash-2', 'hash-3']);
+    expect(doc.imageCount).toBe(3);
+  });
+
+  it('2+ copy variants (single image) also triggers the dynamic path, with titles[] falling back to body text when no headline is given', async () => {
+    const { db, addMock } = makeAdminDb();
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const dynamicCopySpec = {
+      ...CHAIN_SPEC,
+      creative: {
+        ...CHAIN_SPEC.creative,
+        imageHashes: ['abc123hash'],
+        copy: [{ primary: 'Variant A' }, { primary: 'Variant B', headline: 'B headline' }],
+      },
+    };
+    await createCampaignChain(PROPERTY, dynamicCopySpec);
+
+    const [, adSetInit] = findCall('adsets');
+    expect(new URLSearchParams(adSetInit.body as string).get('is_dynamic_creative')).toBe('true');
+
+    const [, creativeInit] = findCall('adcreatives');
+    const assetFeedSpec = JSON.parse(new URLSearchParams(creativeInit.body as string).get('asset_feed_spec') as string);
+    expect(assetFeedSpec.bodies).toEqual([{ text: 'Variant A' }, { text: 'Variant B' }]);
+    expect(assetFeedSpec.titles).toEqual([{ text: 'Variant A' }, { text: 'B headline' }]); // no-headline variant falls back to its own body text
+
+    const doc = addMock.mock.calls[0][0];
+    expect(doc.assetHashes).toEqual(['abc123hash']);
+    expect(doc.imageCount).toBe(1);
   });
 });

--- a/src/services/growth/metaAds/__tests__/geo.test.ts
+++ b/src/services/growth/metaAds/__tests__/geo.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+
+// Mock adContext (token resolution) only — use the REAL client.ts (metaGraph)
+// against a mocked global.fetch, so the exact verified query-string shape
+// (§9f) is exercised end-to-end, not assumed.
+jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
+
+import { searchCities } from '../geo';
+import { resolveAdContext } from '../adContext';
+import { GRAPH_API_VERSION } from '../client';
+
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockFetch = global.fetch as jest.Mock;
+
+const PROPERTY = 'prahova-mountain-chalet';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetch.mockReset();
+  mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_543311232953437', token: 'SECRET-TOKEN' });
+});
+
+describe('searchCities — token/context resolution', () => {
+  it('returns {ok:false,error:"no-ad-context"} without calling fetch when the property has no ad context', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await searchCities(PROPERTY, 'Ploiesti');
+    expect(res).toEqual({ ok: false, error: 'no-ad-context' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits to an empty match list, WITHOUT calling fetch, for an empty/whitespace query', async () => {
+    const res = await searchCities(PROPERTY, '   ');
+    expect(res).toEqual({ ok: true, data: [] });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockResolveAdContext).not.toHaveBeenCalled();
+  });
+});
+
+describe('searchCities — verified query contract (§9f)', () => {
+  it('GETs /search with type=adgeolocation, location_types=["city"], q, country_code, limit — token in the header, never the URL', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: [] }) });
+    await searchCities(PROPERTY, 'Ploiesti');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe(`/${GRAPH_API_VERSION}/search`);
+    expect(parsed.searchParams.get('type')).toBe('adgeolocation');
+    expect(parsed.searchParams.get('location_types')).toBe('["city"]');
+    expect(parsed.searchParams.get('q')).toBe('Ploiesti');
+    expect(parsed.searchParams.get('country_code')).toBe('RO'); // default
+    expect(parsed.searchParams.get('limit')).toBe('8'); // default
+    expect(String(url)).not.toContain('SECRET-TOKEN');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer SECRET-TOKEN');
+  });
+
+  it('trims the query before sending it', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: [] }) });
+    await searchCities(PROPERTY, '  Constanta  ');
+    const [url] = mockFetch.mock.calls[0];
+    expect(new URL(String(url)).searchParams.get('q')).toBe('Constanta');
+  });
+
+  it('honors an explicit countryCode/limit override', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: [] }) });
+    await searchCities(PROPERTY, 'Berlin', { countryCode: 'DE', limit: 3 });
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.searchParams.get('country_code')).toBe('DE');
+    expect(parsed.searchParams.get('limit')).toBe('3');
+  });
+});
+
+describe('searchCities — response parsing', () => {
+  it('parses the verified match shape (§9f: București/Ploiești/Constanța keys)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { key: '1910415', name: 'Bucharest', region: 'Bucuresti', region_id: '111', country_code: 'RO', type: 'city' },
+          { key: '1925836', name: 'Ploiesti', region: 'Prahova', country_code: 'RO', type: 'city' },
+        ],
+      }),
+    });
+
+    const res = await searchCities(PROPERTY, 'plo');
+    expect(res).toEqual({
+      ok: true,
+      data: [
+        { key: '1910415', name: 'Bucharest', region: 'Bucuresti', countryCode: 'RO' },
+        { key: '1925836', name: 'Ploiesti', region: 'Prahova', countryCode: 'RO' },
+      ],
+    });
+  });
+
+  it('filters out malformed entries missing key/name, never throws', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ name: 'No key' }, { key: '123' }, { key: '456', name: 'Valid City' }] }),
+    });
+
+    const res = await searchCities(PROPERTY, 'x');
+    expect(res).toEqual({ ok: true, data: [{ key: '456', name: 'Valid City', region: undefined, countryCode: undefined }] });
+  });
+
+  it('handles a missing data[] field as zero matches', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const res = await searchCities(PROPERTY, 'x');
+    expect(res).toEqual({ ok: true, data: [] });
+  });
+});
+
+describe('searchCities — never throws (GraphResult discipline)', () => {
+  it('returns a typed {ok:false,error} on a non-OK response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, text: async () => 'bad request' });
+    const res = await searchCities(PROPERTY, 'x');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('bad request');
+  });
+
+  it('returns a typed {ok:false,error} on a network error', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    const res = await searchCities(PROPERTY, 'x');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('network down');
+  });
+});

--- a/src/services/growth/metaAds/campaignBuilder.ts
+++ b/src/services/growth/metaAds/campaignBuilder.ts
@@ -33,7 +33,7 @@ import { loggers } from '@/lib/logger';
 import { isAdsEngineEnabled } from '@/config/growth-ads';
 import { getPixelIdForProperty } from '@/lib/meta-pixels';
 import { resolveAdContext } from './adContext';
-import { createResource, deleteResource, type GraphResult } from './client';
+import { createResource, deleteResource, type GraphParamValue, type GraphResult } from './client';
 
 const logger = loggers.ads;
 
@@ -55,7 +55,17 @@ export interface CreateCampaignSpec {
 }
 
 export interface AdSetTargeting {
-  /** Meta `targeting` object shape, e.g. `{ geo_locations: {...}, age_min, age_max }` — passed through as-is (validated shape: docs/meta-ads-infrastructure-2026.md §9). */
+  /**
+   * Meta `targeting` object shape — passed through as-is (validated shape:
+   * docs/meta-ads-infrastructure-2026.md §9/§9f). The caller (`adComposer`)
+   * builds this Meta-shaped object; `createAdSet` only injects the
+   * `targeting_automation` default (below) on top of it. Phase-2b shape:
+   * `{ geo_locations: { cities:[{key,radius,distance_unit:'kilometer'}], location_types:['home','recent'] } }`
+   * (city targeting) OR `{ geo_locations: { countries:[...] } }` (2a's
+   * whole-country fallback, still supported — §9c). NO `age_min`/`age_max` on
+   * the default `advantage_audience:1` path (§9f: Advantage+ Audience owns
+   * demographics and rejects a hard age range outright).
+   */
   [key: string]: unknown;
 }
 
@@ -77,19 +87,51 @@ export interface CreateAdSetSpec {
    */
   endTime?: string;
   startTime?: string;
+  /**
+   * Phase 2b (§9f): true when the paired creative is a Dynamic Creative
+   * (`asset_feed_spec` — 2+ images or 2+ copy variants) — injects
+   * `is_dynamic_creative:true` into the create payload. REQUIRED whenever the
+   * creative is dynamic: attaching a Dynamic-Creative ad to a NON-dynamic ad
+   * set fails with err 100/1885998 "Cannot Create Dynamic Creative ad In
+   * Non-Dynamic Creative Ad Set" — `createCampaignChain` computes this once
+   * and threads the SAME value to both `createAdSet` and `createCreative` so
+   * the two can never disagree. Omitted (not sent to Meta at all) when falsy —
+   * matches the single-image path's byte-for-byte pre-2b payload.
+   */
+  isDynamic?: boolean;
+}
+
+/** One copy variant for a creative — `link_data.message`/`.name` on the single-image path, one entry of `asset_feed_spec.bodies[]`/`titles[]` on the Dynamic Creative path. */
+export interface CreativeCopyVariant {
+  primary: string;
+  headline?: string;
 }
 
 export interface CreateCreativeSpec {
   name: string;
-  /** Click-through link — should already carry `?utm_source=facebook&utm_campaign=<adCampaigns.id>` (Fable H1); this module does not append UTMs itself. */
+  /** Click-through link — should already carry `?utm_source=facebook&utm_campaign=<adCampaigns.id>` (Fable H1); this module does not append UTMs itself. Used as `link_data.link` (single-image) or every `asset_feed_spec.link_urls[].website_url` (dynamic — one link, §9f's verified shape has a single `link_urls` entry regardless of image count). */
   link: string;
-  message: string;
-  /** Image hash from `/act_<id>/adimages` (`metaAds/adImages.uploadImageToAccount`, plan REVISIONS B4). */
-  imageHash: string;
-  /** Defaults to 'LEARN_MORE', the only CTA verified against the live account (§9c). */
+  /**
+   * Image hash(es) from `/act_<id>/adimages` (`metaAds/adImages.uploadImageToAccount`,
+   * plan REVISIONS B4). Exactly 1 element ⇒ single-image `object_story_spec.link_data`
+   * path (§9c/§9d, unchanged payload shape). 2+ elements ⇒ Dynamic Creative
+   * `asset_feed_spec.images[]` path (§9f).
+   */
+  imageHashes: string[];
+  /** Copy variant(s). Exactly 1 ⇒ single-image path (`.message`/`.name`). 2+ (or paired with 2+ `imageHashes`) ⇒ Dynamic Creative `bodies[]`/`titles[]`. */
+  copy: CreativeCopyVariant[];
+  /** Defaults to 'LEARN_MORE', the only CTA verified against the live account (§9c). Sent as `link_data.call_to_action.type` (single) or the sole entry of `asset_feed_spec.call_to_action_types[]` (dynamic) — §9f's verified spike only exercised a ONE-element CTA array, so this module does not (yet) support per-variant CTAs in the dynamic path. */
   callToActionType?: string;
-  /** `link_data.name` — the ad's headline. Verified accepted + read back correctly (§9d); optional (S6: be ready to drop it from the form if it turns out not to render everywhere). */
-  headline?: string;
+  /**
+   * Phase 2b (§9f): true ⇒ build `asset_feed_spec` with NO `link_data` on
+   * `object_story_spec` (the two are mutually exclusive on this endpoint).
+   * MUST match the paired ad set's `is_dynamic_creative` (see
+   * `CreateAdSetSpec.isDynamic`'s doc comment — err 100/1885998 otherwise).
+   * When omitted, derived as `imageHashes.length > 1 || copy.length > 1` — a
+   * direct (non-chain) caller gets a sane default; `createCampaignChain`
+   * always sets this explicitly so it can never diverge from the ad set's flag.
+   */
+  isDynamic?: boolean;
 }
 
 export interface CreateAdSpec {
@@ -197,12 +239,18 @@ export async function createAdSet(
 
   // Meta REQUIRES an explicit Advantage+ audience opt-in/out (error 100/1870227
   // "Advantage Audience Flag Required") whenever the ad set carries audience
-  // targeting (age/interests) — verified live in the Phase-2a compose test (the
-  // §9b/c spikes used geo-only, so they didn't hit it). Default `advantage_audience:0`
-  // = respect our EXACT targeting (no Meta audience expansion); a caller that
-  // sets its own `targeting_automation` overrides it. (docs …§9e)
+  // targeting — verified live in the Phase-2a compose test (the §9b/c spikes
+  // used geo-only, so they didn't hit it). DEFAULT flipped 0→1 in Phase 2b
+  // (§9f, KEY design fact): `advantage_audience:1` = Meta's Advantage+
+  // Audience OWNS demographics — it is our system's baked default (best
+  // cold-start; no hard age/gender/interests in this system, GEO + copy
+  // qualify instead) and, per §9f, is INCOMPATIBLE with a hard `age_min`/
+  // `age_max` (err 100/1870188-9) — so `adComposer` never sends age fields on
+  // this default path. A caller that sets its own `targeting_automation`
+  // (e.g. an explicit `advantage_audience:0` escape hatch, which MAY then
+  // carry age/gender/interests) overrides this default via the spread below.
   const targeting = {
-    targeting_automation: { advantage_audience: 0 },
+    targeting_automation: { advantage_audience: 1 },
     ...spec.targeting,
   };
 
@@ -222,6 +270,10 @@ export async function createAdSet(
       bid_strategy: 'LOWEST_COST_WITHOUT_CAP',
       ...(spec.startTime ? { start_time: spec.startTime } : {}),
       ...(spec.endTime ? { end_time: spec.endTime } : {}),
+      // §9f gotcha (err 100/1885998): a Dynamic-Creative ad REQUIRES its ad
+      // set to carry this flag — omitted (not merely `false`) on the normal
+      // single-image path so the payload matches the pre-2b shape exactly.
+      ...(spec.isDynamic ? { is_dynamic_creative: true } : {}),
     },
     propertyId
   );
@@ -231,17 +283,31 @@ export async function createAdSet(
  * Create a PAUSED ad creative. Requires the property to have a configured
  * Meta Page (`ctx.pageId` — multi-property config); returns
  * `{ok:false,error:'no-page'}` without calling Meta if none is configured.
- * `object_story_spec` shape matches the live-verified contract (§9c), extended
- * with three fields verified in the Phase-2a spike (§9d):
- *  - `instagram_user_id` (`ctx.instagramActorId`, when the property has one
- *    configured) — WITHOUT it the ad is FB-only; Meta's IG placements need it
- *    (plan REVISIONS S5).
- *  - `link_data.use_flexible_image_aspect_ratio: true` — always on; lets Meta
- *    auto-fit the single supplied image to each placement's aspect ratio
- *    (2a ships one photo, no per-placement crops yet — plan §2 "Non-goals").
- *  - `link_data.name` — the headline, only when the caller supplies one (S6:
- *    unverified whether it renders on every placement; keep it optional so a
- *    2a form can drop it without a code change).
+ * Two payload shapes, chosen by `isDynamic` (`spec.isDynamic`, or derived —
+ * see `CreateCreativeSpec.isDynamic`'s doc comment):
+ *
+ *  - **Single-image** (`imageHashes.length===1 && copy.length===1`): the
+ *    original `object_story_spec.link_data` shape (§9c), extended with three
+ *    fields verified in the Phase-2a spike (§9d) — `instagram_user_id`
+ *    (`ctx.instagramActorId`, when configured — WITHOUT it the ad is FB-only,
+ *    plan REVISIONS S5), `link_data.use_flexible_image_aspect_ratio:true`
+ *    (always on — lets Meta auto-fit the one photo per placement), and
+ *    `link_data.name` (the headline, only when supplied — S6: unverified
+ *    whether it renders on every placement). BYTE-FOR-BYTE unchanged from
+ *    pre-2b for this path.
+ *  - **Dynamic Creative** (2+ images or 2+ copy variants, §9f): NO
+ *    `link_data` on `object_story_spec` — the two are mutually exclusive on
+ *    this endpoint — plus a sibling `asset_feed_spec` carrying every image
+ *    hash, every copy variant's body/title, the (single) link and CTA, and
+ *    `ad_formats:['AUTOMATIC_FORMAT']` so Meta mixes assets and picks per
+ *    placement. `titles[]` falls back to a variant's body text when it has no
+ *    explicit headline, so this array is NEVER empty (Meta's `titles[]` is a
+ *    required sibling of `bodies[]`, unlike the optional `descriptions[]`,
+ *    which this module does not send — no neutral field maps to it). The
+ *    PAIRED ad set MUST carry `is_dynamic_creative:true` or Meta rejects this
+ *    ad with err 100/1885998 — `createCampaignChain` is the module that keeps
+ *    the two in sync; a direct caller of this function is responsible for that
+ *    itself.
  */
 export async function createCreative(
   propertyId: string,
@@ -256,28 +322,53 @@ export async function createCreative(
     logger.warn('createCreative: no Meta Page configured for property — refusing to create', { propertyId });
     return { ok: false, error: 'no-page' };
   }
+  if (!spec.imageHashes.length) {
+    logger.warn('createCreative: no image hashes supplied — refusing to create', { propertyId });
+    return { ok: false, error: 'no-image-hashes' };
+  }
+  if (!spec.copy.length) {
+    logger.warn('createCreative: no copy variants supplied — refusing to create', { propertyId });
+    return { ok: false, error: 'no-copy-variants' };
+  }
 
-  return createResource<{ id: string }>(
-    'adcreatives',
-    ctx.adAccountId,
-    ctx.token,
-    {
-      name: spec.name,
-      object_story_spec: {
-        page_id: ctx.pageId,
-        ...(ctx.instagramActorId ? { instagram_user_id: ctx.instagramActorId } : {}),
-        link_data: {
-          link: spec.link,
-          message: spec.message,
-          image_hash: spec.imageHash,
-          call_to_action: { type: spec.callToActionType ?? 'LEARN_MORE' },
-          use_flexible_image_aspect_ratio: true,
-          ...(spec.headline ? { name: spec.headline } : {}),
-        },
+  const isDynamic = spec.isDynamic ?? (spec.imageHashes.length > 1 || spec.copy.length > 1);
+  const callToActionType = spec.callToActionType ?? 'LEARN_MORE';
+
+  const objectStorySpec: Record<string, unknown> = {
+    page_id: ctx.pageId,
+    ...(ctx.instagramActorId ? { instagram_user_id: ctx.instagramActorId } : {}),
+  };
+
+  const payload: Record<string, GraphParamValue> = { name: spec.name };
+
+  if (isDynamic) {
+    payload.object_story_spec = objectStorySpec; // NO link_data (§9f — mutually exclusive with asset_feed_spec)
+    payload.asset_feed_spec = {
+      images: spec.imageHashes.map((hash) => ({ hash })),
+      bodies: spec.copy.map((c) => ({ text: c.primary })),
+      // Required sibling of bodies[] — fall back to the body text itself when
+      // a variant has no explicit headline, so this is never empty (see this
+      // function's doc comment).
+      titles: spec.copy.map((c) => ({ text: c.headline ?? c.primary })),
+      link_urls: [{ website_url: spec.link }],
+      call_to_action_types: [callToActionType],
+      ad_formats: ['AUTOMATIC_FORMAT'],
+    };
+  } else {
+    payload.object_story_spec = {
+      ...objectStorySpec,
+      link_data: {
+        link: spec.link,
+        message: spec.copy[0].primary,
+        image_hash: spec.imageHashes[0],
+        call_to_action: { type: callToActionType },
+        use_flexible_image_aspect_ratio: true,
+        ...(spec.copy[0].headline ? { name: spec.copy[0].headline } : {}),
       },
-    },
-    propertyId
-  );
+    };
+  }
+
+  return createResource<{ id: string }>('adcreatives', ctx.adAccountId, ctx.token, payload, propertyId);
 }
 
 /** Create a PAUSED ad under `adSetId`, wired to `creativeId`. Last link in the chain. */
@@ -398,6 +489,16 @@ async function rollback(propertyId: string, token: string, targets: RollbackTarg
  * either way (B5) — `adComposer` never touches Firestore directly. Omitting
  * `adCampaignId` keeps the original `.add()` behavior exactly (the Phase-1
  * validation harness and existing tests rely on this).
+ *
+ * Phase 2b (§9f): this function is the SINGLE place `isDynamic` gets computed
+ * — `spec.creative.imageHashes.length > 1 || spec.creative.copy.length > 1` —
+ * and it is threaded, identically, into BOTH `createAdSet` (→
+ * `is_dynamic_creative`) and `createCreative` (→ `asset_feed_spec` vs
+ * `object_story_spec.link_data`). Any `isDynamic` the caller set on the
+ * nested `spec.adSet`/`spec.creative` is overridden here — this is the ONE
+ * enforcement point that keeps the ad set's flag and the creative's payload
+ * shape from ever disagreeing (§9f's err 100/1885998 gotcha), the same
+ * "single enforcement point" discipline `client.ts`'s PAUSED injection uses.
  */
 export async function createCampaignChain(
   propertyId: string,
@@ -420,6 +521,9 @@ export async function createCampaignChain(
     return { ok: false, error: 'no-ad-context', stage: 'context' };
   }
 
+  // Computed ONCE, threaded to both stages below (§9f) — see doc comment.
+  const isDynamic = spec.creative.imageHashes.length > 1 || spec.creative.copy.length > 1;
+
   // (c) campaign
   const campaignRes = await createCampaign(propertyId, spec.campaign);
   if (!campaignRes.ok) {
@@ -429,7 +533,7 @@ export async function createCampaignChain(
   const campaignId = campaignRes.data.id;
 
   // (d) ad set
-  const adSetRes = await createAdSet(propertyId, campaignId, spec.adSet);
+  const adSetRes = await createAdSet(propertyId, campaignId, { ...spec.adSet, isDynamic });
   if (!adSetRes.ok) {
     logger.warn('createCampaignChain: adSet stage failed — rolling back', { propertyId, error: adSetRes.error });
     await rollback(propertyId, ctx.token, [{ kind: 'campaign', id: campaignId }]);
@@ -438,7 +542,7 @@ export async function createCampaignChain(
   const adSetId = adSetRes.data.id;
 
   // (e) creative
-  const creativeRes = await createCreative(propertyId, spec.creative);
+  const creativeRes = await createCreative(propertyId, { ...spec.creative, isDynamic });
   if (!creativeRes.ok) {
     logger.warn('createCampaignChain: creative stage failed — rolling back', {
       propertyId,
@@ -480,6 +584,12 @@ export async function createCampaignChain(
       // arithmetic (dailyBudget × days × margin ≤ cap) without a Meta read-back.
       endTime: spec.adSet.endTime ?? null,
       creativeRef: creativeId,
+      // Phase 2b (§9f) — record which/how-many image hashes this creative was
+      // built from, so the console can show "3 photos, dynamic" without a
+      // Meta read-back. `assetHashes` doubles as an audit trail (same image
+      // reused across ads is visible directly on the doc).
+      assetHashes: spec.creative.imageHashes,
+      imageCount: spec.creative.imageHashes.length,
       status: 'draft',
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),

--- a/src/services/growth/metaAds/geo.ts
+++ b/src/services/growth/metaAds/geo.ts
@@ -1,0 +1,111 @@
+/**
+ * City geo-targeting search — Phase 2b (docs/meta-ads-infrastructure-2026.md
+ * §9f). Resolves a free-text city name to Meta's `adgeolocation` `key` —
+ * cities MUST be targeted by `key`, never by name (§9f: "keys verified —
+ * București=1910415, Ploiești=1925836, Constanța=1913456"). This is a
+ * read-only GET through the shared `metaGraph` client — no `createResource`
+ * needed (that helper's PAUSED enforcement only matters for writes).
+ *
+ * Takes a `propertyId` purely to resolve a Bearer token via
+ * `resolveAdContext` — Meta's `/search?type=adgeolocation` node is NOT
+ * ad-account-scoped (it isn't called as `act_<id>/search`), but every Graph
+ * call in this codebase goes through a resolved ad context so there's exactly
+ * one token-resolution path, mirroring every other `metaAds/*` module.
+ *
+ * Never throws (`GraphResult` discipline, same as the rest of `metaAds/*`) —
+ * an unconfigured property, a network error, or a malformed response all
+ * resolve to a typed `{ok:false}`; a caller-facing city-picker autocomplete
+ * must degrade to "no results," never crash the form.
+ *
+ * Plain server module (NOT `'use server'`) — exports types + async functions.
+ */
+import { loggers } from '@/lib/logger';
+import { resolveAdContext } from './adContext';
+import { metaGraph, type GraphResult } from './client';
+
+const logger = loggers.ads;
+
+/** A single Meta `adgeolocation` city match. `key` is the ONLY valid targeting identifier — `name`/`region` are display-only. */
+export interface CityMatch {
+  key: string;
+  name: string;
+  region?: string;
+  countryCode?: string;
+}
+
+export interface SearchCitiesOptions {
+  /** ISO 3166-1 alpha-2. Defaults to `'RO'` — this system's only market so far (multi-property note: pass explicitly once a non-RO property onboards). */
+  countryCode?: string;
+  /** Max matches to return. Defaults to 8 — enough for a form's autocomplete dropdown without over-fetching. */
+  limit?: number;
+}
+
+/** Raw shape of Meta's `/search?type=adgeolocation` response — only the fields we read. */
+interface AdGeoLocationSearchResponse {
+  data?: Array<{
+    key?: string;
+    name?: string;
+    region?: string;
+    region_id?: string | number;
+    country_code?: string;
+    type?: string;
+  }>;
+}
+
+/**
+ * Resolve city name(s) matching `query` to Meta's `adgeolocation` keys.
+ * Verified contract (§9f): `GET /search?type=adgeolocation&location_types=["city"]&q=<name>&country_code=<cc>&limit=<n>`
+ * → `data[].{key,name,region,region_id,country_code}`. `location_types` is
+ * sent as a JSON-encoded array (`metaGraph`'s standard handling of
+ * object/array param values) — this reproduces the exact verified query
+ * string shape, not an approximation of it.
+ *
+ * An empty/whitespace-only `query` short-circuits to `{ok:true,data:[]}`
+ * WITHOUT calling Meta — an autocomplete field firing on every keystroke
+ * shouldn't burn a Graph call on an empty string.
+ */
+export async function searchCities(
+  propertyId: string,
+  query: string,
+  opts: SearchCitiesOptions = {}
+): Promise<GraphResult<CityMatch[]>> {
+  const trimmed = query.trim();
+  if (!trimmed) return { ok: true, data: [] };
+
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('searchCities: no ad context for property — refusing to search', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  const countryCode = opts.countryCode ?? 'RO';
+  const limit = opts.limit ?? 8;
+
+  const result = await metaGraph<AdGeoLocationSearchResponse>('search', {
+    method: 'GET',
+    params: {
+      type: 'adgeolocation',
+      location_types: ['city'],
+      q: trimmed,
+      country_code: countryCode,
+      limit,
+    },
+    token: ctx.token,
+    propertyId,
+  });
+
+  if (!result.ok) return result;
+
+  const matches: CityMatch[] = (result.data.data ?? [])
+    .filter((entry): entry is { key: string; name: string; region?: string; country_code?: string } =>
+      Boolean(entry.key && entry.name)
+    )
+    .map((entry) => ({
+      key: entry.key,
+      name: entry.name,
+      region: entry.region,
+      countryCode: entry.country_code,
+    }));
+
+  return { ok: true, data: matches };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -468,6 +468,10 @@ export interface AdCampaign {
   status: AdCampaignStatus;
   effectiveStatus?: string;        // Meta's effective_status, mirrored by the Phase-2 reconciliation cron
   creativeRef?: string;
+  /** Phase 2b (§9f) — the Meta `image_hash`(es) the creative was built from; 1 = single-image `object_story_spec`, 2+ = Dynamic Creative `asset_feed_spec`. */
+  assetHashes?: string[];
+  /** Phase 2b — `assetHashes.length`, denormalized for a list view (e.g. "3 photos, dynamic") without reading the array. */
+  imageCount?: number;
   approvedBy?: string;
   approvalSnapshot?: {
     dailyBudgetMinor?: number;
@@ -489,9 +493,12 @@ export interface AdCampaign {
 
 /**
  * Growth Ad Engine — platform-NEUTRAL copy for one ad (Phase 2a Build A, plan
- * REVISIONS S1). 2a composes with exactly ONE variant (`ComposeAndCreateAdInput.copy.length === 1`)
- * — the array shape is future-proofed for 2b's `asset_feed_spec` multi-variant
- * creative so that change doesn't need a schema migration later.
+ * REVISIONS S1; genuinely multi-variant since Phase 2b). 2a composed with
+ * exactly ONE variant; 2b allows up to `MAX_COPY_VARIANTS` (5, mirrors Meta's
+ * `asset_feed_spec.bodies[]`/`titles[]` ≤5-each limit,
+ * docs/meta-ads-infrastructure-2026.md §10) — `adComposer` maps 1 variant to
+ * the single-image `object_story_spec.link_data` path and 2+ to the Dynamic
+ * Creative `asset_feed_spec` path (§9f).
  */
 export interface CopyVariant {
   primary: string;
@@ -515,16 +522,40 @@ export type AdObjective = 'sales';
 export type AdCallToAction = 'learn_more' | 'book_now' | 'contact_us';
 
 /**
+ * Growth Ad Engine — a single city geo-target (Phase 2b,
+ * docs/meta-ads-infrastructure-2026.md §9f). `key` is Meta's opaque
+ * `adgeolocation` identifier (resolved via `metaAds/geo.searchCities`) —
+ * cities MUST be targeted by `key`, NEVER by `name`; `name`/`region` here are
+ * for display only (e.g. an admin form's selected-city chip). `radius` is
+ * ALWAYS kilometers — the Meta adapter hardcodes `distance_unit:'kilometer'`
+ * (§9f's verified shape), no miles option in the neutral layer.
+ */
+export interface CityTarget {
+  key: string;
+  name: string;
+  region?: string;
+  radius: number;
+}
+
+/**
  * `adComposer.composeAndCreateAd` input — the platform-NEUTRAL compose
  * boundary (plan "The seam"). Nothing Meta-specific may leak in here (S1) —
- * everything platform-specific lives downstream, in `metaAds/*`. Deliberately
- * has NO `cities` field — cut from 2a (S1: Meta's `adgeolocation` city keys
- * aren't verified yet); only `countries[]` + age range.
+ * everything platform-specific lives downstream, in `metaAds/*`.
+ *
+ * Phase 2b (docs/meta-ads-infrastructure-2026.md §9f) widened this from 2a's
+ * shape in two ways: `assetRef` (one image) → `assetRefs` (1-`MAX_IMAGES`
+ * images — 2+ triggers the Dynamic Creative `asset_feed_spec` path); and
+ * `targeting.{ageMin,ageMax}` is GONE — the baked default is
+ * `advantage_audience:1` (Advantage+ Audience), and per §9f that flag OWNS
+ * demographics, rejecting a hard `age_min`/`age_max` outright (err
+ * 100/1870188-9). `targeting.cities[]` is the new primary control; `countries`
+ * is kept ONLY as a fallback for when no city is selected (2a's original
+ * whole-country targeting still works, just without cities).
  */
 export interface ComposeAndCreateAdInput {
   propertyId: string;
-  assetRef: {
-    /** 2a only supports the existing property gallery; `kind:'catalog'` is an additive 2b concept (S7). */
+  assetRefs: Array<{
+    /** 2b only supports the existing property gallery; `kind:'catalog'` is an additive future concept (S7). */
     kind: 'gallery';
     /** Full Firebase Storage path — NEVER a thumbnail. Asserted to start with `properties/${propertyId}/` (ownership, S7). */
     storagePath: string;
@@ -537,8 +568,8 @@ export interface ComposeAndCreateAdInput {
      * this up front.
      */
     contentHash?: string;
-  };
-  /** Exactly 1 element in 2a (S1). */
+  }>;
+  /** 1 element ⇒ single-image `object_story_spec` path; 2+ (or 2+ `copy` variants) ⇒ Dynamic Creative `asset_feed_spec` path (§9f). Up to `MAX_COPY_VARIANTS` (5). */
   copy: CopyVariant[];
   objective: AdObjective;
   /** Should be the property's canonical custom domain, not a `*.hosted.app` URL — a mismatch breaks `conversion_domain` attribution (plan REVISIONS S8). */
@@ -546,9 +577,10 @@ export interface ComposeAndCreateAdInput {
   /** Bani (minor units) — NEVER major-unit RON (plan §13 M3). Enforced ≤ `MAX_DAILY_BUDGET_MINOR` server-side (B2). */
   dailyBudgetMinor: number;
   targeting: {
-    countries: string[];
-    ageMin: number;
-    ageMax: number;
+    /** Primary control (2b). Mapped to `geo_locations.cities` + `location_types:['home','recent']` (§9f). */
+    cities: CityTarget[];
+    /** Fallback ONLY — used as `geo_locations.countries` when `cities` is empty (backward-compatible with 2a's whole-country targeting). */
+    countries?: string[];
   };
   /** ISO 8601 — REQUIRED in 2a (plan REVISIONS B2): bounds the ad set's real spend window (Meta's 500 RON campaign-level spend-cap floor is too high for a small first test). */
   endTime: string;


### PR DESCRIPTION
## What
Makes the ad console capable of **good** campaigns: **city+radius targeting**, **Advantage+ audience**, and **multi-image Advantage+ (Dynamic) Creative** with copy variants. For this campaign and all future ones.

## Design (the deliberate call)
Our admin controls **cities, photos, copy, CTA, landing, budget, dates**. Everything else is a **baked API default** (Advantage+ audience ON, OUTCOME_SALES/PURCHASE/lowest-cost/auto-placements, `is_dynamic_creative` auto). **No age/gender/interests UI** — Meta's Advantage+ audience owns demographics (you literally can't hard-set age with it on, §9f), and fine control is an Ads-Manager escape hatch. Not a Meta-UI clone.

## Contract — verified live first (§9f)
Before any code: a PAUSED self-cleaning spike confirmed city name→key resolution, city targeting, the Advantage+/age incompatibility, `asset_feed_spec`, and the `is_dynamic_creative` gotcha (a Dynamic Creative ad needs its ad set flagged, else err 1885998). All recorded.

## Build
- **Backend (A):** `geo.searchCities`; `createAdSet` (advantage_audience default 1, `is_dynamic_creative` when multi); `createCreative` (single `object_story_spec` vs multi `asset_feed_spec`); `createCampaignChain` computes `isDynamic` **once** and threads it to both (single enforcement point vs the mismatch error). Opus contract-reviewed.
- **UI (B):** multi-photo picker, 1–5 copy variants, city typeahead with radius. `searchCitiesAction` super-admin gated.

Money path (gateway/approval/two-switch) **untouched**; creation stays PAUSED. Still dark. **167 growth+ads tests pass**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)