### PR TITLE
fix: recompute guest totals from bookings (cancelled = zero)

### DIFF
--- a/src/app/api/cron/recompute-guest-aggregates/__tests__/route.test.ts
+++ b/src/app/api/cron/recompute-guest-aggregates/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({ getAdminDb: jest.fn(), FieldValue: { serverTimestamp: jest.fn(() => 'ts') } }));
+jest.mock('@/services/guestService', () => ({ recomputeGuestAggregates: jest.fn() }));
+jest.mock('@/lib/logger', () => ({ loggers: { guest: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } } }));
+
+import { GET } from '../route';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { recomputeGuestAggregates } from '@/services/guestService';
+import type { NextRequest } from 'next/server';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+const mockRecompute = recomputeGuestAggregates as jest.Mock;
+
+function makeReq(params: Record<string, string> = {}, headers: Record<string, string> = {}) {
+  return {
+    nextUrl: { searchParams: new URLSearchParams(params) },
+    headers: { get: (k: string) => headers[k] ?? null },
+  } as unknown as NextRequest;
+}
+
+function makeDb(guestIds: string[]) {
+  const docs = guestIds.map((id) => ({ id, data: () => ({ firstName: id }) }));
+  return { collection: () => ({ get: async () => ({ docs }) }) };
+}
+
+const CRON = { 'X-Appengine-Cron': 'true' };
+
+beforeEach(() => mockRecompute.mockReset());
+
+describe('recompute-guest-aggregates cron', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    mockGetAdminDb.mockResolvedValue(makeDb([]));
+    expect((await GET(makeReq())).status).toBe(401);
+  });
+
+  it('tallies the number of guests whose totals changed', async () => {
+    mockGetAdminDb.mockResolvedValue(makeDb(['g1', 'g2', 'g3']));
+    mockRecompute.mockImplementation(async (id: string) => ({
+      changed: id !== 'g2',
+      before: { totalBookings: 2, totalSpent: 2000 },
+      after: { totalBookings: 1, totalSpent: 1000 },
+    }));
+
+    const res = await GET(makeReq({}, CRON));
+    const json = await res.json();
+
+    expect(json.scanned).toBe(3);
+    expect(json.changed).toBe(2); // g1 and g3
+    expect(json.changes).toHaveLength(2);
+    expect(mockRecompute).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes dryRun through to the recompute', async () => {
+    mockGetAdminDb.mockResolvedValue(makeDb(['g1']));
+    mockRecompute.mockResolvedValue({ changed: false, before: { totalBookings: 1, totalSpent: 1 }, after: { totalBookings: 1, totalSpent: 1 } });
+
+    await GET(makeReq({ dryRun: '1' }, CRON));
+
+    expect(mockRecompute).toHaveBeenCalledWith('g1', { dryRun: true });
+  });
+});

--- a/src/app/api/cron/recompute-guest-aggregates/route.ts
+++ b/src/app/api/cron/recompute-guest-aggregates/route.ts
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Cron endpoint: recompute guest `totalBookings` + `totalSpent`
+ * from the source of truth (their bookings), counting only NON-cancelled
+ * bookings.
+ *
+ * The running counters are maintained by `FieldValue.increment` across several
+ * inconsistent booking paths (create/complete/cancel), so they drift — e.g. a
+ * cancellation can re-inflate a guest. Recomputing from bookings makes the CRM
+ * self-heal regardless of which path touched it. Writes only guests whose totals
+ * actually changed. `?dryRun=1` reports the corrections without writing.
+ *
+ * Security: cron-only (X-Appengine-Cron header or Bearer token).
+ * Frequency: intended weekly via Cloud Scheduler.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import { recomputeGuestAggregates } from '@/services/guestService';
+
+const logger = loggers.guest;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  const cronHeader = request.headers.get('X-Appengine-Cron');
+  if (!cronHeader && !authHeader?.startsWith('Bearer ')) {
+    logger.error('Unauthorized access attempt to recompute-guest-aggregates');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const dryRunParam = request.nextUrl.searchParams.get('dryRun');
+  const dryRun = dryRunParam === '1' || dryRunParam === 'true';
+
+  try {
+    const db = await getAdminDb();
+    const guests = await db.collection('guests').get();
+    const nameById = new Map<string, string>();
+    guests.docs.forEach((d) => {
+      const g = d.data();
+      nameById.set(d.id, [g.firstName, g.lastName].filter(Boolean).join(' ') || d.id);
+    });
+    const ids = guests.docs.map((d) => d.id);
+
+    let changed = 0;
+    const changes: Array<{ guestId: string; name: string; before: unknown; after: unknown }> = [];
+
+    // Bounded concurrency so a large guest list doesn't fan out unbounded.
+    const CHUNK = 25;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const batch = ids.slice(i, i + CHUNK);
+      const results = await Promise.all(
+        batch.map(async (id) => ({ id, res: await recomputeGuestAggregates(id, { dryRun }) }))
+      );
+      for (const { id, res } of results) {
+        if (res.changed) {
+          changed++;
+          if (changes.length < 30) {
+            changes.push({ guestId: id, name: nameById.get(id) ?? id, before: res.before, after: res.after });
+          }
+        }
+      }
+    }
+
+    logger.info('recompute-guest-aggregates run', { dryRun, scanned: ids.length, changed });
+    return NextResponse.json({ success: true, dryRun, scanned: ids.length, changed, changes });
+  } catch (error) {
+    logger.error('recompute-guest-aggregates failed', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to recompute guest aggregates', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    );
+  }
+}
+
+// POST for manual testing (protected).
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return GET(request);
+}

--- a/src/services/__tests__/guestService.recompute.test.ts
+++ b/src/services/__tests__/guestService.recompute.test.ts
@@ -1,0 +1,89 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'ts'), arrayUnion: jest.fn(), increment: jest.fn() },
+}));
+
+import { recomputeGuestAggregates } from '../guestService';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb({ guest, bookings }: { guest: Record<string, unknown>; bookings: Record<string, Record<string, unknown>> }) {
+  const updateCapture: Record<string, unknown>[] = [];
+  const gref = {
+    get: async () => ({ exists: true, data: () => guest }),
+    update: async (p: Record<string, unknown>) => { updateCapture.push(p); },
+  };
+  const db = {
+    collection: (name: string) => {
+      if (name === 'guests') return { doc: () => gref };
+      if (name === 'bookings') return { doc: (id: string) => ({ _id: id }) };
+      return { doc: () => ({}) };
+    },
+    getAll: async (...refs: Array<{ _id: string }>) =>
+      refs.map((r) => ({ exists: bookings[r._id] != null, data: () => bookings[r._id] })),
+  };
+  return { db, updateCapture };
+}
+
+describe('recomputeGuestAggregates', () => {
+  it('counts only non-cancelled bookings and fixes inflated totals', async () => {
+    const { db, updateCapture } = makeDb({
+      guest: { totalBookings: 3, totalSpent: 3000, bookingIds: ['b1', 'b2', 'b3'] },
+      bookings: {
+        b1: { status: 'completed', pricing: { total: 1000 } },
+        b2: { status: 'confirmed', pricing: { total: 1500 } },
+        b3: { status: 'cancelled', pricing: { total: 500 } }, // never happened
+      },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await recomputeGuestAggregates('g1');
+
+    expect(res.changed).toBe(true);
+    expect(res.before).toEqual({ totalBookings: 3, totalSpent: 3000 });
+    expect(res.after).toEqual({ totalBookings: 2, totalSpent: 2500 });
+    expect(updateCapture[0]).toMatchObject({ totalBookings: 2, totalSpent: 2500 });
+  });
+
+  it('is a no-op (no write) when the totals already match', async () => {
+    const { db, updateCapture } = makeDb({
+      guest: { totalBookings: 1, totalSpent: 1000, bookingIds: ['b1'] },
+      bookings: { b1: { status: 'completed', pricing: { total: 1000 } } },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await recomputeGuestAggregates('g1');
+
+    expect(res.changed).toBe(false);
+    expect(updateCapture).toHaveLength(0);
+  });
+
+  it('dry-run computes the correction but writes nothing', async () => {
+    const { db, updateCapture } = makeDb({
+      guest: { totalBookings: 3, totalSpent: 3000, bookingIds: ['b1', 'b2'] },
+      bookings: {
+        b1: { status: 'completed', pricing: { total: 1000 } },
+        b2: { status: 'confirmed', pricing: { total: 1000 } },
+      },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await recomputeGuestAggregates('g1', { dryRun: true });
+
+    expect(res.changed).toBe(true);
+    expect(res.after).toEqual({ totalBookings: 2, totalSpent: 2000 });
+    expect(updateCapture).toHaveLength(0);
+  });
+
+  it('handles a guest with no bookings (zeroes)', async () => {
+    const { db } = makeDb({ guest: { totalBookings: 2, totalSpent: 500, bookingIds: [] }, bookings: {} });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await recomputeGuestAggregates('g1');
+
+    expect(res.after).toEqual({ totalBookings: 0, totalSpent: 0 });
+  });
+});

--- a/src/services/guestService.ts
+++ b/src/services/guestService.ts
@@ -226,6 +226,54 @@ export async function advanceGuestLastStay(bookingId: string, checkOutDate: Date
   }
 }
 
+export interface GuestTotals {
+  totalBookings: number;
+  totalSpent: number;
+}
+
+/**
+ * Recompute a guest's `totalBookings` + `totalSpent` from the source of truth —
+ * their bookings — counting ONLY non-cancelled ones (a cancelled booking never
+ * happened: no stay, no revenue). Writes only when a value actually changes.
+ *
+ * The running counters are maintained by `FieldValue.increment` across several
+ * inconsistent booking paths (create/complete/cancel), so they drift — this
+ * recompute is the trustworthy correction, idempotent and safe to run
+ * repeatedly. Pass `{ dryRun: true }` to preview without writing.
+ */
+export async function recomputeGuestAggregates(
+  guestId: string,
+  opts?: { dryRun?: boolean }
+): Promise<{ changed: boolean; before: GuestTotals; after: GuestTotals }> {
+  const db = await getAdminDb();
+  const gref = db.collection('guests').doc(guestId);
+  const gsnap = await gref.get();
+  const g = gsnap.exists ? gsnap.data()! : {};
+  const before: GuestTotals = { totalBookings: (g.totalBookings as number) || 0, totalSpent: (g.totalSpent as number) || 0 };
+
+  const ids: string[] = Array.isArray(g.bookingIds) ? Array.from(new Set(g.bookingIds as string[])) : [];
+  let totalBookings = 0;
+  let totalSpent = 0;
+  if (ids.length > 0) {
+    const docs = await db.getAll(...ids.map((id) => db.collection('bookings').doc(id)));
+    for (const d of docs) {
+      if (!d.exists) continue;
+      const b = d.data()!;
+      if (b.status === 'cancelled') continue; // cancelled = never happened
+      totalBookings++;
+      totalSpent += (b.pricing?.total as number) || 0;
+    }
+  }
+  const after: GuestTotals = { totalBookings, totalSpent };
+
+  const changed = before.totalBookings !== after.totalBookings || before.totalSpent !== after.totalSpent;
+  if (changed && !gsnap.exists) return { changed: false, before, after }; // guest vanished mid-run
+  if (changed && !opts?.dryRun) {
+    await gref.update({ totalBookings, totalSpent, updatedAt: FieldValue.serverTimestamp() });
+  }
+  return { changed, before, after };
+}
+
 /**
  * Find a guest by email address.
  */


### PR DESCRIPTION
## Recompute guest totals from bookings (cancelled = zero)

**The gap:** guest `totalBookings` / `totalSpent` are maintained by `FieldValue.increment` across several inconsistent booking paths (create / complete / cancel), so they drift. A read-only audit found **11 / 262 guests wrong** — some inflated (all-cancelled guests carrying phantom stays + revenue; double-counted bookings), some *understated*. Per the owner: a cancelled booking never happened — no stay, no revenue.

**Preview (read-only, against prod):**
- ~7 all-cancelled guests → correctly `0 / 0` (e.g. Catalina Cristea `2→0`, Yaniv Zur `5080→0`, Mariam Andre Hassan `15385→0`).
- Fabiola Raggi `3 → 1 / 4651 → 1493` (double-count fixed).
- A few understated get corrected up (Ion Berceanu `3117 → 3617`) — drift fixed both directions.

**Changes:**
- `recomputeGuestAggregates(guestId, {dryRun})` — recompute `totalBookings` + `totalSpent` from the guest's **non-cancelled** bookings (source of truth); write only when changed. Idempotent.
- `/api/cron/recompute-guest-aggregates` — recompute all guests, write only the changed ones, `?dryRun=1` previews. Cron-auth. Intended **weekly** so totals self-heal regardless of which booking path touched them (rather than chasing the increment bug across every path).

**Tests:** 7 — recompute (exclude-cancelled / no-op / dry-run / no-bookings) + cron (tally / dry-run / auth). `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
