### PR TITLE
feat: make experience section title/description optional

### DIFF
--- a/src/components/homepage/experience-section.tsx
+++ b/src/components/homepage/experience-section.tsx
@@ -39,22 +39,33 @@ export function ExperienceSection({ content, language = 'en' }: ExperienceSectio
     highlights = []
   } = content;
 
-  // Don't render if required content is missing
-  if (!title || !description || !highlights || highlights.length === 0) {
+  // The highlight cards are the block. Title and description are each optional,
+  // so a property can lead with just the description — or omit both — without
+  // leaving an empty heading behind.
+  if (!highlights || highlights.length === 0) {
     return null;
   }
+
+  const titleText = tc(title);
+  const descriptionText = tc(description);
 
   return (
     <section className="py-10 md:py-16 bg-secondary/50" id="experience"> {/* Added ID */}
       <div className="container mx-auto px-4">
-        <div className="max-w-3xl mx-auto text-center mb-8">
-          <h2 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-4">
-            {tc(title)}
-          </h2>
-          <p className="text-lg text-muted-foreground">
-            {tc(description)}
-          </p>
-        </div>
+        {(titleText || descriptionText) && (
+          <div className="max-w-3xl mx-auto text-center mb-8">
+            {titleText && (
+              <h2 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-4">
+                {titleText}
+              </h2>
+            )}
+            {descriptionText && (
+              <p className="text-lg text-muted-foreground">
+                {descriptionText}
+              </p>
+            )}
+          </div>
+        )}
 
         {/* Use a fluid grid layout */}
         <div className="grid gap-8" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))' }}>


### PR DESCRIPTION
## Why

On the homepage `experience` block, the owner wants to drop the section heading and lead with the description alone. Two things blocked that:

1. The render guard bailed on a missing title:
   ```ts
   if (!title || !description || !highlights || highlights.length === 0) return null;
   ```
2. The `<h2>` rendered unconditionally, so blanking the title in data left an **empty heading + its `mb-4` margin** — a visible gap above the description.

## Change

`experience-section.tsx`:
- Guard on `highlights` only — title and description are each optional.
- Resolve `titleText`/`descriptionText` once, render the `<h2>` and `<p>` each only when non-empty, and drop the header wrapper entirely when both are empty (no stray margin).

## Multi-property

The block-content merge is a shallow spread (`{...templateDefault, ...pageOverride}`), so a property that doesn't override the title still gets the template default and renders a heading as before — verified against `coltei-apartment-bucharest`, which uses the template default experience block. Only a title that resolves to empty now hides.

## Follow-up (data, after deploy)

Once this is live, `homepage.experience.title.ro/en` for `prahova-mountain-chalet` will be blanked so the heading disappears with no interim gap. The softened description is already live.

## Verification

- `npm run build` exits 0
- `tsc --noEmit` clean on the changed file
- `public/` tracing intact: 31 source, 31 bundled, 0 missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)