### PR TITLE
fix: gallery tag pills — add missing labels, stop raw English chips

### DIFF
--- a/src/components/property/gallery-grid.tsx
+++ b/src/components/property/gallery-grid.tsx
@@ -16,8 +16,11 @@ import { useLanguage } from '@/hooks/useLanguage';
 
 // Default bilingual labels for common image tags.
 // Properties can override/extend via content.tagLabels in Firestore.
-// An unlabelled tag falls back to the raw tag string, which surfaces untranslated
-// English slugs as filter pills — so every tag in use needs an entry here.
+// Having a label here is what makes a tag eligible to become a filter pill
+// (see tagCounts below), so this map doubles as the pill allowlist. Broad
+// structural tags like `interior` are deliberately left out: they sit on most
+// indoor photos, so they would out-count every real category while filtering
+// almost nothing.
 // `exterior` is the building seen from outside; `outdoor` is the outdoor spaces.
 // They are distinct pills, so they must not share a Romanian label.
 const DEFAULT_TAG_LABELS: Record<string, { en: string; ro: string }> = {
@@ -28,7 +31,6 @@ const DEFAULT_TAG_LABELS: Record<string, { en: string; ro: string }> = {
   dining: { en: 'Dining', ro: 'Sufragerie' },
   kids: { en: 'Kids Areas', ro: 'Zone pentru copii' },
   playroom: { en: 'Play Room', ro: 'Cameră de joacă' },
-  interior: { en: 'Interior', ro: 'Interior' },
   fireplace: { en: 'Fireplace', ro: 'Șemineu' },
   terrace: { en: 'Terrace', ro: 'Terasă' },
   garden: { en: 'Garden', ro: 'Grădină' },
@@ -132,6 +134,14 @@ export function GalleryGrid({ content }: GalleryGridProps) {
   };
 
   const lang = currentLang || 'en';
+
+  // Names the photo's most specific category in the lightbox. Skips tags with no
+  // label — they are structural, and rendering the raw slug would leak an
+  // untranslated English word onto the page.
+  const chipLabel = (tags?: string[]) => {
+    const tag = tags?.find((t) => tagLabels[t]);
+    return tag ? tagLabels[tag][lang as 'en' | 'ro'] : null;
+  };
 
   return (
     <section className="py-8 md:py-12 bg-background" onKeyDown={lightboxOpen ? handleKeyDown : undefined}>
@@ -319,9 +329,9 @@ export function GalleryGrid({ content }: GalleryGridProps) {
                   <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent px-6 pb-4 pt-10">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
-                        {filteredImages[currentImageIndex].tags?.[0] && (
+                        {chipLabel(filteredImages[currentImageIndex].tags) && (
                           <span className="text-xs font-medium bg-white/20 text-white px-2 py-0.5 rounded-full">
-                            {tagLabels[filteredImages[currentImageIndex].tags![0]]?.[lang as 'en' | 'ro'] || filteredImages[currentImageIndex].tags![0]}
+                            {chipLabel(filteredImages[currentImageIndex].tags)}
                           </span>
                         )}
                         {tc(filteredImages[currentImageIndex].alt) && (

--- a/src/components/property/gallery-grid.tsx
+++ b/src/components/property/gallery-grid.tsx
@@ -16,6 +16,10 @@ import { useLanguage } from '@/hooks/useLanguage';
 
 // Default bilingual labels for common image tags.
 // Properties can override/extend via content.tagLabels in Firestore.
+// An unlabelled tag falls back to the raw tag string, which surfaces untranslated
+// English slugs as filter pills — so every tag in use needs an entry here.
+// `exterior` is the building seen from outside; `outdoor` is the outdoor spaces.
+// They are distinct pills, so they must not share a Romanian label.
 const DEFAULT_TAG_LABELS: Record<string, { en: string; ro: string }> = {
   bedroom: { en: 'Bedrooms', ro: 'Dormitoare' },
   'living-room': { en: 'Living Areas', ro: 'Zone de zi' },
@@ -23,9 +27,20 @@ const DEFAULT_TAG_LABELS: Record<string, { en: string; ro: string }> = {
   bathroom: { en: 'Bathrooms', ro: 'Băi' },
   dining: { en: 'Dining', ro: 'Sufragerie' },
   kids: { en: 'Kids Areas', ro: 'Zone pentru copii' },
+  playroom: { en: 'Play Room', ro: 'Cameră de joacă' },
+  interior: { en: 'Interior', ro: 'Interior' },
+  fireplace: { en: 'Fireplace', ro: 'Șemineu' },
   terrace: { en: 'Terrace', ro: 'Terasă' },
   garden: { en: 'Garden', ro: 'Grădină' },
   outdoor: { en: 'Outdoors', ro: 'Exterior' },
+  exterior: { en: 'Exterior', ro: 'Fațadă' },
+  bbq: { en: 'BBQ', ro: 'Grătar' },
+  hammock: { en: 'Hammocks', ro: 'Hamace' },
+  playground: { en: 'Playground', ro: 'Loc de joacă' },
+  view: { en: 'Views', ro: 'Priveliști' },
+  landscape: { en: 'Landscape', ro: 'Peisaj' },
+  autumn: { en: 'Autumn', ro: 'Toamna' },
+  lifestyle: { en: 'Lifestyle', ro: 'Atmosferă' },
   pool: { en: 'Pool', ro: 'Piscină' },
   spa: { en: 'Spa', ro: 'Spa' },
   balcony: { en: 'Balcony', ro: 'Balcon' },


### PR DESCRIPTION
## Problem

`DEFAULT_TAG_LABELS` in `gallery-grid.tsx` covered 15 tags, but **21 are in use** across the two properties. The map is not only a translation table — it doubles as the **allowlist deciding which tags become filter pills**:

```ts
// gallery-grid.tsx:63 — a tag only counts toward a pill if it has a label
if (tagLabels[tag]) { counts[tag] = (counts[tag] || 0) + 1; }
```

Two distinct consequences:

1. **Useful categories never became pills.** `playground` (4 photos), `bbq` (2) and `exterior` (2) all clear the 2-photo threshold but were silently dropped from the filter bar for want of a label. Families could not filter for the playground at all.
2. **The lightbox chip rendered a raw English slug.** Unlike the pills, the chip read `tags[0]` with no label check, so a photo whose first tag was unlabelled showed a chip reading `interior`, `playground` or `exterior` — untranslated, on the Romanian site.

## Fix

Added labels for the tags that should be filterable: `exterior`, `bbq`, `hammock`, `playground`, `playroom`, `fireplace`, plus `view`, `landscape`, `autumn`, `lifestyle`.

`interior` is deliberately **left unlabelled**. It sits on 14 of Prahova's 27 gallery photos, so a pill would sort first — above Dormitoare — while filtering almost nothing. It stays a structural tag, consistent with the existing design where "no label" means "not a pill".

That leaves the chip, which is the actual defect: it now names the first *labelled* tag rather than `tags[0]`. Verified every gallery photo still resolves to one (`interior` is never a photo's only tag).

**Naming:** `exterior` and `outdoor` are distinct pills and cannot share the Romanian "Exterior". `outdoor` keeps **Exterior** (outdoor spaces); `exterior` (the building from outside) becomes **Fațadă**. Likewise `playground` = **Loc de joacă** (outdoor) vs `playroom` = **Cameră de joacă** (indoor).

## Visible effect (Prahova, 27 gallery photos)

Pills go from 6 to 9 — gaining **Loc de joacă (4)**, **Grătar (2)** and **Fațadă (2)**:

`Dormitoare (6) · Zone pentru copii (5) · Zone de zi (4) · Exterior (4) · Loc de joacă (4) · Grădină (3) · Grătar (2) · Fațadă (2) · Terasă (2)`

Lightbox chips are now translated in both languages, with no raw slugs.

## Multi-property

Property-agnostic — checked against **both** `prahova-mountain-chalet` and `coltei-apartment-bucharest`: every tag in use resolves, no duplicate Romanian label among tags in use, and no photo loses its chip. Per-property `content.tagLabels` still merges over these defaults.

## Verification

- `npm run build` exits 0
- 27/27 gallery photos resolve to a labelled chip
- `public/` tracing intact: 31 source files, 31 bundled, 0 missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)