### PR TITLE
fix: make bilingual image alt first-class

### DIFF
--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -33,6 +33,7 @@ import { loggers } from '@/lib/logger';
 import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { convertTimestampsToISOStrings } from '@/lib/utils';
+import { serverTranslateContent } from '@/lib/server-language-utils';
 import { getBaseUrl } from '@/lib/structured-data';
 import { getMaxDailyBudgetMinor } from '@/config/growth-ads';
 import type { AdCampaign, AdCampaignStatus, ComposeAndCreateAdInput, PropertyImage } from '@/types';
@@ -170,7 +171,8 @@ export async function fetchComposeDataAction(propertyId: string): Promise<{
       .map((img) => ({
         storagePath: img.storagePath,
         url: img.url,
-        alt: img.alt || '',
+        // alt may be bilingual; the picker preview needs a plain string.
+        alt: serverTranslateContent(img.alt, 'en'),
         thumbnailUrl: img.thumbnailUrl,
       }));
 

--- a/src/app/admin/properties/[slug]/images/_components/sortable-image-card.tsx
+++ b/src/app/admin/properties/[slug]/images/_components/sortable-image-card.tsx
@@ -8,12 +8,19 @@ import Image from 'next/image';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { MultilingualInput } from '@/app/admin/website/_components/multilingual-input';
+// Pure resolver (no server-only deps), so it is safe in this client component.
+import { serverTranslateContent } from '@/lib/server-language-utils';
 import type { PropertyImage } from '@/types';
 
+// Keep in sync with DEFAULT_TAG_LABELS in src/components/property/gallery-grid.tsx —
+// a tag only becomes a gallery filter pill if it has a label there.
 const SUGGESTED_TAGS = [
   'bedroom', 'living-room', 'kitchen', 'bathroom', 'dining',
-  'kids', 'terrace', 'garden', 'outdoor', 'pool',
-  'spa', 'balcony', 'parking', 'beach-access', 'deck',
+  'kids', 'playroom', 'fireplace', 'interior',
+  'exterior', 'terrace', 'balcony', 'garden', 'outdoor',
+  'bbq', 'hammock', 'playground', 'view', 'landscape',
+  'pool', 'spa', 'parking', 'beach-access', 'deck',
 ];
 
 interface SortableImageCardProps {
@@ -93,7 +100,7 @@ export function SortableImageCard({
       <div className="relative aspect-[4/3] bg-muted">
         <Image
           src={image.thumbnailUrl || image.url}
-          alt={image.alt || 'Property image'}
+          alt={serverTranslateContent(image.alt, 'en') || 'Property image'}
           fill
           className="object-cover"
           sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
@@ -106,12 +113,12 @@ export function SortableImageCard({
 
       {/* Controls */}
       <div className="p-3 space-y-2">
-        <Input
-          type="text"
-          placeholder="Alt text (accessibility)"
-          value={image.alt || ''}
-          onChange={(e) => onUpdate(index, { alt: e.target.value })}
-          className="text-sm h-8"
+        <MultilingualInput
+          inline
+          label="Alt text"
+          placeholder="Alt text — shown as the lightbox caption"
+          value={image.alt}
+          onChange={(alt) => onUpdate(index, { alt: alt as PropertyImage['alt'] })}
         />
         <ImageTagInput
           tags={image.tags || []}

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -494,15 +494,19 @@ export function buildImageGalleryJsonLd(options: {
       if (!a.isFeatured && b.isFeatured) return 1;
       return (a.sortOrder ?? 999) - (b.sortOrder ?? 999);
     })
-    .map(img => ({
-      '@type': 'ImageObject',
-      contentUrl: img.url,
-      ...(img.alt && { description: img.alt }),
-      ...(img.alt && { name: img.alt }),
-    }));
+    .map(img => {
+      // alt may be bilingual; schema.org expects Text, so resolve it first.
+      const alt = pickLang(img.alt);
+      return {
+        '@type': 'ImageObject',
+        contentUrl: img.url,
+        ...(alt && { description: alt }),
+        ...(alt && { name: alt }),
+      };
+    });
 
   const galleryTitle = language === 'ro'
-    ? `Galerie Foto - ${name}`
+    ? `Galerie foto - ${name}`
     : `Photo Gallery - ${name}`;
 
   return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,13 @@ export type MultilingualString = {
 
 export interface PropertyImage {
   url: string;
-  alt: string;
+  /**
+   * Plain string (legacy) or bilingual. It is rendered as a visible caption in
+   * the gallery lightbox, not just as an accessibility attribute, so it is
+   * translatable. Always read it through tc() on the client or
+   * serverTranslateContent() on the server — never interpolate it directly.
+   */
+  alt: string | { en: string; ro: string };
   isFeatured?: boolean;
   'data-ai-hint'?: string; // For AI image generation hints
   tags?: string[]; // For gallery filtering


### PR DESCRIPTION
## Context

`PropertyImage.alt` was typed `string`. But `alt` is rendered as a **visible caption** in the gallery lightbox (`gallery-grid.tsx:312`), not merely an accessibility attribute — so on the Romanian site it read in English.

Prahova's alt data was widened to `{en, ro}` (all 42 photos were re-described against the actual image files; the stored text described the wrong photo). `tc()` handles both shapes, so the gallery was correct — but **the type did not permit the object and three other readers did not handle it**. The write went through a Firestore script that never type-checked against the interface, so the build stayed green.

This is the regression fix: the data shape was right, the contract and the readers were not.

## Changes

**`types/index.ts`** — `alt: string | { en: string; ro: string }`, documented as translatable and to be read via `tc()` / `serverTranslateContent()`.

Widening the type made the compiler find the remaining offenders:

**`lib/structured-data.ts`** — emitted the raw object as JSON-LD `description`/`name`, where schema.org expects Text. Production was serving:
```json
"description":{"ro":"Fațada cabanei…","en":"…"}
```
Now resolved through the `pickLang` already defined in that function. Also sentence-cased the hardcoded `Galerie Foto` → `Galerie foto` (Romanian does not title-case).

**`admin/properties/[slug]/images/_components/sortable-image-card.tsx`** — passed the object to `<Input value>` and wrote back a **plain string** on change, silently discarding the Romanian. Now uses the existing `MultilingualInput` (EN/RO tabs, orange dot when RO is empty). Its `<Image alt>` resolved the object to `[object Object]` — caught by the compiler once the type was honest.

**`admin/ads/actions.ts`** — the picker preview is typed `alt: string` and renders `<img alt={img.alt}>` (`compose-form.tsx:255`), so it showed `[object Object]`. Normalized with `serverTranslateContent`. **No Meta API logic touched** — this alt is preview-only and never sent to Meta.

`property-page-renderer.tsx:469` already flows alt through `tc()` and needed no change.

**Also:** synced `SUGGESTED_TAGS` with `DEFAULT_TAG_LABELS` (#155). The admin couldn't suggest `playground`, `bbq` or `exterior` — the tags that just gained labels and pills.

## Multi-property

Property-agnostic: the type accepts the legacy plain string, so Coltei (whose alt text is untouched) is unaffected. Every resolver falls back `preferred → en → ro`.

## Verification

- `npx tsc --noEmit` clean across all app/lib/component code (the 13 remaining errors are in `.test.ts` files and are pre-existing on `main` — verified by checking out main and re-running)
- `npm run build` exits 0
- `public/` tracing intact: 31 source, 31 bundled, 0 missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)