### PR TITLE
fix: auto-complete past bookings (stale lastStayDate) + stop double-counting

### DIFF
--- a/src/app/admin/bookings/bulk-actions.ts
+++ b/src/app/admin/bookings/bulk-actions.ts
@@ -155,12 +155,15 @@ export async function bulkCompleteBookings(bookingIds: string[]): Promise<BulkAc
         updatedAt: FieldValue.serverTimestamp(),
       });
 
-      // Sync guest record (non-blocking within allSettled)
+      // Advance the guest's lastStayDate WITHOUT re-incrementing totals.
+      // upsertGuestFromBooking uses FieldValue.increment, so re-upserting this
+      // already-counted booking would double-count totalBookings/totalSpent.
+      // Non-blocking within allSettled.
       try {
-        const { upsertGuestFromBooking } = await import('@/services/guestService');
-        await upsertGuestFromBooking({ ...data, id: bookingId, status: 'completed' } as Booking);
+        const { advanceGuestLastStay } = await import('@/services/guestService');
+        await advanceGuestLastStay(bookingId, checkOutDate);
       } catch (guestError) {
-        logger.warn('Non-blocking: failed to sync guest on bulk complete', { bookingId, error: (guestError as Error).message });
+        logger.warn('Non-blocking: failed to advance guest lastStay on bulk complete', { bookingId, error: (guestError as Error).message });
       }
     })
   );

--- a/src/app/api/cron/complete-past-bookings/__tests__/route.test.ts
+++ b/src/app/api/cron/complete-past-bookings/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'ts') },
+}));
+jest.mock('@/services/guestService', () => ({ advanceGuestLastStay: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/logger', () => ({
+  loggers: { booking: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
+}));
+
+import { GET } from '../route';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { advanceGuestLastStay } from '@/services/guestService';
+import type { NextRequest } from 'next/server';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockAdvance = advanceGuestLastStay as jest.Mock;
+
+function makeReq(params: Record<string, string> = {}, headers: Record<string, string> = {}) {
+  return {
+    nextUrl: { searchParams: new URLSearchParams(params) },
+    headers: { get: (k: string) => headers[k] ?? null },
+  } as unknown as NextRequest;
+}
+
+function makeDb(bookings: Array<{ id: string; data: Record<string, unknown> }>) {
+  const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const docs = bookings.map((b) => ({
+    id: b.id,
+    data: () => b.data,
+    ref: { update: async (patch: Record<string, unknown>) => { updates.push({ id: b.id, patch }); } },
+  }));
+  const query: Record<string, jest.Mock> = {};
+  query.where = jest.fn(() => query);
+  query.get = jest.fn().mockResolvedValue({ docs });
+  const db = { collection: jest.fn(() => query) };
+  return { db, updates };
+}
+
+const CRON = { 'X-Appengine-Cron': 'true' };
+const past = new Date(Date.now() - 10 * 86400000);
+const future = new Date(Date.now() + 10 * 86400000);
+
+beforeEach(() => {
+  mockAdvance.mockClear();
+  mockAdvance.mockResolvedValue(true);
+});
+
+describe('complete-past-bookings cron', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    mockGetAdminDb.mockResolvedValue(makeDb([]).db);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it('completes confirmed past-checkout bookings and advances the guest; leaves future ones', async () => {
+    const { db, updates } = makeDb([
+      { id: 'b-past', data: { status: 'confirmed', propertyId: 'prahova', checkOutDate: past, guestInfo: { firstName: 'Eugenia', lastName: 'Lungu' } } },
+      { id: 'b-future', data: { status: 'confirmed', propertyId: 'prahova', checkOutDate: future } },
+    ]);
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await GET(makeReq({}, CRON));
+    const json = await res.json();
+
+    expect(json.eligible).toBe(1);
+    expect(json.completed).toBe(1);
+    expect(json.guestsAdvanced).toBe(1);
+    expect(json.skippedNotPast).toBe(1);
+    expect(updates).toEqual([{ id: 'b-past', patch: expect.objectContaining({ status: 'completed' }) }]);
+    expect(mockAdvance).toHaveBeenCalledWith('b-past', expect.any(Date));
+    expect(mockAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('dry-run reports eligible but writes nothing', async () => {
+    const { db, updates } = makeDb([
+      { id: 'b-past', data: { status: 'confirmed', propertyId: 'prahova', checkOutDate: past } },
+    ]);
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await GET(makeReq({ dryRun: '1' }, CRON));
+    const json = await res.json();
+
+    expect(json.dryRun).toBe(true);
+    expect(json.eligible).toBe(1);
+    expect(json.completed).toBe(0);
+    expect(updates).toHaveLength(0);
+    expect(mockAdvance).not.toHaveBeenCalled();
+  });
+
+  it('skips bookings with an unparseable checkout date', async () => {
+    const { db, updates } = makeDb([
+      { id: 'b-bad', data: { status: 'confirmed', propertyId: 'prahova', checkOutDate: null } },
+    ]);
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await GET(makeReq({}, CRON));
+    const json = await res.json();
+
+    expect(json.skippedBadDate).toBe(1);
+    expect(json.eligible).toBe(0);
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/src/app/api/cron/complete-past-bookings/route.ts
+++ b/src/app/api/cron/complete-past-bookings/route.ts
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Cron endpoint: mark past-checkout bookings as `completed`.
+ *
+ * There is no automatic confirmed→completed transition in the booking lifecycle,
+ * so a stay that has ended stays `confirmed` until an admin manually completes it.
+ * Anything keyed on `completed` therefore lags reality: the guest CRM
+ * `lastStayDate` (recency) and the post-stay review-request emails.
+ *
+ * This job flips non-cancelled `confirmed` bookings whose checkout has passed to
+ * `completed`, and advances the guest's `lastStayDate` via `advanceGuestLastStay`
+ * — which does NOT re-increment totals (unlike upsertGuestFromBooking), so it is
+ * safe to run over already-counted bookings.
+ *
+ * Only touches `confirmed` bookings. Idempotent: once completed, a booking is no
+ * longer selected. `?dryRun=1` reports what WOULD happen without writing.
+ *
+ * Security: cron-only (X-Appengine-Cron header or Bearer token).
+ * Frequency: intended daily via Cloud Scheduler.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { Timestamp as AdminTimestamp } from 'firebase-admin/firestore';
+import { isPast, parseISO, isValid } from 'date-fns';
+import { loggers } from '@/lib/logger';
+import { advanceGuestLastStay } from '@/services/guestService';
+
+const logger = loggers.booking;
+
+/** Parse a Firestore date field (Timestamp | {_seconds} | Date | ISO string). */
+function toDate(raw: unknown): Date | null {
+  if (!raw) return null;
+  if (raw instanceof Date) return raw;
+  if (raw instanceof AdminTimestamp) return raw.toDate();
+  if (typeof raw === 'object' && raw !== null && '_seconds' in raw) {
+    return new Date((raw as { _seconds: number })._seconds * 1000);
+  }
+  if (typeof raw === 'string') {
+    const d = parseISO(raw);
+    return isValid(d) ? d : null;
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  const cronHeader = request.headers.get('X-Appengine-Cron');
+  if (!cronHeader && !authHeader?.startsWith('Bearer ')) {
+    logger.error('Unauthorized access attempt to complete-past-bookings');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const dryRunParam = request.nextUrl.searchParams.get('dryRun');
+  const dryRun = dryRunParam === '1' || dryRunParam === 'true';
+
+  try {
+    const db = await getAdminDb();
+    const snap = await db.collection('bookings').where('status', '==', 'confirmed').get();
+
+    const byProperty: Record<string, number> = {};
+    const sample: Array<{ id: string; propertyId?: string; checkOut: string; guest?: string }> = [];
+    let eligible = 0;
+    let completed = 0;
+    let guestsAdvanced = 0;
+    let skippedNotPast = 0;
+    let skippedBadDate = 0;
+
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      const checkOut = toDate(data.checkOutDate);
+      if (!checkOut) {
+        skippedBadDate++;
+        continue;
+      }
+      if (!isPast(checkOut)) {
+        skippedNotPast++;
+        continue;
+      }
+
+      eligible++;
+      const propertyId = data.propertyId as string | undefined;
+      const key = propertyId ?? 'unknown';
+      byProperty[key] = (byProperty[key] ?? 0) + 1;
+      if (sample.length < 25) {
+        const gi = (data.guestInfo ?? {}) as { firstName?: string; lastName?: string };
+        sample.push({
+          id: doc.id,
+          propertyId,
+          checkOut: checkOut.toISOString().slice(0, 10),
+          guest: [gi.firstName, gi.lastName].filter(Boolean).join(' ') || undefined,
+        });
+      }
+
+      if (dryRun) continue;
+
+      await doc.ref.update({ status: 'completed', updatedAt: FieldValue.serverTimestamp() });
+      completed++;
+      if (await advanceGuestLastStay(doc.id, checkOut)) guestsAdvanced++;
+    }
+
+    logger.info('complete-past-bookings run', {
+      dryRun,
+      confirmedScanned: snap.docs.length,
+      eligible,
+      completed,
+      guestsAdvanced,
+      skippedNotPast,
+      skippedBadDate,
+      byProperty,
+    });
+
+    return NextResponse.json({
+      success: true,
+      dryRun,
+      confirmedScanned: snap.docs.length,
+      eligible, // confirmed AND checkout in the past — what a live run would complete
+      completed, // 0 in dry-run
+      guestsAdvanced,
+      skippedNotPast, // confirmed but checkout still today/future (untouched)
+      skippedBadDate,
+      byProperty,
+      sample,
+    });
+  } catch (error) {
+    logger.error('complete-past-bookings failed', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to complete past bookings', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    );
+  }
+}
+
+// POST for manual testing (protected).
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return GET(request);
+}

--- a/src/services/__tests__/guestService.advanceLastStay.test.ts
+++ b/src/services/__tests__/guestService.advanceLastStay.test.ts
@@ -1,0 +1,79 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: {
+    serverTimestamp: jest.fn(() => 'ts'),
+    arrayUnion: jest.fn((x) => ({ __arrayUnion: x })),
+    increment: jest.fn((n) => ({ __increment: n })),
+  },
+}));
+
+import { advanceGuestLastStay } from '../guestService';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb(guest: Record<string, unknown> | null) {
+  const updateCapture: Record<string, unknown>[] = [];
+  const ref = {};
+  const snap = { empty: guest == null, docs: guest ? [{ ref }] : [] };
+  const query: Record<string, jest.Mock> = {};
+  query.where = jest.fn(() => query);
+  query.limit = jest.fn(() => query);
+  query.get = jest.fn().mockResolvedValue(snap);
+  const txApi = {
+    get: jest.fn().mockResolvedValue({ data: () => guest }),
+    update: jest.fn((_ref: unknown, patch: Record<string, unknown>) => updateCapture.push(patch)),
+  };
+  const db = {
+    collection: jest.fn(() => query),
+    runTransaction: jest.fn((fn: (tx: typeof txApi) => unknown) => fn(txApi)),
+  };
+  return { db, txApi, updateCapture };
+}
+
+describe('advanceGuestLastStay', () => {
+  it('advances lastStayDate when the checkout is newer — and never touches counters', async () => {
+    const { db, txApi, updateCapture } = makeDb({ lastStayDate: new Date('2024-08-12') });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await advanceGuestLastStay('b1', new Date('2026-07-16'));
+
+    expect(res).toBe(true);
+    expect(txApi.update).toHaveBeenCalledTimes(1);
+    expect(updateCapture[0]).toMatchObject({ lastStayDate: new Date('2026-07-16') });
+    expect(updateCapture[0]).not.toHaveProperty('totalBookings');
+    expect(updateCapture[0]).not.toHaveProperty('totalSpent');
+    expect(updateCapture[0]).not.toHaveProperty('bookingIds');
+  });
+
+  it('is a no-op when the guest already has a newer or equal lastStayDate', async () => {
+    const { db, txApi } = makeDb({ lastStayDate: new Date('2026-08-01') });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await advanceGuestLastStay('b1', new Date('2026-07-16'));
+
+    expect(res).toBe(false);
+    expect(txApi.update).not.toHaveBeenCalled();
+  });
+
+  it('advances when the guest has no lastStayDate yet', async () => {
+    const { db, txApi } = makeDb({});
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await advanceGuestLastStay('b1', new Date('2026-07-16'));
+
+    expect(res).toBe(true);
+    expect(txApi.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when no guest is linked to the booking', async () => {
+    const { db } = makeDb(null);
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await advanceGuestLastStay('bX', new Date('2026-07-16'));
+
+    expect(res).toBe(false);
+  });
+});

--- a/src/services/guestService.ts
+++ b/src/services/guestService.ts
@@ -186,6 +186,47 @@ export async function upsertGuestFromBooking(booking: Booking): Promise<string |
 }
 
 /**
+ * Advance a guest's `lastStayDate` to a completed booking's checkout WITHOUT
+ * re-incrementing totals.
+ *
+ * `upsertGuestFromBooking` uses `FieldValue.increment` for totalBookings/
+ * totalSpent, so re-upserting an already-counted booking (which every booking is,
+ * from its creation upsert) double-counts. This helper only moves lastStayDate
+ * forward (max of current vs. this checkout) and touches nothing else, so it is
+ * idempotent and safe to call whenever a booking is marked completed.
+ *
+ * Finds the guest via `bookingIds array-contains bookingId` (the canonical link).
+ * Returns true iff a guest's lastStayDate was actually advanced.
+ */
+export async function advanceGuestLastStay(bookingId: string, checkOutDate: Date): Promise<boolean> {
+  try {
+    const db = await getAdminDb();
+    const snap = await db
+      .collection('guests')
+      .where('bookingIds', 'array-contains', bookingId)
+      .limit(1)
+      .get();
+    if (snap.empty) {
+      logger.warn('advanceGuestLastStay: no guest linked to booking', { bookingId });
+      return false;
+    }
+    const ref = snap.docs[0].ref;
+    return await db.runTransaction(async (tx) => {
+      const doc = await tx.get(ref);
+      const current = parseFirestoreDate(doc.data()?.lastStayDate);
+      if (current && current.getTime() >= checkOutDate.getTime()) {
+        return false; // already at or past this stay
+      }
+      tx.update(ref, { lastStayDate: checkOutDate, updatedAt: FieldValue.serverTimestamp() });
+      return true;
+    });
+  } catch (error) {
+    logger.error('advanceGuestLastStay failed', error as Error, { bookingId });
+    return false;
+  }
+}
+
+/**
  * Find a guest by email address.
  */
 export async function findGuestByEmail(email: string): Promise<Guest | null> {


### PR DESCRIPTION
## Auto-complete past bookings + stop double-counting

**The gap:** there is no automated `confirmed → completed` transition. A stay that has ended sits `confirmed` until an admin manually completes it, so anything keyed on `completed` lags reality — the guest CRM `lastStayDate` (recency), and the post-stay review-request emails. (Discovered because the audience picker showed guest "Eugenia" with a 2-year-old last stay despite a summer-2026 booking.)

**Live check (read-only, against prod):**
- **44** confirmed bookings are past checkout (Coltei 31, Prahova 13, oldest 2026-02-09) → these get completed.
- **All 44** guests' `lastStayDate` would be corrected — many currently have *none at all*.
- Data-health scan found **8/262 guests already inflated** (`totalBookings` > distinct `bookingIds`) from the pre-existing double-count bug — flagged, cleaned up separately.

**Changes:**
- `advanceGuestLastStay` (guestService) — moves `lastStayDate` forward idempotently, **without** re-incrementing totals. `upsertGuestFromBooking` uses `FieldValue.increment`, so re-upserting an already-counted booking double-counts (repo already documents this); this helper avoids it.
- `/api/cron/complete-past-bookings` — flips confirmed + past-checkout bookings to `completed` and advances the guest. `?dryRun=1` reports without writing. Cron-auth (`X-Appengine-Cron` / Bearer); intended daily.
- Fixed admin `bulkCompleteBookings` to use `advanceGuestLastStay` — it had the same latent double-count bug.

**Tests:** 8 — `advanceGuestLastStay` (advance / no-op / no-guest / never touches counters) and the cron (complete / skip-future / dry-run / auth). `npm run build` green.

**No review-email flood:** `send-review-requests` only emails checkouts 1.5–3.5 days old, so completing the old backlog sends nothing late (the ~2 recent ones get the review request they were previously missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
