### PR TITLE
Engagement system v1: Phase 0 fixes + outbox delivery + audience picker

### DIFF
--- a/src/app/admin/campaigns/_components/audience-picker.tsx
+++ b/src/app/admin/campaigns/_components/audience-picker.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Users, Search } from 'lucide-react';
+import type { AudienceCandidate, IneligibleReason } from '@/services/audienceService';
+
+// Operator-facing labels for the (only) automatic exclusions.
+const REASON_LABEL: Record<IneligibleReason, string> = {
+  unsubscribed: 'Opted out',
+  'no-contact': 'No WhatsApp',
+  suppressed: 'Suppressed',
+  'frequency-cap': 'Messaged recently',
+  'active-future-booking': 'Has upcoming stay',
+};
+
+type LangFilter = 'all' | 'ro' | 'en';
+type RepeatFilter = 'all' | 'repeat' | 'once';
+
+export function AudiencePicker({
+  candidates,
+  eligibleCount,
+  perRunCap,
+}: {
+  candidates: AudienceCandidate[];
+  eligibleCount: number;
+  perRunCap: number;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [search, setSearch] = useState('');
+  const [lang, setLang] = useState<LangFilter>('all');
+  const [repeat, setRepeat] = useState<RepeatFilter>('all');
+  const [eligibleOnly, setEligibleOnly] = useState(true);
+
+  // Filters narrow the VIEW only; they never remove anyone from eligibility.
+  // Sorted most-recent-stay first (recency is a soft signal, so it's a sort, not
+  // a filter — a winter-stayer is just as eligible for a summer offer).
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return candidates
+      .filter((c) => (eligibleOnly ? c.eligible : true))
+      .filter((c) => (lang === 'all' ? true : c.language === lang))
+      .filter((c) => (repeat === 'all' ? true : repeat === 'repeat' ? c.isRepeat : !c.isRepeat))
+      .filter((c) => (q ? c.name.toLowerCase().includes(q) : true))
+      .sort((a, b) => (b.lastStayDate || '').localeCompare(a.lastStayDate || ''));
+  }, [candidates, search, lang, repeat, eligibleOnly]);
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const selectableFiltered = filtered.filter((c) => c.eligible);
+  const allFilteredSelected =
+    selectableFiltered.length > 0 && selectableFiltered.every((c) => selected.has(c.guestId));
+  const toggleAllFiltered = () =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allFilteredSelected) selectableFiltered.forEach((c) => next.delete(c.guestId));
+      else selectableFiltered.forEach((c) => next.add(c.guestId));
+      return next;
+    });
+
+  const selectedCount = selected.size;
+  const overCap = selectedCount > perRunCap;
+
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search name…"
+            className="w-52 pl-8"
+          />
+        </div>
+        <FilterGroup
+          label="Lang"
+          value={lang}
+          onChange={(v) => setLang(v as LangFilter)}
+          options={[['all', 'All'], ['ro', 'RO'], ['en', 'EN']]}
+        />
+        <FilterGroup
+          label="Guest"
+          value={repeat}
+          onChange={(v) => setRepeat(v as RepeatFilter)}
+          options={[['all', 'All'], ['repeat', 'Repeat'], ['once', 'One-time']]}
+        />
+        <Button
+          size="sm"
+          variant={eligibleOnly ? 'default' : 'outline'}
+          className="h-7 px-2 text-xs"
+          onClick={() => setEligibleOnly((v) => !v)}
+        >
+          Eligible only
+        </Button>
+      </div>
+
+      {/* Count bar */}
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+        <span className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-muted-foreground" />
+          <strong>{selectedCount}</strong> selected · {eligibleCount} eligible · {filtered.length} shown
+        </span>
+        {overCap && (
+          <span className="text-amber-600">
+            Over the ~{perRunCap} WhatsApp-safe batch — consider splitting into rounds.
+          </span>
+        )}
+      </div>
+
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-input"
+                  checked={allFilteredSelected}
+                  onChange={toggleAllFiltered}
+                  aria-label="Select all shown"
+                />
+              </TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Lang</TableHead>
+              <TableHead>Country</TableHead>
+              <TableHead className="text-right">Stays</TableHead>
+              <TableHead>Last stay</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((c) => (
+              <TableRow key={c.guestId} className={c.eligible ? '' : 'opacity-60'}>
+                <TableCell>
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-input"
+                    disabled={!c.eligible}
+                    checked={selected.has(c.guestId)}
+                    onChange={() => toggle(c.guestId)}
+                    aria-label={`Select ${c.name}`}
+                  />
+                </TableCell>
+                <TableCell className="font-medium">{c.name}</TableCell>
+                <TableCell className="uppercase text-muted-foreground">{c.language}</TableCell>
+                <TableCell className="text-muted-foreground">{c.country || '—'}</TableCell>
+                <TableCell className="text-right">
+                  {c.totalBookings}
+                  {c.isRepeat ? <span className="ml-1 text-xs text-emerald-600">repeat</span> : null}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {c.lastStayDate || '—'}
+                  {c.lastStaySeason ? <span className="ml-1 text-xs">({c.lastStaySeason})</span> : null}
+                </TableCell>
+                <TableCell>
+                  {c.eligible ? (
+                    <Badge variant="outline" className="text-emerald-700">
+                      eligible
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary">{REASON_LABEL[c.ineligibleReason!]}</Badge>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+            {filtered.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} className="py-8 text-center text-muted-foreground">
+                  No guests match these filters.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Handoff to the message step (Gate 1) — wired in the next increment. */}
+      <div className="flex justify-end">
+        <Button disabled={selectedCount === 0}>
+          Continue with {selectedCount} guest{selectedCount === 1 ? '' : 's'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FilterGroup({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: [string, string][];
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs text-muted-foreground">{label}:</span>
+      {options.map(([val, lbl]) => (
+        <Button
+          key={val}
+          size="sm"
+          variant={value === val ? 'default' : 'outline'}
+          className="h-7 px-2 text-xs"
+          onClick={() => onChange(val)}
+        >
+          {lbl}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -6,6 +6,7 @@ import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/au
 import type { Campaign, SegmentDefinition } from '@/types';
 import { PREDEFINED_SEGMENTS, previewAudience } from '@/services/segmentService';
 import { listCampaigns, createCampaign, approveCampaign, sendCampaign } from '@/services/campaignService';
+import { buildAudience, type AudienceCandidate } from '@/services/audienceService';
 
 const logger = loggers.campaign;
 
@@ -144,5 +145,34 @@ export async function runCampaignAction(id: string): Promise<{
   } catch (error) {
     logger.error('runCampaignAction failed', error as Error);
     return { success: false, error: (error as Error).message };
+  }
+}
+
+export async function fetchAudienceAction(propertyId: string): Promise<{
+  success: boolean;
+  candidates?: AudienceCandidate[];
+  total?: number;
+  eligibleCount?: number;
+  perRunCap?: number;
+  error?: string;
+}> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const res = await buildAudience(propertyId);
+    return {
+      success: true,
+      candidates: res.candidates,
+      total: res.total,
+      eligibleCount: res.eligibleCount,
+      perRunCap: res.perRunCap,
+    };
+  } catch (error) {
+    logger.error('fetchAudienceAction failed', error as Error);
+    return { success: false, error: 'Failed to load audience' };
   }
 }

--- a/src/app/admin/campaigns/new/page.tsx
+++ b/src/app/admin/campaigns/new/page.tsx
@@ -1,0 +1,47 @@
+import { AdminPage } from '@/components/admin';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { fetchAudienceAction } from '../actions';
+import { AudiencePicker } from '../_components/audience-picker';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function NewCampaignPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const res = await fetchAudienceAction(property);
+
+  return (
+    <AdminPage
+      title="New campaign — audience"
+      description="Pick who to reach. Only the hard rules exclude a guest (opted out, no WhatsApp, suppressed, upcoming stay, messaged recently); everything else is advisory and up to you."
+    >
+      <PropertyUrlSync />
+      <Card>
+        <CardHeader>
+          <CardTitle>Audience</CardTitle>
+          <CardDescription>
+            Every past guest for this property, annotated. Nothing is capped — the count is your choice.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {res.success && res.candidates ? (
+            <AudiencePicker
+              candidates={res.candidates}
+              eligibleCount={res.eligibleCount ?? 0}
+              perRunCap={res.perRunCap ?? 20}
+            />
+          ) : (
+            <p className="text-sm text-destructive">{res.error || 'Failed to load audience.'}</p>
+          )}
+        </CardContent>
+      </Card>
+    </AdminPage>
+  );
+}

--- a/src/app/api/automation/__tests__/route.test.ts
+++ b/src/app/api/automation/__tests__/route.test.ts
@@ -1,0 +1,191 @@
+/** @jest-environment node */
+
+// Mock the Admin SDK, the logger, and the Bucharest date helpers (imported by the
+// route module but unused by the outbox ops) before importing the route.
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'ts') },
+}));
+jest.mock('@/lib/logger', () => ({
+  loggers: { adminBookings: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } },
+}));
+jest.mock('@/lib/dates/property-times', () => ({
+  formatBucharestDate: jest.fn(() => '2026-07-21'),
+  getBucharestDay: jest.fn(() => 21),
+  getBucharestMonth: jest.fn(() => 7),
+}));
+
+import { GET } from '../route';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import type { NextRequest } from 'next/server';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+/** Minimal NextRequest — the route only reads searchParams (+ headers, which the
+ *  outbox path never reaches because the test property has no share token). */
+function makeReq(params: Record<string, string>): NextRequest {
+  const sp = new URLSearchParams(params);
+  return {
+    nextUrl: { searchParams: sp, origin: 'https://test.local' },
+    headers: { get: () => null },
+  } as unknown as NextRequest;
+}
+
+/** In-memory Firestore mock with a mutable `outbox`, serialized transactions, and
+ *  capture of guests/messageLog updates. `properties` is always absent (so the
+ *  share-token / calendar-url pre-step is a no-op for the outbox ops). */
+function makeDb(seed: Record<string, Record<string, unknown>> = {}) {
+  const outbox = new Map<string, Record<string, unknown>>(Object.entries(seed));
+  const guestUpdates: { id: string; patch: Record<string, unknown> }[] = [];
+  const messageLogUpdates: { id: string; patch: Record<string, unknown> }[] = [];
+
+  const outboxDocRef = (id: string) => ({
+    id,
+    get: async () => ({ exists: outbox.has(id), data: () => outbox.get(id) }),
+    update: async (patch: Record<string, unknown>) => { outbox.set(id, { ...(outbox.get(id) || {}), ...patch }); },
+  });
+
+  const outboxQuery = () => {
+    const filters: Record<string, unknown> = {};
+    const q: Record<string, (...a: unknown[]) => unknown> = {};
+    q.where = (field: string, _op: string, val: unknown) => { filters[field] = val; return q; };
+    q.limit = () => q;
+    q.get = async () => {
+      const docs = [...outbox.entries()]
+        .filter(([, d]) => Object.entries(filters).every(([f, v]) => d[f] === v))
+        .slice(0, 1)
+        .map(([id, d]) => ({ id, ref: outboxDocRef(id), data: () => d }));
+      return { empty: docs.length === 0, docs };
+    };
+    return q;
+  };
+
+  let txChain: Promise<unknown> = Promise.resolve();
+  const txApi = {
+    get: async (ref: { id: string }) => ({ exists: outbox.has(ref.id), data: () => outbox.get(ref.id) }),
+    update: (ref: { id: string }, patch: Record<string, unknown>) => { outbox.set(ref.id, { ...(outbox.get(ref.id) || {}), ...patch }); },
+  };
+  const runTransaction = (fn: (tx: typeof txApi) => Promise<unknown>) => {
+    const result = txChain.then(() => fn(txApi));
+    txChain = result.then(() => undefined, () => undefined);
+    return result;
+  };
+
+  const db = {
+    runTransaction,
+    collection: (name: string) => {
+      if (name === 'outbox') { const q = outboxQuery(); return { where: q.where, doc: (id: string) => outboxDocRef(id) }; }
+      if (name === 'properties') return { doc: () => ({ get: async () => ({ exists: false, data: () => ({}) }) }) };
+      if (name === 'messageLog') return { doc: (id: string) => ({ update: async (patch: Record<string, unknown>) => { messageLogUpdates.push({ id, patch }); } }) };
+      if (name === 'guests') return { doc: (id: string) => ({ update: async (patch: Record<string, unknown>) => { guestUpdates.push({ id, patch }); } }) };
+      return { doc: () => ({ get: async () => ({ exists: false }) }) };
+    },
+  };
+  return { db, outbox, guestUpdates, messageLogUpdates };
+}
+
+beforeEach(() => {
+  process.env.AUTOMATION_TOKEN = 'secret';
+});
+
+describe('/api/automation — auth', () => {
+  it('rejects a bad token with 401', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_next', propertyId: 'prahova', token: 'wrong' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts the correct token', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_next', propertyId: 'prahova', token: 'secret' }));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('/api/automation — outbox_next', () => {
+  it('claims the next queued message and returns a ready waUrl', async () => {
+    const { db, outbox } = makeDb({
+      o1: { propertyId: 'prahova', status: 'approved_pending_send', phone: '+40712345678', body: 'Salut Ana!' },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await GET(makeReq({ op: 'outbox_next', propertyId: 'prahova', token: 'secret' }));
+    const json = await res.json();
+
+    expect(json.status).toBe('ok');
+    expect(json.id).toBe('o1');
+    expect(json.phone).toBe('40712345678'); // digits only for wa.me
+    expect(json.body).toBe('Salut Ana!');
+    expect(json.waUrl).toBe('https://wa.me/40712345678?text=Salut%20Ana!');
+    expect(outbox.get('o1')?.status).toBe('claimed'); // atomically claimed
+  });
+
+  it('returns none when the queue is empty', async () => {
+    const { db } = makeDb({});
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_next', propertyId: 'prahova', token: 'secret' }));
+    expect((await res.json()).status).toBe('none');
+  });
+
+  it('ignores messages for other properties', async () => {
+    const { db } = makeDb({ o1: { propertyId: 'coltei', status: 'approved_pending_send', phone: '+40712345678', body: 'x' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_next', propertyId: 'prahova', token: 'secret' }));
+    expect((await res.json()).status).toBe('none');
+  });
+
+  it('does not return an already-claimed message', async () => {
+    const { db } = makeDb({ o1: { propertyId: 'prahova', status: 'claimed', phone: '+40712345678', body: 'x' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_next', propertyId: 'prahova', token: 'secret' }));
+    expect((await res.json()).status).toBe('none');
+  });
+});
+
+describe('/api/automation — outbox_sent', () => {
+  it('marks sent, captures finalText, and closes the loop (messageLog + lastCampaignAt)', async () => {
+    const { db, outbox, messageLogUpdates, guestUpdates } = makeDb({
+      o1: { propertyId: 'prahova', status: 'claimed', guestId: 'g1', body: 'orig', messageLogId: 'ml1' },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await GET(makeReq({ op: 'outbox_sent', propertyId: 'prahova', id: 'o1', finalText: 'edited text', token: 'secret' }));
+    expect((await res.json()).status).toBe('ok');
+
+    expect(outbox.get('o1')?.status).toBe('sent');
+    expect(outbox.get('o1')?.finalText).toBe('edited text');
+    expect(messageLogUpdates).toEqual([{ id: 'ml1', patch: expect.objectContaining({ status: 'sent', finalText: 'edited text' }) }]);
+    expect(guestUpdates).toEqual([{ id: 'g1', patch: expect.objectContaining({ lastCampaignAt: 'ts' }) }]);
+  });
+
+  it('falls back to the stored body when no finalText is given', async () => {
+    const { db, outbox } = makeDb({ o1: { propertyId: 'prahova', status: 'claimed', guestId: 'g1', body: 'orig' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    await GET(makeReq({ op: 'outbox_sent', propertyId: 'prahova', id: 'o1', token: 'secret' }));
+    expect(outbox.get('o1')?.finalText).toBe('orig');
+  });
+
+  it('is idempotent when already sent (no double touch)', async () => {
+    const { db, guestUpdates } = makeDb({ o1: { propertyId: 'prahova', status: 'sent', guestId: 'g1' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_sent', propertyId: 'prahova', id: 'o1', token: 'secret' }));
+    expect((await res.json()).status).toBe('ok');
+    expect(guestUpdates).toHaveLength(0);
+  });
+
+  it('rejects a message belonging to a different property with 400', async () => {
+    const { db } = makeDb({ o1: { propertyId: 'coltei', status: 'claimed', guestId: 'g1' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_sent', propertyId: 'prahova', id: 'o1', token: 'secret' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    const { db } = makeDb({});
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await GET(makeReq({ op: 'outbox_sent', propertyId: 'prahova', token: 'secret' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/automation/route.ts
+++ b/src/app/api/automation/route.ts
@@ -23,6 +23,7 @@
 //       active-booking ids for the current Bucharest month).
 
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
 import { formatBucharestDate, getBucharestDay, getBucharestMonth } from '@/lib/dates/property-times';
@@ -112,7 +113,11 @@ function authOk(req: NextRequest): boolean {
   const expected = process.env.AUTOMATION_TOKEN;
   if (!expected) return false;
   const got = req.nextUrl.searchParams.get('token');
-  return !!got && got === expected;
+  if (!got) return false;
+  const a = Buffer.from(got);
+  const b = Buffer.from(expected);
+  // Constant-time compare (length-guarded so timingSafeEqual never throws).
+  return a.length === b.length && timingSafeEqual(a, b);
 }
 
 // ---- Fetch active bookings for a property ----
@@ -507,6 +512,102 @@ async function changedReservations(propertyId: string, calUrl?: string): Promise
 }
 
 // ============================================================
+// Outbox — the owner's manual-send queue (Gate 2)
+//   op=outbox_next  → atomically claim & return the next queued message (JSON)
+//   op=outbox_sent  → mark a message sent, capture finalText, close the loop
+// The iOS/Mac Shortcut loops: outbox_next → open waUrl → tap send → outbox_sent.
+// ============================================================
+
+interface OutboxRow {
+  propertyId?: string;
+  guestId?: string;
+  phone?: string;
+  body?: string;
+  status?: string;
+  messageLogId?: string | null;
+}
+
+/** Claim and return the next queued outbox message for the property (or none). */
+async function outboxNext(propertyId: string): Promise<NextResponse> {
+  const db = await getAdminDb();
+  // No orderBy → two equality filters need no composite index; a manual queue
+  // does not require strict FIFO. Small retry loop covers the (single-user, rare)
+  // claim race so the Shortcut only ever sees 'ok' or 'none'.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const snap = await db
+      .collection('outbox')
+      .where('propertyId', '==', propertyId)
+      .where('status', '==', 'approved_pending_send')
+      .limit(1)
+      .get();
+    if (snap.empty) return NextResponse.json({ status: 'none' });
+
+    const ref = snap.docs[0].ref;
+    const claimed = await db.runTransaction(async (tx) => {
+      const doc = await tx.get(ref);
+      const d = doc.data() as OutboxRow | undefined;
+      if (!doc.exists || d?.status !== 'approved_pending_send') return null;
+      tx.update(ref, { status: 'claimed', claimedAt: FieldValue.serverTimestamp() });
+      return d;
+    });
+
+    if (claimed) {
+      const digits = (claimed.phone || '').replace(/\D/g, ''); // wa.me wants digits only
+      const body = claimed.body || '';
+      const waUrl = `https://wa.me/${digits}?text=${encodeURIComponent(body)}`;
+      return NextResponse.json({ status: 'ok', id: ref.id, phone: digits, body, waUrl });
+    }
+    // Lost the race — loop and try the next candidate.
+  }
+  return NextResponse.json({ status: 'none' });
+}
+
+/** Mark a claimed outbox message as sent; capture the final text; close the loop. */
+async function outboxSent(req: NextRequest, propertyId: string): Promise<NextResponse> {
+  const db = await getAdminDb();
+  const id = req.nextUrl.searchParams.get('id');
+  if (!id) return new NextResponse('Missing id', { status: 400 });
+  const finalText = req.nextUrl.searchParams.get('finalText');
+
+  const ref = db.collection('outbox').doc(id);
+  const doc = await ref.get();
+  if (!doc.exists) return new NextResponse('Not found', { status: 404 });
+  const row = doc.data() as OutboxRow;
+  if (row.propertyId && row.propertyId !== propertyId) {
+    return new NextResponse('Wrong property', { status: 400 });
+  }
+  if (row.status === 'sent') return NextResponse.json({ status: 'ok' }); // idempotent
+
+  const sentText = finalText ?? row.body ?? null;
+  await ref.update({ status: 'sent', sentAt: FieldValue.serverTimestamp(), finalText: sentText });
+
+  // Flip the linked gateway claim 'queued' → 'sent' and capture the final text.
+  if (row.messageLogId) {
+    try {
+      await db.collection('messageLog').doc(row.messageLogId).update({
+        status: 'sent',
+        finalText: sentText,
+        at: FieldValue.serverTimestamp(),
+      });
+    } catch {
+      logger.warn('outbox_sent: messageLog update failed (non-blocking)', { id, messageLogId: row.messageLogId });
+    }
+  }
+
+  // The real send just happened → set lastCampaignAt so the frequency cap counts
+  // actual contact (queuing deliberately did not touch it).
+  if (row.guestId) {
+    try {
+      await db.collection('guests').doc(row.guestId).update({ lastCampaignAt: FieldValue.serverTimestamp() });
+    } catch {
+      logger.warn('outbox_sent: lastCampaignAt update failed (non-blocking)', { guestId: row.guestId });
+    }
+  }
+
+  return NextResponse.json({ status: 'ok' });
+}
+
+// ============================================================
 // Route handler
 // ============================================================
 
@@ -530,6 +631,10 @@ export async function GET(req: NextRequest) {
         return await dailyCheck(propertyId, calUrl);
       case 'changedReservations':
         return await changedReservations(propertyId, calUrl);
+      case 'outbox_next':
+        return await outboxNext(propertyId);
+      case 'outbox_sent':
+        return await outboxSent(req, propertyId);
       default:
         return new NextResponse('Invalid operation', { status: 400 });
     }

--- a/src/services/__tests__/audienceService.test.ts
+++ b/src/services/__tests__/audienceService.test.ts
@@ -1,0 +1,126 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'ts') },
+}));
+// executionGateway (imported for isConsentBlocked) pulls guestService at load — stub it.
+jest.mock('@/services/guestService', () => ({ getGuestById: jest.fn() }));
+
+import { buildAudience } from '../audienceService';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import type { Guest } from '@/types';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb({ guests = [], suppression = [], bookings = [] }: {
+  guests?: Record<string, unknown>[];
+  suppression?: Record<string, unknown>[];
+  bookings?: Record<string, unknown>[];
+} = {}) {
+  const guestSnap = { docs: guests.map((g) => ({ id: g.id as string, data: () => g })) };
+  const suppSnap = { docs: suppression.map((s) => ({ data: () => s })) };
+  const bookingSnap = { docs: bookings.map((b) => ({ id: b.id as string, data: () => b })) };
+  return {
+    collection: (name: string) => {
+      if (name === 'guests') return { where: () => ({ get: async () => guestSnap }) };
+      if (name === 'suppressionList') return { get: async () => suppSnap };
+      if (name === 'bookings') return { where: () => ({ get: async () => bookingSnap }) };
+      return { get: async () => ({ docs: [] }) };
+    },
+  };
+}
+
+function guest(overrides: Partial<Guest> = {}): Guest {
+  return {
+    id: 'g',
+    firstName: 'Ana',
+    language: 'ro',
+    bookingIds: [],
+    propertyIds: ['prahova'],
+    totalBookings: 1,
+    totalSpent: 1000,
+    currency: 'RON',
+    reviewSubmitted: false,
+    tags: [],
+    unsubscribed: false,
+    normalizedPhone: '+40712345678',
+    ...overrides,
+  } as Guest;
+}
+
+const NOW = new Date('2026-07-21T12:00:00Z');
+
+describe('audienceService.buildAudience', () => {
+  it('annotates each candidate with eligibility + reason and never caps the list', async () => {
+    const twoDaysAgo = { _seconds: Math.floor(NOW.getTime() / 1000) - 2 * 86400 };
+    const guests = [
+      guest({ id: 'ok', normalizedPhone: '+40700000001' }),
+      guest({ id: 'unsub', unsubscribed: true, normalizedPhone: '+40700000002' }),
+      guest({ id: 'nocontact', normalizedPhone: undefined, phone: undefined, email: undefined }),
+      guest({ id: 'supp', normalizedPhone: '+40700000004' }),
+      guest({ id: 'freq', normalizedPhone: '+40700000005', lastCampaignAt: twoDaysAgo as unknown as Guest['lastCampaignAt'] }),
+      guest({ id: 'future', normalizedPhone: '+40700000006', bookingIds: ['b-future'] }),
+    ];
+    const db = makeDb({
+      guests,
+      suppression: [{ normalizedPhone: '+40700000004' }],
+      bookings: [{ id: 'b-future', propertyId: 'prahova', status: 'confirmed', checkOutDate: new Date(NOW.getTime() + 14 * 86400000) }],
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await buildAudience('prahova', { now: NOW });
+    const by = Object.fromEntries(res.candidates.map((c) => [c.guestId, c]));
+
+    expect(by.ok.eligible).toBe(true);
+    expect(by.unsub).toMatchObject({ eligible: false, ineligibleReason: 'unsubscribed' });
+    expect(by.nocontact).toMatchObject({ eligible: false, ineligibleReason: 'no-contact' });
+    expect(by.supp).toMatchObject({ eligible: false, ineligibleReason: 'suppressed' });
+    expect(by.freq).toMatchObject({ eligible: false, ineligibleReason: 'frequency-cap' });
+    expect(by.future).toMatchObject({ eligible: false, ineligibleReason: 'active-future-booking' });
+
+    expect(res.total).toBe(6);
+    expect(res.eligibleCount).toBe(1);
+    expect(res.candidates).toHaveLength(6); // ALL returned — the picker annotates, never caps
+  });
+
+  it('surfaces fit signals (repeat, last-stay season) as advisory annotations', async () => {
+    const guests = [
+      guest({ id: 'winterRepeat', totalBookings: 3, lastStayDate: new Date('2025-01-05') as unknown as Guest['lastStayDate'], normalizedPhone: '+40700000010' }),
+      guest({ id: 'summerOnce', totalBookings: 1, lastStayDate: new Date('2025-08-10') as unknown as Guest['lastStayDate'], normalizedPhone: '+40700000011' }),
+    ];
+    mockGetAdminDb.mockResolvedValue(makeDb({ guests }));
+
+    const res = await buildAudience('prahova', { now: NOW });
+    const by = Object.fromEntries(res.candidates.map((c) => [c.guestId, c]));
+
+    // A winter-stayer is STILL eligible — season is advisory, never an exclusion.
+    expect(by.winterRepeat).toMatchObject({ eligible: true, isRepeat: true, lastStaySeason: 'winter' });
+    expect(by.summerOnce).toMatchObject({ eligible: true, isRepeat: false, lastStaySeason: 'summer' });
+    expect(res.perRunCap).toBeGreaterThan(0);
+  });
+
+  it('does not flag a cancelled future booking as active', async () => {
+    const guests = [guest({ id: 'g1', bookingIds: ['b-cancelled'], normalizedPhone: '+40700000020' })];
+    const db = makeDb({
+      guests,
+      bookings: [{ id: 'b-cancelled', propertyId: 'prahova', status: 'cancelled', checkOutDate: new Date(NOW.getTime() + 14 * 86400000) }],
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await buildAudience('prahova', { now: NOW });
+    expect(res.candidates[0].eligible).toBe(true);
+  });
+
+  it('does not flag a PAST booking as an active future booking', async () => {
+    const guests = [guest({ id: 'g1', bookingIds: ['b-past'], normalizedPhone: '+40700000030' })];
+    const db = makeDb({
+      guests,
+      bookings: [{ id: 'b-past', propertyId: 'prahova', status: 'completed', checkOutDate: new Date(NOW.getTime() - 60 * 86400000) }],
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await buildAudience('prahova', { now: NOW });
+    expect(res.candidates[0].eligible).toBe(true);
+  });
+});

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -41,6 +41,7 @@ function chainableGet(result: unknown) {
 function makeDb({ suppressed = false, priorDelivered = false, propertyName = 'Prahova Mountain Chalet', propertyData, bookings = {} }: { suppressed?: boolean; priorDelivered?: boolean; propertyName?: string; propertyData?: Record<string, unknown>; bookings?: Record<string, Record<string, unknown>> } = {}) {
   const store = new Map<string, Record<string, unknown>>();
   const logWrites: Record<string, unknown>[] = [];
+  const outboxWrites: Record<string, unknown>[] = [];
   const addMock = jest.fn((data: Record<string, unknown>) => { logWrites.push(data); return Promise.resolve({ id: 'log-123' }); });
   const setMock = jest.fn();
   const guestUpdateMock = jest.fn().mockResolvedValue(undefined);
@@ -81,10 +82,11 @@ function makeDb({ suppressed = false, priorDelivered = false, propertyName = 'Pr
       if (name === 'propertyOverrides') return { doc: jest.fn(() => overridesDoc) };
       if (name === 'guests') return { doc: jest.fn(() => guestsDoc) };
       if (name === 'bookings') return { doc: (id: string) => ({ get: async () => ({ exists: !!bookings[id], data: () => bookings[id] }) }) };
+      if (name === 'outbox') return { doc: (id?: string) => ({ id: id ?? 'outbox-1', set: async (data: Record<string, unknown>) => { outboxWrites.push(data); } }) };
       return suppressionQuery; // suppressionList
     }),
   };
-  return { db, addMock, setMock, guestUpdateMock, logWrites, store };
+  return { db, addMock, setMock, guestUpdateMock, logWrites, store, outboxWrites };
 }
 
 function guest(overrides: Partial<Guest> = {}): Guest {
@@ -394,5 +396,62 @@ describe('executeSend — live mode (both switches on)', () => {
     expect([a.status, b.status].sort()).toEqual(['sent', 'skipped']);
     expect([a, b].find((r) => r.status === 'skipped')?.reason).toBe('dedup');
     expect(store.get('c1__g1__winter_invite')).toMatchObject({ status: 'sent' });
+  });
+});
+
+describe('executeSend — manual_queue driver (outbox)', () => {
+  beforeEach(() => {
+    process.env.GROWTH_ENGINE_ENABLED = 'true';
+    process.env.GROWTH_ENGINE_SEND_MODE = 'live';
+  });
+
+  it('queues a rendered message to the outbox instead of calling the provider', async () => {
+    const { db, outboxWrites, store } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({
+      guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp',
+      templateName: 'winter_invite', campaignId: 'c1',
+      deliveryMode: 'manual_queue', body: 'Salut Ana! O anulare a eliberat...',
+    });
+
+    expect(mockSendWhatsApp).not.toHaveBeenCalled(); // no provider call
+    expect(res.status).toBe('queued');
+    expect(outboxWrites).toHaveLength(1);
+    expect(outboxWrites[0]).toMatchObject({
+      campaignId: 'c1', guestId: 'g1', propertyId: 'prahova-mountain-chalet',
+      phone: '+40712345678', body: 'Salut Ana! O anulare a eliberat...',
+      status: 'approved_pending_send',
+    });
+    // Claim doc finalized as 'queued' (blocks re-queue).
+    expect(store.get('c1__g1__winter_invite')).toMatchObject({ status: 'queued' });
+  });
+
+  it('does not re-queue an already-queued guest (dedup via the claim doc)', async () => {
+    const { db, outboxWrites } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+    const req = { guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp' as const, templateName: 'winter_invite', campaignId: 'c1', deliveryMode: 'manual_queue' as const, body: 'hi' };
+
+    const first = await executeSend(req);
+    const second = await executeSend(req);
+
+    expect(first.status).toBe('queued');
+    expect(second.status).toBe('skipped');
+    expect(second.reason).toBe('dedup');
+    expect(outboxWrites).toHaveLength(1); // queued exactly once
+  });
+
+  it('records dry-run intent (no outbox write) when not live', async () => {
+    delete process.env.GROWTH_ENGINE_ENABLED;
+    delete process.env.GROWTH_ENGINE_SEND_MODE;
+    const { db, outboxWrites } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+
+    const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite', campaignId: 'c1', deliveryMode: 'manual_queue', body: 'hi' });
+    expect(res.status).toBe('dry-run');
+    expect(outboxWrites).toHaveLength(0);
   });
 });

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -31,26 +31,60 @@ function chainableGet(result: unknown) {
   return q;
 }
 
-/** Chainable Firestore mock; toggles suppressionList hit and prior-delivery dedup. */
-function makeDb({ suppressed = false, priorDelivered = false, propertyName = 'Prahova Mountain Chalet', propertyData }: { suppressed?: boolean; priorDelivered?: boolean; propertyName?: string; propertyData?: Record<string, unknown> } = {}) {
-  const addMock = jest.fn().mockResolvedValue({ id: 'log-123' });
+/**
+ * In-memory Firestore mock. `messageLog` supports deterministic docs
+ * (`.doc(id).get/.set`) plus append (`.add`), and `runTransaction` is SERIALIZED
+ * so the idempotency claim can be tested under concurrency (a committed tx is
+ * seen by the next). `logWrites` records every messageLog write (add or set) in
+ * order. When `priorDelivered`, any deterministic-doc read reports a prior 'sent'.
+ */
+function makeDb({ suppressed = false, priorDelivered = false, propertyName = 'Prahova Mountain Chalet', propertyData, bookings = {} }: { suppressed?: boolean; priorDelivered?: boolean; propertyName?: string; propertyData?: Record<string, unknown>; bookings?: Record<string, Record<string, unknown>> } = {}) {
+  const store = new Map<string, Record<string, unknown>>();
+  const logWrites: Record<string, unknown>[] = [];
+  const addMock = jest.fn((data: Record<string, unknown>) => { logWrites.push(data); return Promise.resolve({ id: 'log-123' }); });
+  const setMock = jest.fn();
   const guestUpdateMock = jest.fn().mockResolvedValue(undefined);
   const suppressionQuery = chainableGet({ empty: !suppressed });
-  const messageLogQuery = chainableGet({ docs: priorDelivered ? [{ data: () => ({ status: 'sent' }) }] : [] });
-  const messageLogCol = { add: addMock, where: messageLogQuery.where };
+
+  const docHandle = (id: string) => ({
+    _id: id,
+    get: async () => ({
+      exists: priorDelivered || store.has(id),
+      data: () => (priorDelivered && !store.has(id) ? { status: 'sent' } : store.get(id)),
+    }),
+    set: async (data: Record<string, unknown>) => { store.set(id, data); setMock(id, data); logWrites.push(data); },
+  });
+  const messageLogCol = { add: addMock, doc: (id: string) => docHandle(id) };
+
   const propertiesDoc = { get: jest.fn().mockResolvedValue({ exists: true, data: () => propertyData ?? { name: propertyName } }) };
   const overridesDoc = { get: jest.fn().mockResolvedValue({ exists: false, data: () => ({}) }) };
   const guestsDoc = { update: guestUpdateMock };
+
+  // Serialize transactions: each runs only after the previous one settles, so a
+  // claim written by tx A is visible to tx B (models Firestore's guarantee).
+  let txChain: Promise<unknown> = Promise.resolve();
+  const txApi = {
+    get: async (ref: { _id: string }) => ({ exists: store.has(ref._id), data: () => store.get(ref._id) }),
+    set: (ref: { _id: string }, data: Record<string, unknown>) => { store.set(ref._id, data); setMock(ref._id, data); logWrites.push(data); },
+  };
+  const runTransaction = jest.fn((fn: (tx: typeof txApi) => Promise<unknown>) => {
+    const result = txChain.then(() => fn(txApi));
+    txChain = result.then(() => undefined, () => undefined);
+    return result;
+  });
+
   const db = {
+    runTransaction,
     collection: jest.fn((name: string) => {
       if (name === 'messageLog') return messageLogCol;
       if (name === 'properties') return { doc: jest.fn(() => propertiesDoc) };
       if (name === 'propertyOverrides') return { doc: jest.fn(() => overridesDoc) };
       if (name === 'guests') return { doc: jest.fn(() => guestsDoc) };
+      if (name === 'bookings') return { doc: (id: string) => ({ get: async () => ({ exists: !!bookings[id], data: () => bookings[id] }) }) };
       return suppressionQuery; // suppressionList
     }),
   };
-  return { db, addMock, guestUpdateMock };
+  return { db, addMock, setMock, guestUpdateMock, logWrites, store };
 }
 
 function guest(overrides: Partial<Guest> = {}): Guest {
@@ -188,6 +222,49 @@ describe('executeSend — dark-launch safety (default)', () => {
   });
 });
 
+describe('executeSend — active future booking guard (#159)', () => {
+  const future = new Date(Date.now() + 14 * 86400000);
+  const past = new Date(Date.now() - 60 * 86400000);
+
+  it('skips a guest who has a live upcoming booking for the property', async () => {
+    const { db } = makeDb({ bookings: { b1: { propertyId: 'prahova-mountain-chalet', status: 'confirmed', checkInDate: future, checkOutDate: future } } });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ bookingIds: ['b1'] }));
+
+    const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('active-future-booking');
+    expect(mockSendWhatsApp).not.toHaveBeenCalled();
+  });
+
+  it('does NOT skip when the guest has only past bookings', async () => {
+    const { db } = makeDb({ bookings: { b1: { propertyId: 'prahova-mountain-chalet', status: 'completed', checkInDate: past, checkOutDate: past } } });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ bookingIds: ['b1'] }));
+
+    const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('dry-run');
+  });
+
+  it('does NOT skip when the upcoming booking is cancelled', async () => {
+    const { db } = makeDb({ bookings: { b1: { propertyId: 'prahova-mountain-chalet', status: 'cancelled', checkInDate: future, checkOutDate: future } } });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ bookingIds: ['b1'] }));
+
+    const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('dry-run');
+  });
+
+  it('does NOT skip when the upcoming booking is at a different property', async () => {
+    const { db } = makeDb({ bookings: { b1: { propertyId: 'coltei-apartment-bucharest', status: 'confirmed', checkInDate: future, checkOutDate: future } } });
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest({ bookingIds: ['b1'] }));
+
+    const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite' });
+    expect(res.status).toBe('dry-run');
+  });
+});
+
 describe('executeSend — live mode (both switches on)', () => {
   beforeEach(() => {
     process.env.GROWTH_ENGINE_ENABLED = 'true';
@@ -195,7 +272,7 @@ describe('executeSend — live mode (both switches on)', () => {
   });
 
   it('delivers via WhatsApp and logs sent, selecting the guest-language template (#2)', async () => {
-    const { db, addMock } = makeDb();
+    const { db, logWrites } = makeDb();
     mockGetAdminDb.mockResolvedValue(db);
     mockGetGuestById.mockResolvedValue(guest()); // language 'en'
 
@@ -206,7 +283,8 @@ describe('executeSend — live mode (both switches on)', () => {
     expect(res.status).toBe('sent');
     expect(res.mode).toBe('live');
     expect(res.providerId).toBe('SM-1');
-    expect(addMock.mock.calls.at(-1)?.[0]).toMatchObject({ status: 'sent', providerId: 'SM-1' });
+    // Final write lands on the deterministic claim doc (set), not an append.
+    expect(logWrites.at(-1)).toMatchObject({ status: 'sent', providerId: 'SM-1' });
   });
 
   it('property-brands the live message with the property name (H1)', async () => {
@@ -287,5 +365,34 @@ describe('executeSend — live mode (both switches on)', () => {
 
     const res = await executeSend({ guestId: 'g1', channel: 'whatsapp', templateName: 'winter_invite' });
     expect(res.status).toBe('sent');
+  });
+
+  it('a second send of the same campaign template is deduped by the claim doc (M1)', async () => {
+    const { db } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+    const req = { guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp' as const, templateName: 'winter_invite', campaignId: 'c1' };
+
+    const first = await executeSend(req);
+    const second = await executeSend(req);
+
+    expect(first.status).toBe('sent');
+    expect(second.status).toBe('skipped');
+    expect(second.reason).toBe('dedup');
+    expect(mockSendWhatsApp).toHaveBeenCalledTimes(1); // delivered exactly once
+  });
+
+  it('never double-delivers under concurrency — atomic claim (M2 / #158)', async () => {
+    const { db, store } = makeDb();
+    mockGetAdminDb.mockResolvedValue(db);
+    mockGetGuestById.mockResolvedValue(guest());
+    const req = { guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp' as const, templateName: 'winter_invite', campaignId: 'c1' };
+
+    const [a, b] = await Promise.all([executeSend(req), executeSend(req)]);
+
+    expect(mockSendWhatsApp).toHaveBeenCalledTimes(1); // exactly one real delivery
+    expect([a.status, b.status].sort()).toEqual(['sent', 'skipped']);
+    expect([a, b].find((r) => r.status === 'skipped')?.reason).toBe('dedup');
+    expect(store.get('c1__g1__winter_invite')).toMatchObject({ status: 'sent' });
   });
 });

--- a/src/services/audienceService.ts
+++ b/src/services/audienceService.ts
@@ -1,0 +1,138 @@
+/**
+ * audienceService — the audience picker's brain.
+ *
+ * For a property it fetches EVERY candidate guest and annotates each with:
+ *   - eligibility: whether the guest can be messaged and, if not, WHY
+ *     (unsubscribed / no-contact / suppressed / frequency-cap / future-booking).
+ *     These are the only automatic exclusions — they mirror executionGateway's
+ *     gates (minus per-campaign dedup), reusing the SAME primitives so the picker
+ *     and the actual send agree. The gateway remains authoritative at send time.
+ *   - fit signals: language, repeat, last-stay recency + season, country, spend.
+ *     These are ADVISORY — the operator sorts/filters on them. Nothing is ever
+ *     excluded on a soft signal (e.g. a winter-stayer is a perfectly valid lead
+ *     for a summer offer — they already like the property).
+ *
+ * It NEVER caps the audience — the operator picks freely; `perRunCap` is surfaced
+ * as soft WhatsApp-volume guidance only.
+ *
+ * Plain server module (NOT 'use server') — exports types + async functions.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { Guest, ChannelType, LanguageCode, Season } from '@/types';
+import { GROWTH_ENGINE_LIMITS } from '@/config/growth-engine';
+import { parseFirestoreDate, seasonOf } from '@/lib/growth/date-utils';
+import { resolveGuestLanguage } from '@/lib/growth/language';
+import { isConsentBlocked } from '@/services/executionGateway';
+import { resolveChannel, loadSuppressionSet, isGuestSuppressed } from '@/services/segmentService';
+
+const logger = loggers.segment;
+
+export type IneligibleReason =
+  | 'unsubscribed'
+  | 'no-contact'
+  | 'suppressed'
+  | 'frequency-cap'
+  | 'active-future-booking';
+
+export interface AudienceCandidate {
+  guestId: string;
+  name: string;
+  language: LanguageCode;
+  country?: string;
+  channel: ChannelType | null;
+  totalBookings: number;
+  totalSpent: number;
+  isRepeat: boolean;                 // fit signal — advisory only
+  lastStayDate: string | null;       // ISO yyyy-mm-dd (advisory display)
+  lastStaySeason: Season | null;     // fit signal — advisory only
+  eligible: boolean;
+  ineligibleReason?: IneligibleReason;
+}
+
+export interface AudienceResult {
+  candidates: AudienceCandidate[];   // ALL candidates, eligible + not, annotated
+  total: number;
+  eligibleCount: number;
+  perRunCap: number;                 // soft per-run guidance (WhatsApp volume safety)
+}
+
+/** All guests for the property (tiny dataset → in-memory annotation). */
+async function fetchGuests(propertyId: string): Promise<Guest[]> {
+  const db = await getAdminDb();
+  const snap = await db.collection('guests').where('propertyIds', 'array-contains', propertyId).get();
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() } as Guest));
+}
+
+/**
+ * Booking ids for the property whose stay has NOT ended yet (checkout today or
+ * later) and is not cancelled — the same "active future booking" definition the
+ * gateway uses (#159). One query + in-memory filter (no composite index).
+ */
+async function futureBookingIds(propertyId: string, now: Date): Promise<Set<string>> {
+  const db = await getAdminDb();
+  const snap = await db.collection('bookings').where('propertyId', '==', propertyId).get();
+  const startOfTodayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const ids = new Set<string>();
+  snap.docs.forEach((d) => {
+    const b = d.data() as { status?: string; checkInDate?: unknown; checkOutDate?: unknown };
+    if (b.status === 'cancelled') return;
+    const end = parseFirestoreDate(b.checkOutDate) ?? parseFirestoreDate(b.checkInDate);
+    if (end && end.getTime() >= startOfTodayUtc) ids.add(d.id);
+  });
+  return ids;
+}
+
+/** The ONLY automatic exclusions — mirrors the gateway's gates (minus dedup). */
+function eligibilityOf(
+  guest: Guest,
+  channel: ChannelType | null,
+  suppression: { phones: Set<string>; emails: Set<string> },
+  futureIds: Set<string>,
+  now: Date
+): IneligibleReason | null {
+  if (guest.unsubscribed) return 'unsubscribed'; // global opt-out (channel-independent)
+  if (!channel) return 'no-contact';
+  if (isConsentBlocked(guest, channel)) return 'unsubscribed'; // per-channel opt-out
+  if (isGuestSuppressed(guest, suppression)) return 'suppressed';
+  const last = parseFirestoreDate(guest.lastCampaignAt);
+  if (last && (now.getTime() - last.getTime()) / 86400000 < GROWTH_ENGINE_LIMITS.frequencyCapDays) {
+    return 'frequency-cap';
+  }
+  if ((guest.bookingIds || []).some((id) => futureIds.has(id))) return 'active-future-booking';
+  return null;
+}
+
+/** Build the annotated candidate list for a property's audience picker. */
+export async function buildAudience(propertyId: string, opts?: { now?: Date }): Promise<AudienceResult> {
+  const now = opts?.now ?? new Date();
+  const [guests, suppression, futureIds] = await Promise.all([
+    fetchGuests(propertyId),
+    loadSuppressionSet(),
+    futureBookingIds(propertyId, now),
+  ]);
+
+  const candidates: AudienceCandidate[] = guests.map((g) => {
+    const channel = resolveChannel(g);
+    const reason = eligibilityOf(g, channel, suppression, futureIds, now);
+    const stay = parseFirestoreDate(g.lastStayDate);
+    return {
+      guestId: g.id,
+      name: [g.firstName, g.lastName].filter(Boolean).join(' ').trim() || '(no name)',
+      language: resolveGuestLanguage(g),
+      country: g.country,
+      channel,
+      totalBookings: g.totalBookings || 0,
+      totalSpent: g.totalSpent || 0,
+      isRepeat: (g.totalBookings || 0) > 1,
+      lastStayDate: stay ? stay.toISOString().slice(0, 10) : null,
+      lastStaySeason: stay ? seasonOf(stay) : null,
+      eligible: reason === null,
+      ineligibleReason: reason ?? undefined,
+    };
+  });
+
+  const eligibleCount = candidates.filter((c) => c.eligible).length;
+  logger.info('Built audience', { propertyId, total: candidates.length, eligibleCount });
+  return { candidates, total: candidates.length, eligibleCount, perRunCap: GROWTH_ENGINE_LIMITS.perRunCap };
+}

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -106,22 +106,70 @@ async function isSuppressed(db: AdminDb, guest: Guest): Promise<boolean> {
 }
 
 /**
+ * Deterministic messageLog doc id for a campaign send, so the idempotency claim
+ * and the dedup check key on the SAME document (create-if-not-exists) instead of
+ * a query over random-id rows. Non-campaign (lifecycle) sends have no id and are
+ * never deduped.
+ */
+function campaignLogId(req: SendRequest): string | null {
+  if (!req.campaignId) return null;
+  // Firestore doc ids cannot contain '/'; campaign/guest ids and snake_case
+  // template names are already safe, but guard anyway.
+  const safe = (s: string) => s.replace(/\//g, '_');
+  return `${safe(req.campaignId)}__${safe(req.guestId)}__${safe(req.templateName)}`;
+}
+
+/**
  * Within a campaign, has this guest already been REALLY delivered this template?
- * Only real deliveries ('sent'/'delivered') block a resend — dry-run previews
- * never do, so a campaign can be previewed repeatedly (M1).
+ * Reads the single deterministic doc (no query). Only real deliveries
+ * ('sent'/'delivered') block a resend — dry-runs never persist here, and a
+ * 'failed'/'sending' state is handled by the atomic claim at delivery time (M1).
  */
 async function alreadyDelivered(db: AdminDb, req: SendRequest): Promise<boolean> {
-  if (!req.campaignId) return false; // dedup only makes sense inside a campaign
-  const snap = await db
-    .collection('messageLog')
-    .where('guestId', '==', req.guestId)
-    .where('campaignId', '==', req.campaignId)
-    .where('templateName', '==', req.templateName)
-    .get();
-  return snap.docs.some((d) => {
-    const s = (d.data() as { status?: string }).status;
-    return s === 'sent' || s === 'delivered';
-  });
+  const id = campaignLogId(req);
+  if (!id) return false; // dedup only makes sense inside a campaign
+  const snap = await db.collection('messageLog').doc(id).get();
+  if (!snap.exists) return false;
+  const s = (snap.data() as { status?: string }).status;
+  return s === 'sent' || s === 'delivered';
+}
+
+/**
+ * #159 — the cardinal-sin guard: never message a guest who has a live upcoming
+ * (or in-progress) stay. Discounting to someone who already paid full rate for
+ * near dates turns a happy guest into a refund argument.
+ *
+ * Uses the guest's canonical `bookingIds` link (reliable; avoids fragile phone
+ * matching) and blocks on any NON-cancelled booking whose stay has not yet ended
+ * (checkout today or later — UTC, matching this project's date-math lesson).
+ * Scoped to `propertyId` when provided, so an upcoming stay at another property
+ * does not block a cross-property message.
+ */
+async function hasActiveFutureBooking(
+  db: AdminDb,
+  guest: Guest,
+  propertyId?: string
+): Promise<boolean> {
+  const ids = guest.bookingIds ?? [];
+  if (ids.length === 0) return false;
+
+  const now = new Date();
+  const startOfTodayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+
+  const snaps = await Promise.all(ids.map((id) => db.collection('bookings').doc(id).get()));
+  for (const snap of snaps) {
+    if (!snap.exists) continue;
+    const b = snap.data() as
+      | { propertyId?: string; status?: string; checkInDate?: unknown; checkOutDate?: unknown }
+      | undefined;
+    if (!b) continue;
+    if (propertyId && b.propertyId !== propertyId) continue;
+    if (b.status === 'cancelled') continue;
+    // Active if the stay hasn't ended yet; fall back to check-in if no checkout.
+    const end = parseFirestoreDate(b.checkOutDate) ?? parseFirestoreDate(b.checkInDate);
+    if (end && end.getTime() >= startOfTodayUtc) return true;
+  }
+  return false;
 }
 
 interface MessageLogInput {
@@ -286,6 +334,20 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     }
   }
 
+  // 2.7) active future booking — never send a reactivation/discount message to a
+  // guest who already has a live upcoming (or in-progress) stay (#159). Runs in
+  // dry-run too, so a campaign preview reflects who would really be excluded.
+  if (await hasActiveFutureBooking(db, guest, req.propertyId)) {
+    const id = await writeMessageLog(db, {
+      ...base,
+      status: 'skipped',
+      reason: 'active-future-booking',
+      to: null,
+      providerId: null,
+    });
+    return { status: 'skipped', reason: 'active-future-booking', messageLogId: id, mode };
+  }
+
   // 3) resolve a contact for the channel
   const contact = resolveContact(guest, req.channel);
   if (!contact) {
@@ -317,9 +379,49 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     return { status: 'dry-run', messageLogId: id, mode: 'dry-run' };
   }
 
-  // 5) LIVE delivery (only when both flags are flipped). Delivery and the log
-  // write are deliberately separated so a Firestore log-write failure can never
-  // mislabel an already-delivered message as 'failed' and cause a re-send (M2).
+  // 5) LIVE delivery (only when both flags are flipped).
+  //
+  // IDEMPOTENT CLAIM (campaign sends): before delivering, atomically claim the
+  // deterministic messageLog doc ({campaignId}__{guestId}__{templateName}) in a
+  // transaction. Two concurrent executeSend calls for the same triple can never
+  // both deliver — the loser sees the claim and is deduped. Because the claim is
+  // written BEFORE delivery, even a post-delivery log-write failure leaves a
+  // 'sending' row that still blocks a re-send, so a Firestore hiccup can never
+  // cause a double delivery (M2). Non-campaign (lifecycle) sends have no id and
+  // keep the simple append-only log.
+  const claimId = campaignLogId(req);
+  const claimRef = claimId ? db.collection('messageLog').doc(claimId) : null;
+
+  if (claimRef) {
+    const claimed = await db.runTransaction(async (tx) => {
+      const snap = await tx.get(claimRef);
+      if (snap.exists) {
+        const st = (snap.data() as { status?: string }).status;
+        // Already delivered, or another worker is mid-send → do not deliver.
+        if (st === 'sent' || st === 'delivered' || st === 'sending') return false;
+        // A prior 'failed' claim is retryable — fall through and re-claim.
+      }
+      tx.set(claimRef, {
+        ...base,
+        status: 'sending',
+        reason: null,
+        to: null,
+        providerId: null,
+        at: FieldValue.serverTimestamp(),
+      });
+      return true;
+    });
+
+    if (!claimed) {
+      logger.info('Send skipped: already claimed/delivered (idempotent)', {
+        guestId: req.guestId,
+        campaignId: req.campaignId,
+        template: req.templateName,
+      });
+      return { status: 'skipped', reason: 'dedup', messageLogId: claimId!, mode: 'live' };
+    }
+  }
+
   // Property-brand the message: inject `property` (name) and `link` (guest
   // availability calendar) template variables so the guest knows which property
   // is reaching out and where to check dates (H1). The approved marketing
@@ -341,13 +443,22 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
   }
 
   const status: MessageLogStatus = delivery.success ? 'sent' : 'failed';
-  const id = await writeMessageLog(db, {
+  const finalEntry: MessageLogInput = {
     ...base,
     status,
     reason: delivery.error ?? null,
     to: maskContact(contact),
     providerId: delivery.providerId ?? null,
-  });
+  };
+
+  // Finalize on the SAME doc we claimed (campaign send), else append (lifecycle).
+  let id: string;
+  if (claimRef) {
+    await claimRef.set({ ...finalEntry, at: FieldValue.serverTimestamp() });
+    id = claimId!;
+  } else {
+    id = await writeMessageLog(db, finalEntry);
+  }
 
   // Record the touch on the GUEST (not just the booking) so the frequency cap
   // and cross-campaign dedup work across properties (H4). Best-effort.

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -31,6 +31,8 @@ export interface SendRequest {
   templateName: string;
   variables?: Record<string, string>;
   campaignId?: string;
+  body?: string;                              // pre-rendered text (required for manual_queue)
+  deliveryMode?: 'provider' | 'manual_queue'; // default 'provider' (Twilio); manual_queue → outbox
 }
 
 export interface SendResult {
@@ -131,7 +133,7 @@ async function alreadyDelivered(db: AdminDb, req: SendRequest): Promise<boolean>
   const snap = await db.collection('messageLog').doc(id).get();
   if (!snap.exists) return false;
   const s = (snap.data() as { status?: string }).status;
-  return s === 'sent' || s === 'delivered';
+  return s === 'sent' || s === 'delivered' || s === 'queued';
 }
 
 /**
@@ -397,8 +399,8 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
       const snap = await tx.get(claimRef);
       if (snap.exists) {
         const st = (snap.data() as { status?: string }).status;
-        // Already delivered, or another worker is mid-send → do not deliver.
-        if (st === 'sent' || st === 'delivered' || st === 'sending') return false;
+        // Already delivered/queued, or another worker is mid-send → do not proceed.
+        if (st === 'sent' || st === 'delivered' || st === 'sending' || st === 'queued') return false;
         // A prior 'failed' claim is retryable — fall through and re-claim.
       }
       tx.set(claimRef, {
@@ -420,6 +422,48 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
       });
       return { status: 'skipped', reason: 'dedup', messageLogId: claimId!, mode: 'live' };
     }
+  }
+
+  // MANUAL QUEUE driver: hand the rendered message to the owner's phone outbox
+  // for a one-tap wa.me send — no provider call. The body is already rendered
+  // (property-branded + opt-out line) upstream, so we do not resolve a template.
+  // lastCampaignAt is set at ACTUAL send time by the outbox_sent callback, not
+  // here, so the frequency cap counts real sends, not queued-but-unsent rows.
+  if (req.deliveryMode === 'manual_queue') {
+    const outboxRef = db.collection('outbox').doc();
+    await outboxRef.set({
+      campaignId: req.campaignId ?? null,
+      guestId: req.guestId,
+      propertyId: req.propertyId ?? null,
+      phone: contact,
+      body: req.body ?? '',
+      language: resolveGuestLanguage(guest),
+      status: 'approved_pending_send',
+      messageLogId: claimId ?? null,
+      claimedAt: null,
+      sentAt: null,
+      finalText: null,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+    // Finalize the claim as 'queued' so a re-run cannot re-queue this guest.
+    const queuedEntry: MessageLogInput = {
+      ...base,
+      status: 'queued',
+      reason: null,
+      to: maskContact(contact),
+      providerId: outboxRef.id, // the outbox row id, for traceability
+    };
+    if (claimRef) await claimRef.set({ ...queuedEntry, at: FieldValue.serverTimestamp() });
+    else await writeMessageLog(db, queuedEntry);
+
+    logger.info('Message queued to outbox for manual send', {
+      guestId: req.guestId,
+      campaignId: req.campaignId,
+      outboxId: outboxRef.id,
+      to: maskContact(contact),
+    });
+    return { status: 'queued', providerId: outboxRef.id, messageLogId: claimId ?? outboxRef.id, mode: 'live' };
   }
 
   // Property-brand the message: inject `property` (name) and `link` (guest

--- a/src/services/segmentService.ts
+++ b/src/services/segmentService.ts
@@ -133,7 +133,7 @@ export interface AudiencePreview {
 }
 
 /** Load the suppression list once into sets for an honest preview (small collection). */
-async function loadSuppressionSet(): Promise<{ phones: Set<string>; emails: Set<string> }> {
+export async function loadSuppressionSet(): Promise<{ phones: Set<string>; emails: Set<string> }> {
   const db = await getAdminDb();
   const snap = await db.collection('suppressionList').get();
   const phones = new Set<string>();
@@ -146,7 +146,7 @@ async function loadSuppressionSet(): Promise<{ phones: Set<string>; emails: Set<
   return { phones, emails };
 }
 
-function isGuestSuppressed(guest: Guest, sets: { phones: Set<string>; emails: Set<string> }): boolean {
+export function isGuestSuppressed(guest: Guest, sets: { phones: Set<string>; emails: Set<string> }): boolean {
   const phone = guest.normalizedPhone || (guest.phone ? normalizePhone(guest.phone) : undefined);
   if (phone && sets.phones.has(phone)) return true;
   if (guest.email && sets.emails.has(guest.email.toLowerCase().trim())) return true;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -362,6 +362,7 @@ export interface Segment {
 export type MessageLogStatus =
   | 'dry-run'      // would-send; recorded but NOT delivered (dark launch)
   | 'sending'      // claim written before delivery; blocks a concurrent/duplicate send (idempotency)
+  | 'queued'       // handed to the manual-send outbox; awaiting the owner's one-tap send
   | 'sent'         // handed to provider
   | 'delivered'    // provider delivery confirmation
   | 'suppressed'   // blocked by suppression / consent / unsubscribe
@@ -381,6 +382,29 @@ export interface MessageLog {
   to?: string | null;          // masked contact
   variables?: Record<string, string> | null;
   at?: SerializableTimestamp;
+}
+
+/** The owner's manual-send queue: rendered messages awaiting a one-tap wa.me send. */
+export type OutboxStatus =
+  | 'approved_pending_send'  // queued by a campaign; awaiting the owner
+  | 'claimed'                // pulled by the Shortcut, not yet confirmed sent
+  | 'sent'                   // owner sent it (Shortcut callback)
+  | 'skipped';               // owner chose not to send
+
+export interface OutboxMessage {
+  id: string;
+  campaignId?: string | null;
+  guestId: string;
+  propertyId?: string | null;
+  phone: string;                  // E.164, ready for wa.me
+  body: string;                   // rendered message text
+  language: LanguageCode;
+  status: OutboxStatus;
+  messageLogId?: string | null;   // gateway claim doc, flipped to 'sent' on callback
+  claimedAt?: SerializableTimestamp | null;
+  sentAt?: SerializableTimestamp | null;
+  finalText?: string | null;      // what the owner actually sent (edit capture)
+  createdAt?: SerializableTimestamp;
 }
 
 export interface SuppressionEntry {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -361,6 +361,7 @@ export interface Segment {
 
 export type MessageLogStatus =
   | 'dry-run'      // would-send; recorded but NOT delivered (dark launch)
+  | 'sending'      // claim written before delivery; blocks a concurrent/duplicate send (idempotency)
   | 'sent'         // handed to provider
   | 'delivered'    // provider delivery confirmation
   | 'suppressed'   // blocked by suppression / consent / unsubscribe


### PR DESCRIPTION
## Engagement System — v1 foundation (Phase 0 → Phase 3 start)

Builds the ban-safe, human-in-the-loop guest-messaging foundation from `plans/engagement-system.md`. **Nothing here changes end-user-facing behavior** — it is admin-only new UI plus dark-launched / inert backend hardening.

### Phase 0 — live-code safety fixes
- **#158 idempotency**: `executeSend` deduped via query-then-write on random messageLog ids → two concurrent sends could both deliver. Now claims a deterministic doc in a transaction before delivery. Closes #158.
- **#159 active-future-booking**: never message a guest with a live upcoming stay. Closes #159.

### Phase 2 — delivery pipe (ban-safe, manual)
- `manual_queue` delivery mode writes a rendered message to an `outbox` collection instead of a provider call (server never touches WhatsApp).
- `/api/automation` `outbox_next` (atomic claim → ready wa.me URL) + `outbox_sent` (mark sent, capture edit, set lastCampaignAt at real-send time). Timing-safe token compare.

### Phase 3 (start) — audience picker
- `audienceService.buildAudience`: annotates every candidate with eligibility (why in/out) + advisory fit signals; reuses the gateway's guardrail primitives.
- `/admin/campaigns/new`: the picker UI (annotated table, filters, selection, soft over-cap warning). Never caps — the operator picks freely.

### Tests
44 passing: executionGateway (29), automation route (11), audienceService (4). `npm run build` green.

### Deploy note
Pushing to `main` auto-deploys to production. This deploy adds an admin-only page and hardens dark-launched code; the growth engine remains flag-gated (off), and the existing `/api/automation` ops (cleaning-lady Shortcut) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
