### PR TITLE
fix: raise Node build heap to 4 GB (App Hosting build OOM)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -22,6 +22,13 @@ runConfig:
 # - RUNTIME
 
 env:
+  # Raise the Node heap for the production build. Next.js `next build` OOM'd on the
+  # App Hosting builder at the ~2 GB v8 default ("JavaScript heap out of memory").
+  # BUILD-time only — runtime stays at runConfig.memoryMiB (1 GiB).
+  - variable: NODE_OPTIONS
+    value: "--max-old-space-size=4096"
+    availability:
+      - BUILD
   - variable: PORT
     value: "8080"
     availability:


### PR DESCRIPTION
The App Hosting build for #161 failed with `JavaScript heap out of memory` (Next.js `next build` exceeded the ~2 GB v8 default on the builder). Adds `NODE_OPTIONS=--max-old-space-size=4096` (BUILD availability) so the compile has headroom; runtime memory unchanged. Unblocks the #161 deploy and hardens future builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)