### PR TITLE
feat: campaign message step — compose, review, approve & manual send

### DIFF
--- a/src/app/admin/campaigns/[id]/page.tsx
+++ b/src/app/admin/campaigns/[id]/page.tsx
@@ -1,0 +1,56 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { AdminPage } from '@/components/admin';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import { getCampaign } from '@/services/campaignService';
+import type { MessageVariant } from '@/types';
+import { MessageComposer } from '../_components/message-composer';
+import { OutboxSender } from '../_components/outbox-sender';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Campaign workspace. While the campaign is a `draft`, the owner composes and
+ * reviews (Gate 1). Once approved & queued (`sending`/`sent`), it becomes the
+ * manual send list (Gate 2). Only serializable scalars cross to the client —
+ * never the raw Firestore doc (Timestamps aren't serializable).
+ */
+export default async function CampaignWorkspacePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const campaign = await getCampaign(id);
+  if (!campaign) notFound();
+
+  const isDraft = campaign.status === 'draft';
+  const variants = (campaign.messageVariants ?? []) as MessageVariant[];
+  const audienceCount = campaign.audienceGuestIds?.length ?? 0;
+
+  return (
+    <AdminPage
+      title={campaign.name}
+      description={
+        isDraft
+          ? 'Write the message, preview exactly what each guest will get, then approve to queue it for sending.'
+          : 'Send each queued message from your own WhatsApp, one tap at a time.'
+      }
+    >
+      <div className="mb-4">
+        <Link href={`/admin/campaigns?propertyId=${campaign.propertyId}`}>
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back to campaigns
+          </Button>
+        </Link>
+      </div>
+
+      {isDraft ? (
+        <MessageComposer campaignId={id} audienceCount={audienceCount} initialVariants={variants} />
+      ) : (
+        <OutboxSender campaignId={id} status={campaign.status} />
+      )}
+    </AdminPage>
+  );
+}

--- a/src/app/admin/campaigns/_components/audience-picker.tsx
+++ b/src/app/admin/campaigns/_components/audience-picker.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Users, Search } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { Users, Search, Loader2, ArrowRight } from 'lucide-react';
 import type { AudienceCandidate, IneligibleReason } from '@/services/audienceService';
+import { createManualCampaignAction } from '../actions';
 
 // Operator-facing labels for the (only) automatic exclusions.
 const REASON_LABEL: Record<IneligibleReason, string> = {
@@ -24,16 +27,36 @@ export function AudiencePicker({
   candidates,
   eligibleCount,
   perRunCap,
+  propertyId,
 }: {
   candidates: AudienceCandidate[];
   eligibleCount: number;
   perRunCap: number;
+  propertyId: string;
 }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [creating, startCreate] = useTransition();
+  const [name, setName] = useState(`Reach-out ${new Date().toISOString().slice(0, 10)}`);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
   const [lang, setLang] = useState<LangFilter>('all');
   const [repeat, setRepeat] = useState<RepeatFilter>('all');
   const [eligibleOnly, setEligibleOnly] = useState(true);
+
+  const handleContinue = () =>
+    startCreate(async () => {
+      const res = await createManualCampaignAction({
+        name: name.trim() || `Reach-out ${new Date().toISOString().slice(0, 10)}`,
+        propertyId,
+        guestIds: [...selected],
+      });
+      if (res.success && res.id) {
+        router.push(`/admin/campaigns/${res.id}`);
+      } else {
+        toast({ title: 'Could not create campaign', description: res.error, variant: 'destructive' });
+      }
+    });
 
   // Filters narrow the VIEW only; they never remove anyone from eligibility.
   // Sorted most-recent-stay first (recency is a soft signal, so it's a sort, not
@@ -185,9 +208,27 @@ export function AudiencePicker({
         </Table>
       </div>
 
-      {/* Handoff to the message step (Gate 1) — wired in the next increment. */}
-      <div className="flex justify-end">
-        <Button disabled={selectedCount === 0}>
+      {/* Handoff to the message step (Gate 1): name the campaign, create it with the
+          chosen audience, and move to compose. */}
+      <div className="flex flex-wrap items-center justify-end gap-3 border-t pt-4">
+        <div className="flex items-center gap-2">
+          <label htmlFor="campaign-name" className="text-sm text-muted-foreground">
+            Name
+          </label>
+          <Input
+            id="campaign-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Campaign name"
+            className="w-56"
+          />
+        </div>
+        <Button disabled={selectedCount === 0 || creating} onClick={handleContinue}>
+          {creating ? (
+            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+          ) : (
+            <ArrowRight className="mr-1 h-4 w-4" />
+          )}
           Continue with {selectedCount} guest{selectedCount === 1 ? '' : 's'}
         </Button>
       </div>

--- a/src/app/admin/campaigns/_components/campaign-table.tsx
+++ b/src/app/admin/campaigns/_components/campaign-table.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useTransition } from 'react';
+import Link from 'next/link';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Play, Check } from 'lucide-react';
+import { Loader2, Play, Check, ArrowRight } from 'lucide-react';
 import type { Campaign } from '@/types';
 import { approveCampaignAction, runCampaignAction } from '../actions';
 
@@ -64,8 +65,15 @@ function CampaignRow({ campaign: c }: { campaign: Campaign }) {
       }
     });
 
+  // Manual (message-step) campaigns carry a hand-picked audience and are worked in
+  // their own workspace; the segment/dry-run controls only apply to the automated path.
+  const isManual = c.templateName === 'manual';
   const stats = c.stats;
-  const reached = stats && stats.attempted > 0 ? `${stats.dryRun + stats.sent}/${stats.audienceSize}` : '—';
+  const reached = isManual
+    ? `${c.audienceGuestIds?.length ?? 0} in audience`
+    : stats && stats.attempted > 0
+      ? `${stats.dryRun + stats.sent}/${stats.audienceSize}`
+      : '—';
 
   return (
     <TableRow>
@@ -73,19 +81,30 @@ function CampaignRow({ campaign: c }: { campaign: Campaign }) {
       <TableCell>
         <Badge variant={STATUS_VARIANT[c.status] || 'outline'}>{c.status}</Badge>
       </TableCell>
-      <TableCell className="text-muted-foreground">{c.templateName}</TableCell>
+      <TableCell className="text-muted-foreground">{isManual ? 'WhatsApp (manual)' : c.templateName}</TableCell>
       <TableCell className="text-right text-sm text-muted-foreground">{reached}</TableCell>
       <TableCell className="space-x-2 whitespace-nowrap text-right">
-        {!c.approvedBy && (
-          <Button size="sm" variant="outline" onClick={approve} disabled={approving}>
-            {approving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-            <span className="ml-1">Approve</span>
-          </Button>
+        {isManual ? (
+          <Link href={`/admin/campaigns/${c.id}`}>
+            <Button size="sm" variant="outline">
+              <span className="mr-1">{c.status === 'draft' ? 'Compose' : 'Open'}</span>
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Button>
+          </Link>
+        ) : (
+          <>
+            {!c.approvedBy && (
+              <Button size="sm" variant="outline" onClick={approve} disabled={approving}>
+                {approving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+                <span className="ml-1">Approve</span>
+              </Button>
+            )}
+            <Button size="sm" onClick={run} disabled={running}>
+              {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+              <span className="ml-1">Run (dry-run)</span>
+            </Button>
+          </>
         )}
-        <Button size="sm" onClick={run} disabled={running}>
-          {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-          <span className="ml-1">Run (dry-run)</span>
-        </Button>
       </TableCell>
     </TableRow>
   );

--- a/src/app/admin/campaigns/_components/message-composer.tsx
+++ b/src/app/admin/campaigns/_components/message-composer.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+/**
+ * Gate 1 — compose + review + approve.
+ *
+ * The owner writes 2–3 short variants per language (v1 has no LLM drafter). We
+ * render them against the real audience (fills {name}/{property}/{link}, rotates
+ * variants, appends the STOP line) so the owner reads the ACTUAL messages before
+ * committing. "Approve & queue" pushes every rendered message through the gateway
+ * into the outbox — it does NOT send anything; the owner sends manually in Gate 2.
+ */
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Eye, Send, Plus, X, Users } from 'lucide-react';
+import type { MessageVariant, LanguageCode } from '@/types';
+import type { RenderedMessage, SkippedRender } from '@/services/campaignMessaging';
+import { previewCampaignMessagesAction, approveAndQueueAction } from '../actions';
+
+const LANGS: { code: LanguageCode; label: string }[] = [
+  { code: 'ro', label: 'Romanian' },
+  { code: 'en', label: 'English' },
+];
+
+const SKIP_LABEL: Record<SkippedRender['reason'], string> = {
+  'guest-not-found': 'Guest not found',
+  'no-phone': 'No WhatsApp number',
+  'no-variant-for-language': 'No variant written for their language',
+};
+
+export function MessageComposer({
+  campaignId,
+  audienceCount,
+  initialVariants,
+}: {
+  campaignId: string;
+  audienceCount: number;
+  initialVariants: MessageVariant[];
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [previewing, startPreview] = useTransition();
+  const [approving, startApprove] = useTransition();
+
+  // Group variants by language into editable text lists (default: one empty each).
+  const [byLang, setByLang] = useState<Record<LanguageCode, string[]>>(() => {
+    const init: Record<LanguageCode, string[]> = { ro: [], en: [] };
+    for (const v of initialVariants) (init[v.language] ??= []).push(v.body);
+    for (const { code } of LANGS) if (init[code].length === 0) init[code] = [''];
+    return init;
+  });
+
+  const [rendered, setRendered] = useState<RenderedMessage[] | null>(null);
+  const [skipped, setSkipped] = useState<SkippedRender[]>([]);
+
+  const setVariant = (lang: LanguageCode, i: number, value: string) =>
+    setByLang((prev) => ({ ...prev, [lang]: prev[lang].map((v, idx) => (idx === i ? value : v)) }));
+  const addVariant = (lang: LanguageCode) =>
+    setByLang((prev) => ({ ...prev, [lang]: [...prev[lang], ''] }));
+  const removeVariant = (lang: LanguageCode, i: number) =>
+    setByLang((prev) => ({ ...prev, [lang]: prev[lang].filter((_, idx) => idx !== i) }));
+
+  // Flatten to MessageVariant[], dropping blanks.
+  const toVariants = (): MessageVariant[] =>
+    LANGS.flatMap(({ code }) =>
+      byLang[code].map((body) => body.trim()).filter(Boolean).map((body) => ({ language: code, body }))
+    );
+
+  const hasCopy = toVariants().length > 0;
+
+  const preview = () =>
+    startPreview(async () => {
+      const res = await previewCampaignMessagesAction(campaignId, toVariants());
+      if (res.success) {
+        setRendered(res.rendered ?? []);
+        setSkipped(res.skipped ?? []);
+      } else {
+        toast({ title: 'Preview failed', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  const approve = () =>
+    startApprove(async () => {
+      const res = await approveAndQueueAction(campaignId, toVariants());
+      if (res.success) {
+        toast({
+          title: `Queued ${res.queued ?? 0} message${res.queued === 1 ? '' : 's'}`,
+          description: 'Nothing sent yet — send them from the list on the next screen.',
+        });
+        router.refresh(); // status → sending: page swaps to the send list (Gate 2)
+      } else {
+        toast({ title: 'Could not queue', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
+      {/* Compose */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Write the message</CardTitle>
+          <CardDescription>
+            2–3 short variants per language. We rotate them across guests (small wording
+            differences keep WhatsApp happy). Use{' '}
+            <code className="rounded bg-muted px-1">{'{name}'}</code>,{' '}
+            <code className="rounded bg-muted px-1">{'{property}'}</code>,{' '}
+            <code className="rounded bg-muted px-1">{'{link}'}</code> — filled per guest. A STOP
+            opt-out line is appended automatically.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {LANGS.map(({ code, label }) => (
+            <div key={code} className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="outline" className="uppercase">
+                  {code}
+                </Badge>
+                <span className="text-sm font-medium">{label}</span>
+              </div>
+              {byLang[code].map((body, i) => (
+                <div key={i} className="flex items-start gap-2">
+                  <Textarea
+                    value={body}
+                    onChange={(e) => setVariant(code, i, e.target.value)}
+                    placeholder={code === 'ro' ? 'Salut {name}, …' : 'Hi {name}, …'}
+                    rows={3}
+                    className="flex-1"
+                  />
+                  {byLang[code].length > 1 && (
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="mt-1 h-8 w-8 shrink-0"
+                      onClick={() => removeVariant(code, i)}
+                      aria-label="Remove variant"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <Button size="sm" variant="ghost" className="text-xs" onClick={() => addVariant(code)}>
+                <Plus className="mr-1 h-3.5 w-3.5" /> Add {label} variant
+              </Button>
+            </div>
+          ))}
+
+          <div className="flex items-center gap-2 border-t pt-4">
+            <Button variant="outline" onClick={preview} disabled={!hasCopy || previewing}>
+              {previewing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Eye className="mr-1 h-4 w-4" />}
+              Preview messages
+            </Button>
+            <Button onClick={approve} disabled={!rendered || rendered.length === 0 || approving}>
+              {approving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Send className="mr-1 h-4 w-4" />}
+              Approve &amp; queue{rendered ? ` (${rendered.length})` : ''}
+            </Button>
+          </div>
+          {!rendered && hasCopy && (
+            <p className="text-xs text-muted-foreground">Preview first — you approve exactly what you saw.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Review */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" /> Review
+          </CardTitle>
+          <CardDescription>
+            {rendered
+              ? `${rendered.length} message${rendered.length === 1 ? '' : 's'} ready · ${skipped.length} skipped · ${audienceCount} in audience`
+              : `${audienceCount} guest${audienceCount === 1 ? '' : 's'} selected. Preview to see each rendered message.`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {!rendered && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Nothing to review yet — write your copy and hit “Preview messages”.
+            </p>
+          )}
+
+          {rendered && rendered.length > 0 && (
+            <div className="max-h-[28rem] space-y-3 overflow-y-auto pr-1">
+              {rendered.map((m) => (
+                <div key={m.guestId} className="rounded-md border p-3">
+                  <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{m.name || '(no name)'}</span>
+                    <span>
+                      {m.phone} · <span className="uppercase">{m.language}</span> · variant {m.variantIndex + 1}
+                    </span>
+                  </div>
+                  <p className="whitespace-pre-wrap text-sm">{m.body}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {rendered && rendered.length === 0 && (
+            <p className="py-6 text-center text-sm text-amber-600">
+              No messages rendered. Check that you wrote a variant for each language below.
+            </p>
+          )}
+
+          {skipped.length > 0 && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm">
+              <p className="mb-1 font-medium text-amber-800">Skipped ({skipped.length})</p>
+              <ul className="space-y-0.5 text-amber-700">
+                {skipped.map((s) => (
+                  <li key={s.guestId}>
+                    {s.name || s.guestId} — {SKIP_LABEL[s.reason]}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/campaigns/_components/outbox-sender.tsx
+++ b/src/app/admin/campaigns/_components/outbox-sender.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+/**
+ * Gate 2 — the manual send list (ban-safe by design: the server never touches
+ * WhatsApp). For each queued message the owner taps "Open WhatsApp" (a wa.me
+ * click-to-chat link that pre-fills the text — no auto-send), sends it by hand,
+ * then taps "Mark sent". Marking sent records the final text and advances the
+ * guest's frequency cap. The text stays editable up to the moment of sending.
+ */
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, MessageCircle, Check, CheckCheck } from 'lucide-react';
+import type { OutboxMessage } from '@/types';
+import { fetchCampaignOutboxAction, markSentAction, markCampaignSentAction } from '../actions';
+
+/** wa.me needs digits only; the text is pre-filled but not auto-sent. */
+function waLink(phone: string, text: string): string {
+  return `https://wa.me/${phone.replace(/\D/g, '')}?text=${encodeURIComponent(text)}`;
+}
+
+export function OutboxSender({
+  campaignId,
+  status,
+}: {
+  campaignId: string;
+  status: string;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [rows, setRows] = useState<OutboxMessage[] | null>(null);
+  const [edited, setEdited] = useState<Record<string, string>>({});
+  const [pending, setPending] = useState<Set<string>>(new Set());
+  const [completing, startComplete] = useTransition();
+
+  useEffect(() => {
+    let alive = true;
+    fetchCampaignOutboxAction(campaignId).then((res) => {
+      if (!alive) return;
+      if (res.success && res.rows) {
+        setRows(res.rows);
+        setEdited(Object.fromEntries(res.rows.map((r) => [r.id, r.finalText ?? r.body])));
+      } else {
+        toast({ title: 'Could not load the send list', description: res.error, variant: 'destructive' });
+      }
+    });
+    return () => {
+      alive = false;
+    };
+  }, [campaignId, toast]);
+
+  const markSent = async (row: OutboxMessage) => {
+    setPending((p) => new Set(p).add(row.id));
+    const text = edited[row.id] ?? row.body;
+    const res = await markSentAction(row.id, text);
+    setPending((p) => {
+      const next = new Set(p);
+      next.delete(row.id);
+      return next;
+    });
+    if (res.success) {
+      setRows((prev) => prev?.map((r) => (r.id === row.id ? { ...r, status: 'sent', finalText: text } : r)) ?? prev);
+    } else {
+      toast({ title: 'Could not mark sent', description: res.error, variant: 'destructive' });
+    }
+  };
+
+  const complete = () =>
+    startComplete(async () => {
+      const res = await markCampaignSentAction(campaignId);
+      if (res.success) {
+        toast({ title: 'Campaign marked complete' });
+        router.refresh();
+      } else {
+        toast({ title: 'Could not update campaign', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  if (!rows) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 py-10 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading the send list…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const sentCount = rows.filter((r) => r.status === 'sent').length;
+  const total = rows.length;
+  const allSent = total > 0 && sentCount === total;
+  const pct = total > 0 ? Math.round((sentCount / total) * 100) : 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between gap-2">
+          <span>Send list</span>
+          <Badge variant={status === 'sent' ? 'default' : 'secondary'}>{status}</Badge>
+        </CardTitle>
+        <CardDescription>
+          Tap “Open WhatsApp”, send the message by hand, then “Mark sent”. You send from your own
+          number — this is what keeps it ban-safe. Text stays editable until you send.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Progress */}
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              {sentCount} of {total} sent
+            </span>
+            {status !== 'sent' && (
+              <Button size="sm" variant={allSent ? 'default' : 'outline'} onClick={complete} disabled={completing}>
+                {completing ? (
+                  <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                ) : (
+                  <CheckCheck className="mr-1 h-4 w-4" />
+                )}
+                Mark campaign complete
+              </Button>
+            )}
+          </div>
+          <Progress value={pct} />
+        </div>
+
+        {total === 0 && (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            Nothing queued. (If you expected messages here, some guests may have been skipped at the
+            gateway — consent, suppression, an upcoming stay, or a recent message.)
+          </p>
+        )}
+
+        <div className="space-y-3">
+          {rows.map((row) => {
+            const isSent = row.status === 'sent';
+            const busy = pending.has(row.id);
+            const text = edited[row.id] ?? row.body;
+            return (
+              <div key={row.id} className={`rounded-md border p-3 ${isSent ? 'bg-muted/40' : ''}`}>
+                <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">{row.phone}</span>
+                  <span className="flex items-center gap-2">
+                    <span className="uppercase">{row.language}</span>
+                    {isSent ? (
+                      <Badge variant="outline" className="text-emerald-700">
+                        <Check className="mr-1 h-3 w-3" /> sent
+                      </Badge>
+                    ) : (
+                      <Badge variant="secondary">pending</Badge>
+                    )}
+                  </span>
+                </div>
+
+                {isSent ? (
+                  <p className="whitespace-pre-wrap text-sm text-muted-foreground">{row.finalText ?? row.body}</p>
+                ) : (
+                  <Textarea
+                    value={text}
+                    onChange={(e) => setEdited((prev) => ({ ...prev, [row.id]: e.target.value }))}
+                    rows={4}
+                    className="text-sm"
+                  />
+                )}
+
+                {!isSent && (
+                  <div className="mt-2 flex items-center gap-2">
+                    <a href={waLink(row.phone, text)} target="_blank" rel="noopener noreferrer">
+                      <Button size="sm" variant="outline">
+                        <MessageCircle className="mr-1 h-4 w-4" /> Open WhatsApp
+                      </Button>
+                    </a>
+                    <Button size="sm" onClick={() => markSent(row)} disabled={busy}>
+                      {busy ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                      Mark sent
+                    </Button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -3,10 +3,12 @@
 import { revalidatePath } from 'next/cache';
 import { loggers } from '@/lib/logger';
 import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
-import type { Campaign, SegmentDefinition } from '@/types';
+import type { Campaign, SegmentDefinition, MessageVariant, OutboxMessage } from '@/types';
 import { PREDEFINED_SEGMENTS, previewAudience } from '@/services/segmentService';
-import { listCampaigns, createCampaign, approveCampaign, sendCampaign } from '@/services/campaignService';
+import { listCampaigns, createCampaign, approveCampaign, sendCampaign, createManualCampaign, markCampaignQueued, markCampaignSent, getCampaign } from '@/services/campaignService';
 import { buildAudience, type AudienceCandidate } from '@/services/audienceService';
+import { renderMessages, queueMessages, type RenderedMessage, type SkippedRender } from '@/services/campaignMessaging';
+import { fetchOutboxForCampaign, markOutboxSent } from '@/services/outboxService';
 
 const logger = loggers.campaign;
 
@@ -174,5 +176,152 @@ export async function fetchAudienceAction(propertyId: string): Promise<{
   } catch (error) {
     logger.error('fetchAudienceAction failed', error as Error);
     return { success: false, error: 'Failed to load audience' };
+  }
+}
+
+// --- Message step (manual campaigns): create → compose/preview → approve+queue → send ---
+
+/** Create a draft campaign carrying the hand-picked audience from the picker. */
+export async function createManualCampaignAction(input: {
+  name: string;
+  propertyId: string;
+  guestIds: string[];
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  if (!input.name?.trim()) return { success: false, error: 'Campaign name is required' };
+  if (!input.guestIds?.length) return { success: false, error: 'Select at least one guest' };
+  try {
+    const id = await createManualCampaign({
+      name: input.name.trim(),
+      propertyId: input.propertyId,
+      audienceGuestIds: input.guestIds,
+    });
+    revalidatePath('/admin/campaigns');
+    return { success: true, id };
+  } catch (error) {
+    logger.error('createManualCampaignAction failed', error as Error);
+    return { success: false, error: 'Failed to create campaign' };
+  }
+}
+
+/** Gate 1 preview: render the owner's variants into per-guest messages (no writes). */
+export async function previewCampaignMessagesAction(
+  campaignId: string,
+  variants: MessageVariant[]
+): Promise<{ success: boolean; rendered?: RenderedMessage[]; skipped?: SkippedRender[]; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const campaign = await getCampaign(campaignId);
+    if (!campaign) return { success: false, error: 'Campaign not found' };
+    const { rendered, skipped } = await renderMessages({
+      propertyId: campaign.propertyId,
+      guestIds: campaign.audienceGuestIds ?? [],
+      variants,
+    });
+    return { success: true, rendered, skipped };
+  } catch (error) {
+    logger.error('previewCampaignMessagesAction failed', error as Error);
+    return { success: false, error: 'Failed to preview messages' };
+  }
+}
+
+/** Gate 1 approve: queue every rendered message through the gateway → outbox. */
+export async function approveAndQueueAction(
+  campaignId: string,
+  variants: MessageVariant[]
+): Promise<{ success: boolean; queued?: number; skipped?: SkippedRender[]; error?: string }> {
+  let approver: string;
+  try {
+    const user = await requireSuperAdmin();
+    approver = user.email || user.uid;
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const campaign = await getCampaign(campaignId);
+    if (!campaign) return { success: false, error: 'Campaign not found' };
+    const res = await queueMessages({
+      campaignId,
+      propertyId: campaign.propertyId,
+      guestIds: campaign.audienceGuestIds ?? [],
+      variants,
+    });
+    await markCampaignQueued(campaignId, { approvedBy: approver, variants });
+    revalidatePath(`/admin/campaigns/${campaignId}`);
+    return { success: true, queued: res.queued, skipped: res.skipped };
+  } catch (error) {
+    logger.error('approveAndQueueAction failed', error as Error);
+    return { success: false, error: 'Failed to queue messages' };
+  }
+}
+
+/** Gate 2: the outbox send-list for a campaign. */
+export async function fetchCampaignOutboxAction(
+  campaignId: string
+): Promise<{ success: boolean; rows?: OutboxMessage[]; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const rows = await fetchOutboxForCampaign(campaignId);
+    return { success: true, rows };
+  } catch (error) {
+    logger.error('fetchCampaignOutboxAction failed', error as Error);
+    return { success: false, error: 'Failed to load outbox' };
+  }
+}
+
+/** Gate 2: mark one outbox message sent (records final text, advances frequency cap). */
+export async function markSentAction(
+  outboxId: string,
+  finalText?: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const res = await markOutboxSent(outboxId, { finalText: finalText ?? null });
+    if (!res.success) return { success: false, error: res.reason ?? 'Failed to mark sent' };
+    return { success: true };
+  } catch (error) {
+    logger.error('markSentAction failed', error as Error);
+    return { success: false, error: 'Failed to mark sent' };
+  }
+}
+
+/** Gate 2: mark the whole campaign finished once the owner has sent everything. */
+export async function markCampaignSentAction(
+  campaignId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    await markCampaignSent(campaignId);
+    revalidatePath(`/admin/campaigns/${campaignId}`);
+    return { success: true };
+  } catch (error) {
+    logger.error('markCampaignSentAction failed', error as Error);
+    return { success: false, error: 'Failed to update campaign' };
   }
 }

--- a/src/app/admin/campaigns/new/page.tsx
+++ b/src/app/admin/campaigns/new/page.tsx
@@ -36,6 +36,7 @@ export default async function NewCampaignPage({
               candidates={res.candidates}
               eligibleCount={res.eligibleCount ?? 0}
               perRunCap={res.perRunCap ?? 20}
+              propertyId={property}
             />
           ) : (
             <p className="text-sm text-destructive">{res.error || 'Failed to load audience.'}</p>

--- a/src/app/admin/campaigns/page.tsx
+++ b/src/app/admin/campaigns/page.tsx
@@ -1,7 +1,9 @@
+import Link from 'next/link';
 import { AdminPage, EmptyState } from '@/components/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
-import { Megaphone } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Megaphone, Plus } from 'lucide-react';
 import { fetchCampaigns } from './actions';
 import { CampaignTable } from './_components/campaign-table';
 import { CampaignComposer } from './_components/campaign-composer';
@@ -22,29 +24,47 @@ export default async function CampaignsPage({
   return (
     <AdminPage
       title="Campaigns"
-      description="Reactivate past guests over WhatsApp. Dark-launched — every run is a dry-run (records intent, sends nothing) until the engine is switched on."
+      description="Reach past guests over WhatsApp. Pick an audience, write the message, review each one, then send from your own number — one tap per guest."
+      actions={
+        <Link href={`/admin/campaigns/new?propertyId=${property}`}>
+          <Button>
+            <Plus className="mr-1 h-4 w-4" /> New campaign
+          </Button>
+        </Link>
+      }
     >
       <PropertyUrlSync />
-      <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Your campaigns</CardTitle>
-            <CardDescription>Create, preview the audience, approve, then run (dry-run).</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {campaigns.length > 0 ? (
-              <CampaignTable campaigns={campaigns} />
-            ) : (
-              <EmptyState
-                icon={Megaphone}
-                title="No campaigns yet"
-                description="Compose your first reactivation campaign on the right."
-              />
-            )}
-          </CardContent>
-        </Card>
-        <CampaignComposer propertyId={property} />
-      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your campaigns</CardTitle>
+          <CardDescription>
+            Open a draft to compose &amp; review; open a queued one to send.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {campaigns.length > 0 ? (
+            <CampaignTable campaigns={campaigns} />
+          ) : (
+            <EmptyState
+              icon={Megaphone}
+              title="No campaigns yet"
+              description="Start with “New campaign” to pick your audience."
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Automated segment path — dark-launched (dry-run only), kept for the future
+          engine and tucked away so it doesn't clutter the manual flow. */}
+      <details className="rounded-lg border bg-muted/30 px-4 py-3">
+        <summary className="cursor-pointer text-sm font-medium text-muted-foreground">
+          Advanced: automated segment campaign (dark-launch — dry-run only)
+        </summary>
+        <div className="mt-4 max-w-md">
+          <CampaignComposer propertyId={property} />
+        </div>
+      </details>
     </AdminPage>
   );
 }

--- a/src/app/api/automation/route.ts
+++ b/src/app/api/automation/route.ts
@@ -27,6 +27,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
 import { formatBucharestDate, getBucharestDay, getBucharestMonth } from '@/lib/dates/property-times';
+import { markOutboxSent } from '@/services/outboxService';
 
 const logger = loggers.adminBookings;
 
@@ -564,46 +565,16 @@ async function outboxNext(propertyId: string): Promise<NextResponse> {
 
 /** Mark a claimed outbox message as sent; capture the final text; close the loop. */
 async function outboxSent(req: NextRequest, propertyId: string): Promise<NextResponse> {
-  const db = await getAdminDb();
   const id = req.nextUrl.searchParams.get('id');
   if (!id) return new NextResponse('Missing id', { status: 400 });
   const finalText = req.nextUrl.searchParams.get('finalText');
 
-  const ref = db.collection('outbox').doc(id);
-  const doc = await ref.get();
-  if (!doc.exists) return new NextResponse('Not found', { status: 404 });
-  const row = doc.data() as OutboxRow;
-  if (row.propertyId && row.propertyId !== propertyId) {
-    return new NextResponse('Wrong property', { status: 400 });
+  const res = await markOutboxSent(id, { finalText, expectedPropertyId: propertyId });
+  if (!res.success) {
+    if (res.reason === 'not-found') return new NextResponse('Not found', { status: 404 });
+    if (res.reason === 'wrong-property') return new NextResponse('Wrong property', { status: 400 });
+    return new NextResponse('Failed', { status: 500 });
   }
-  if (row.status === 'sent') return NextResponse.json({ status: 'ok' }); // idempotent
-
-  const sentText = finalText ?? row.body ?? null;
-  await ref.update({ status: 'sent', sentAt: FieldValue.serverTimestamp(), finalText: sentText });
-
-  // Flip the linked gateway claim 'queued' → 'sent' and capture the final text.
-  if (row.messageLogId) {
-    try {
-      await db.collection('messageLog').doc(row.messageLogId).update({
-        status: 'sent',
-        finalText: sentText,
-        at: FieldValue.serverTimestamp(),
-      });
-    } catch {
-      logger.warn('outbox_sent: messageLog update failed (non-blocking)', { id, messageLogId: row.messageLogId });
-    }
-  }
-
-  // The real send just happened → set lastCampaignAt so the frequency cap counts
-  // actual contact (queuing deliberately did not touch it).
-  if (row.guestId) {
-    try {
-      await db.collection('guests').doc(row.guestId).update({ lastCampaignAt: FieldValue.serverTimestamp() });
-    } catch {
-      logger.warn('outbox_sent: lastCampaignAt update failed (non-blocking)', { guestId: row.guestId });
-    }
-  }
-
   return NextResponse.json({ status: 'ok' });
 }
 

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -87,6 +87,11 @@ const navigationGroups = [
       { title: 'Revenue', href: '/admin/revenue', icon: DollarSign },
       { title: 'Attribution', href: '/admin/attribution', icon: BarChart3 },
       { title: 'Coupons', href: '/admin/coupons', icon: Ticket },
+    ],
+  },
+  {
+    label: 'Growth',
+    items: [
       { title: 'Campaigns', href: '/admin/campaigns', icon: Megaphone },
       { title: 'Ads', href: '/admin/ads', icon: Target },
     ],

--- a/src/services/__tests__/campaignMessaging.test.ts
+++ b/src/services/__tests__/campaignMessaging.test.ts
@@ -1,0 +1,120 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({ getAdminDb: jest.fn().mockResolvedValue({}), FieldValue: { serverTimestamp: jest.fn() } }));
+jest.mock('@/services/guestService', () => ({ getGuestById: jest.fn() }));
+jest.mock('@/services/executionGateway', () => ({
+  executeSend: jest.fn(),
+  getPropertyContext: jest.fn().mockResolvedValue({ name: 'Prahova Mountain Chalet', link: 'https://prahova-chalet.ro/calendar/tok' }),
+}));
+
+import { renderMessages, queueMessages, fillTemplate } from '../campaignMessaging';
+import { getGuestById } from '@/services/guestService';
+import { executeSend } from '@/services/executionGateway';
+import type { Guest } from '@/types';
+
+const mockGetGuest = getGuestById as jest.Mock;
+const mockExecuteSend = executeSend as jest.Mock;
+
+function guest(id: string, o: Partial<Guest> = {}): Guest {
+  return {
+    id, firstName: 'Ana', language: 'ro', normalizedPhone: '+40712345678',
+    unsubscribed: false, bookingIds: [], propertyIds: ['prahova'],
+    totalBookings: 1, totalSpent: 0, reviewSubmitted: false, tags: [], ...o,
+  } as Guest;
+}
+
+beforeEach(() => { mockGetGuest.mockReset(); mockExecuteSend.mockReset(); });
+
+describe('fillTemplate', () => {
+  it('replaces name/property/link and leaves unknown placeholders untouched', () => {
+    expect(fillTemplate('Salut {name}! {property} {link} {x}', { name: 'Ana', property: 'Chalet', link: 'URL' }))
+      .toBe('Salut Ana! Chalet URL {x}');
+  });
+});
+
+describe('renderMessages', () => {
+  it('rotates variants within a language, fills tokens, appends the opt-out line', async () => {
+    const guests: Record<string, Guest> = {
+      g1: guest('g1', { firstName: 'Ana', language: 'ro' }),
+      g2: guest('g2', { firstName: 'Ion', language: 'ro' }),
+      g3: guest('g3', { firstName: 'John', language: 'en' }),
+    };
+    mockGetGuest.mockImplementation(async (id: string) => guests[id] ?? null);
+
+    const { rendered, skipped } = await renderMessages({
+      propertyId: 'prahova',
+      guestIds: ['g1', 'g2', 'g3'],
+      variants: [
+        { language: 'ro', body: 'Salut {name}! Ai fost la {property}.' },
+        { language: 'ro', body: 'Bună {name}! Te așteptăm la {property}.' },
+        { language: 'en', body: 'Hi {name}! Come back to {property}: {link}' },
+      ],
+    });
+
+    expect(skipped).toHaveLength(0);
+    const byId = Object.fromEntries(rendered.map((m) => [m.guestId, m]));
+    expect(byId.g1.variantIndex).toBe(0); // g1,g2 rotate the two RO variants (sorted by id)
+    expect(byId.g2.variantIndex).toBe(1);
+    expect(byId.g1.body).toContain('Salut Ana!');
+    expect(byId.g1.body).toContain('Prahova Mountain Chalet');
+    expect(byId.g2.body).toContain('Bună Ion!');
+    expect(byId.g3.body).toContain('Hi John!');
+    expect(byId.g3.body).toContain('https://prahova-chalet.ro/calendar/tok');
+    expect(byId.g1.body.endsWith('Răspundeți STOP dacă nu mai doriți mesaje.')).toBe(true);
+    expect(byId.g3.body.endsWith('Reply STOP to opt out.')).toBe(true);
+  });
+
+  it('skips guests with no phone / not found / no variant for their language', async () => {
+    const guests: Record<string, Guest | null> = {
+      ok: guest('ok', { language: 'ro' }),
+      nophone: guest('nophone', { language: 'ro', normalizedPhone: undefined, phone: undefined }),
+      missing: null,
+      envariantless: guest('envariantless', { language: 'en' }),
+    };
+    mockGetGuest.mockImplementation(async (id: string) => guests[id] ?? null);
+
+    const { rendered, skipped } = await renderMessages({
+      propertyId: 'prahova',
+      guestIds: ['ok', 'nophone', 'missing', 'envariantless'],
+      variants: [{ language: 'ro', body: 'Salut {name}!' }], // RO only
+    });
+
+    expect(rendered.map((m) => m.guestId)).toEqual(['ok']);
+    expect(Object.fromEntries(skipped.map((s) => [s.guestId, s.reason]))).toEqual({
+      nophone: 'no-phone', missing: 'guest-not-found', envariantless: 'no-variant-for-language',
+    });
+  });
+});
+
+describe('queueMessages', () => {
+  it('sends each rendered message through executeSend(manual_queue) and tallies queued', async () => {
+    mockGetGuest.mockImplementation(async (id: string) => guest(id, { language: 'ro', firstName: id }));
+    mockExecuteSend.mockResolvedValue({ status: 'queued', mode: 'live' });
+
+    const res = await queueMessages({
+      campaignId: 'c1', propertyId: 'prahova', guestIds: ['g1', 'g2'],
+      variants: [{ language: 'ro', body: 'Salut {name}!' }],
+    });
+
+    expect(res.queued).toBe(2);
+    expect(mockExecuteSend).toHaveBeenCalledTimes(2);
+    expect(mockExecuteSend).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'whatsapp', deliveryMode: 'manual_queue', campaignId: 'c1', templateName: 'manual', propertyId: 'prahova',
+    }));
+    expect(mockExecuteSend.mock.calls[0][0].body).toContain('Salut');
+  });
+
+  it('counts a gateway skip (e.g. frequency-cap) as not queued', async () => {
+    mockGetGuest.mockImplementation(async (id: string) => guest(id, { language: 'ro' }));
+    mockExecuteSend.mockImplementation(async (req: { guestId: string }) =>
+      req.guestId === 'g1' ? { status: 'queued', mode: 'live' } : { status: 'skipped', reason: 'frequency-cap', mode: 'live' });
+
+    const res = await queueMessages({
+      campaignId: 'c1', propertyId: 'prahova', guestIds: ['g1', 'g2'],
+      variants: [{ language: 'ro', body: 'Salut {name}!' }],
+    });
+
+    expect(res.queued).toBe(1);
+    expect(res.results.find((r) => r.guestId === 'g2')).toMatchObject({ status: 'skipped', reason: 'frequency-cap' });
+  });
+});

--- a/src/services/__tests__/outboxService.test.ts
+++ b/src/services/__tests__/outboxService.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+
+// outboxService is the shared "mark sent" + "list for campaign" logic behind both
+// the /api/automation Shortcut path and the admin Gate-2 send screen. These tests
+// exercise it directly (the route test covers the same ops through the HTTP layer).
+
+jest.mock('@/lib/firebaseAdminSafe', () => ({
+  getAdminDb: jest.fn(),
+  FieldValue: { serverTimestamp: jest.fn(() => 'ts') },
+}));
+jest.mock('@/lib/logger', () => ({
+  loggers: { campaign: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } },
+}));
+jest.mock('@/lib/utils', () => ({
+  convertTimestampsToISOStrings: (o: unknown) => o, // identity — timestamps are already strings in seed
+}));
+
+import { markOutboxSent, fetchOutboxForCampaign } from '../outboxService';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+const mockGetAdminDb = getAdminDb as jest.Mock;
+
+function makeDb(seed: Record<string, Record<string, unknown>> = {}) {
+  const outbox = new Map<string, Record<string, unknown>>(Object.entries(seed));
+  const guestUpdates: { id: string; patch: Record<string, unknown> }[] = [];
+  const messageLogUpdates: { id: string; patch: Record<string, unknown> }[] = [];
+
+  const outboxDocRef = (id: string) => ({
+    id,
+    get: async () => ({ exists: outbox.has(id), data: () => outbox.get(id) }),
+    update: async (patch: Record<string, unknown>) => { outbox.set(id, { ...(outbox.get(id) || {}), ...patch }); },
+  });
+
+  const db = {
+    collection: (name: string) => {
+      if (name === 'outbox') {
+        return {
+          doc: (id: string) => outboxDocRef(id),
+          where: (field: string, _op: string, val: unknown) => ({
+            get: async () => ({
+              docs: [...outbox.entries()]
+                .filter(([, d]) => d[field] === val)
+                .map(([id, d]) => ({ id, data: () => d })),
+            }),
+          }),
+        };
+      }
+      if (name === 'messageLog') return { doc: (id: string) => ({ update: async (patch: Record<string, unknown>) => { messageLogUpdates.push({ id, patch }); } }) };
+      if (name === 'guests') return { doc: (id: string) => ({ update: async (patch: Record<string, unknown>) => { guestUpdates.push({ id, patch }); } }) };
+      return { doc: () => ({ get: async () => ({ exists: false }) }) };
+    },
+  };
+  return { db, outbox, guestUpdates, messageLogUpdates };
+}
+
+describe('outboxService.markOutboxSent', () => {
+  it('marks sent, records the final text, and closes the loop (messageLog + lastCampaignAt)', async () => {
+    const { db, outbox, messageLogUpdates, guestUpdates } = makeDb({
+      o1: { propertyId: 'prahova', status: 'approved_pending_send', guestId: 'g1', body: 'orig', messageLogId: 'ml1' },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+
+    const res = await markOutboxSent('o1', { finalText: 'edited' });
+
+    expect(res).toEqual({ success: true });
+    expect(outbox.get('o1')?.status).toBe('sent');
+    expect(outbox.get('o1')?.finalText).toBe('edited');
+    expect(messageLogUpdates).toEqual([{ id: 'ml1', patch: expect.objectContaining({ status: 'sent', finalText: 'edited' }) }]);
+    expect(guestUpdates).toEqual([{ id: 'g1', patch: expect.objectContaining({ lastCampaignAt: 'ts' }) }]);
+  });
+
+  it('falls back to the stored body when no finalText is given', async () => {
+    const { db, outbox } = makeDb({ o1: { propertyId: 'prahova', status: 'approved_pending_send', guestId: 'g1', body: 'orig' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    await markOutboxSent('o1');
+    expect(outbox.get('o1')?.finalText).toBe('orig');
+  });
+
+  it('is idempotent when already sent (no guest re-touch)', async () => {
+    const { db, guestUpdates } = makeDb({ o1: { propertyId: 'prahova', status: 'sent', guestId: 'g1' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    const res = await markOutboxSent('o1', { finalText: 'x' });
+    expect(res).toEqual({ success: true });
+    expect(guestUpdates).toHaveLength(0);
+  });
+
+  it('returns not-found for a missing row', async () => {
+    const { db } = makeDb({});
+    mockGetAdminDb.mockResolvedValue(db);
+    expect(await markOutboxSent('nope')).toEqual({ success: false, reason: 'not-found' });
+  });
+
+  it('rejects a row from another property when expectedPropertyId is set', async () => {
+    const { db } = makeDb({ o1: { propertyId: 'coltei', status: 'approved_pending_send', guestId: 'g1' } });
+    mockGetAdminDb.mockResolvedValue(db);
+    expect(await markOutboxSent('o1', { expectedPropertyId: 'prahova' })).toEqual({ success: false, reason: 'wrong-property' });
+  });
+});
+
+describe('outboxService.fetchOutboxForCampaign', () => {
+  it('returns only the campaign rows, oldest first', async () => {
+    const { db } = makeDb({
+      o2: { campaignId: 'c1', createdAt: '2026-07-02', body: 'b' },
+      o1: { campaignId: 'c1', createdAt: '2026-07-01', body: 'a' },
+      x9: { campaignId: 'other', createdAt: '2026-07-03', body: 'z' },
+    });
+    mockGetAdminDb.mockResolvedValue(db);
+    const rows = await fetchOutboxForCampaign('c1');
+    expect(rows.map((r) => r.id)).toEqual(['o1', 'o2']);
+  });
+});

--- a/src/services/campaignMessaging.ts
+++ b/src/services/campaignMessaging.ts
@@ -13,7 +13,7 @@
  */
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
-import type { Guest, LanguageCode } from '@/types';
+import type { Guest, LanguageCode, MessageVariant } from '@/types';
 import { getGuestById } from '@/services/guestService';
 import { resolveGuestLanguage } from '@/lib/growth/language';
 import { normalizePhone } from '@/lib/sanitize';
@@ -24,10 +24,7 @@ const logger = loggers.campaign;
 // A stable template name so a re-queue of the same campaign+guest dedups.
 export const MANUAL_QUEUE_TEMPLATE = 'manual';
 
-export interface MessageVariant {
-  language: LanguageCode;
-  body: string; // may contain {name} / {property} / {link}
-}
+export type { MessageVariant };
 
 export interface RenderedMessage {
   guestId: string;

--- a/src/services/campaignMessaging.ts
+++ b/src/services/campaignMessaging.ts
@@ -1,0 +1,165 @@
+/**
+ * campaignMessaging — render owner-written copy into per-guest messages and queue
+ * them through the Execution Gateway (manual_queue → outbox).
+ *
+ * v1 has no LLM drafter: the owner writes 2–3 short variants per language, with
+ * {name} / {property} / {link} placeholders. The renderer fills each guest's real
+ * tokens, ROTATES variants within a language (byte-variation for WhatsApp
+ * ban-safety), and appends the STOP opt-out line. Every message then goes through
+ * `executeSend` so the guardrails (consent, suppression, dedup, future-booking,
+ * frequency-cap) run before anything reaches the outbox.
+ *
+ * Plain server module (NOT 'use server') — exports types + async functions.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { Guest, LanguageCode } from '@/types';
+import { getGuestById } from '@/services/guestService';
+import { resolveGuestLanguage } from '@/lib/growth/language';
+import { normalizePhone } from '@/lib/sanitize';
+import { executeSend, getPropertyContext } from '@/services/executionGateway';
+
+const logger = loggers.campaign;
+
+// A stable template name so a re-queue of the same campaign+guest dedups.
+export const MANUAL_QUEUE_TEMPLATE = 'manual';
+
+export interface MessageVariant {
+  language: LanguageCode;
+  body: string; // may contain {name} / {property} / {link}
+}
+
+export interface RenderedMessage {
+  guestId: string;
+  name: string;
+  phone: string; // E.164
+  language: LanguageCode;
+  body: string; // fully rendered, incl. opt-out line
+  variantIndex: number;
+}
+
+export type SkipReason = 'guest-not-found' | 'no-phone' | 'no-variant-for-language';
+export interface SkippedRender {
+  guestId: string;
+  name?: string;
+  reason: SkipReason;
+}
+
+/** Opt-out line appended to every message. STOP is what /api/whatsapp/inbound honors. */
+const OPT_OUT: Record<LanguageCode, string> = {
+  ro: 'Răspundeți STOP dacă nu mai doriți mesaje.',
+  en: 'Reply STOP to opt out.',
+};
+
+/** Fill {name} / {property} / {link}. Unknown placeholders are left untouched. */
+export function fillTemplate(body: string, tokens: { name: string; property: string; link: string }): string {
+  return body
+    .replace(/\{name\}/g, tokens.name)
+    .replace(/\{property\}/g, tokens.property)
+    .replace(/\{link\}/g, tokens.link);
+}
+
+interface RenderInput {
+  propertyId: string;
+  guestIds: string[];
+  variants: MessageVariant[];
+}
+
+/**
+ * Render (no writes) — produces the per-guest messages for Gate 1 preview and,
+ * deterministically, the same bodies the queue step will send. Skips (with a
+ * reason) any guest missing a phone or a variant for their language.
+ */
+export async function renderMessages(input: RenderInput): Promise<{ rendered: RenderedMessage[]; skipped: SkippedRender[] }> {
+  const db = await getAdminDb();
+  const ctx = await getPropertyContext(db, input.propertyId);
+  const propertyName = ctx.name;
+  const link = ctx.link ?? '';
+
+  const variantsByLang: Record<string, MessageVariant[]> = {};
+  for (const v of input.variants) {
+    if (!v.body?.trim()) continue;
+    (variantsByLang[v.language] ??= []).push(v);
+  }
+
+  const rendered: RenderedMessage[] = [];
+  const skipped: SkippedRender[] = [];
+
+  // Resolve each guest first, then group by language so variant rotation is
+  // stable and evenly distributed within a language.
+  const resolved: Array<{ guest: Guest; lang: LanguageCode; phone: string | null }> = [];
+  for (const id of input.guestIds) {
+    const g = await getGuestById(id);
+    if (!g) {
+      skipped.push({ guestId: id, reason: 'guest-not-found' });
+      continue;
+    }
+    const phone = g.normalizedPhone || (g.phone ? normalizePhone(g.phone) : null);
+    resolved.push({ guest: g, lang: resolveGuestLanguage(g), phone });
+  }
+
+  const byLang: Record<string, typeof resolved> = {};
+  for (const r of resolved) (byLang[r.lang] ??= []).push(r);
+
+  for (const [lang, list] of Object.entries(byLang)) {
+    list.sort((a, b) => a.guest.id.localeCompare(b.guest.id)); // deterministic rotation order
+    const variants = variantsByLang[lang] ?? [];
+    list.forEach((r, i) => {
+      const name = (r.guest.firstName || '').trim();
+      if (!r.phone) {
+        skipped.push({ guestId: r.guest.id, name, reason: 'no-phone' });
+        return;
+      }
+      if (variants.length === 0) {
+        skipped.push({ guestId: r.guest.id, name, reason: 'no-variant-for-language' });
+        return;
+      }
+      const variantIndex = i % variants.length;
+      const filled = fillTemplate(variants[variantIndex].body, { name, property: propertyName, link });
+      const body = `${filled.trim()}\n\n${OPT_OUT[lang as LanguageCode] ?? OPT_OUT.en}`;
+      rendered.push({ guestId: r.guest.id, name, phone: r.phone, language: lang as LanguageCode, body, variantIndex });
+    });
+  }
+
+  return { rendered, skipped };
+}
+
+export interface QueueResult {
+  queued: number;
+  results: Array<{ guestId: string; status: string; reason?: string }>;
+  skipped: SkippedRender[];
+}
+
+/**
+ * Render + queue: every rendered message goes through `executeSend` with
+ * `deliveryMode: 'manual_queue'`, so all guardrails run and (in live mode) an
+ * outbox row is written. Returns the per-guest outcome.
+ */
+export async function queueMessages(input: RenderInput & { campaignId: string }): Promise<QueueResult> {
+  const { rendered, skipped } = await renderMessages(input);
+  const results: QueueResult['results'] = [];
+  let queued = 0;
+
+  for (const m of rendered) {
+    const res = await executeSend({
+      guestId: m.guestId,
+      propertyId: input.propertyId,
+      channel: 'whatsapp',
+      templateName: MANUAL_QUEUE_TEMPLATE,
+      campaignId: input.campaignId,
+      deliveryMode: 'manual_queue',
+      body: m.body,
+    });
+    if (res.status === 'queued') queued++;
+    results.push({ guestId: m.guestId, status: res.status, reason: res.reason });
+  }
+
+  logger.info('queueMessages complete', {
+    campaignId: input.campaignId,
+    propertyId: input.propertyId,
+    rendered: rendered.length,
+    queued,
+    skipped: skipped.length,
+  });
+  return { queued, results, skipped };
+}

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -12,7 +12,7 @@
  */
 import { getAdminDb, FieldValue, Timestamp } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
-import type { Campaign, CampaignStats, CampaignStatus, SegmentDefinition, ChannelType } from '@/types';
+import type { Campaign, CampaignStats, CampaignStatus, SegmentDefinition, ChannelType, MessageVariant } from '@/types';
 import { evaluateSegment, previewAudience, type AudiencePreview } from '@/services/segmentService';
 import { executeSend } from '@/services/executionGateway';
 import { getSendMode, GROWTH_ENGINE_LIMITS } from '@/config/growth-engine';
@@ -75,6 +75,63 @@ export async function createCampaign(input: CreateCampaignInput): Promise<string
   });
   logger.info('Campaign created', { campaignId: ref.id, name: input.name, status });
   return ref.id;
+}
+
+/**
+ * Create a draft campaign for the manual message step, carrying a hand-picked
+ * audience (explicit guest ids). `segmentDefinition` is a minimal placeholder —
+ * the audience is `audienceGuestIds`, not the segment.
+ */
+export async function createManualCampaign(input: {
+  name: string;
+  propertyId: string;
+  audienceGuestIds: string[];
+}): Promise<string> {
+  const db = await getAdminDb();
+  const ref = await db.collection('campaigns').add({
+    name: input.name,
+    propertyId: input.propertyId,
+    channel: 'whatsapp',
+    templateName: 'manual',
+    variables: {},
+    segmentDefinition: { propertyId: input.propertyId },
+    audienceGuestIds: input.audienceGuestIds,
+    messageVariants: [],
+    scheduleAt: null,
+    status: 'draft',
+    stats: emptyStats(),
+    approvedBy: null,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    sentAt: null,
+  });
+  logger.info('Manual campaign created', { campaignId: ref.id, audience: input.audienceGuestIds.length });
+  return ref.id;
+}
+
+/** Approve a manual campaign: store the copy, record the approver, move to sending. */
+export async function markCampaignQueued(
+  id: string,
+  input: { approvedBy: string; variants: MessageVariant[] }
+): Promise<void> {
+  const db = await getAdminDb();
+  await db.collection('campaigns').doc(id).update({
+    messageVariants: input.variants,
+    approvedBy: input.approvedBy,
+    status: 'sending',
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  logger.info('Manual campaign queued', { campaignId: id, variants: input.variants.length });
+}
+
+/** Mark a manual campaign fully sent (owner finished the send session). */
+export async function markCampaignSent(id: string): Promise<void> {
+  const db = await getAdminDb();
+  await db.collection('campaigns').doc(id).update({
+    status: 'sent',
+    sentAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
 }
 
 export async function getCampaign(id: string): Promise<Campaign | null> {

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -195,7 +195,7 @@ async function writeMessageLog(db: AdminDb, entry: MessageLogInput): Promise<str
   return ref.id;
 }
 
-interface PropertyContext {
+export interface PropertyContext {
   name: string;        // brand name for the {{property}} slot (H1)
   link?: string;       // the {{link}} slot — guest availability calendar
 }
@@ -214,7 +214,7 @@ interface PropertyContext {
  * blocks a send.
  */
 const propertyContextCache = new Map<string, PropertyContext>();
-async function getPropertyContext(db: AdminDb, propertyId: string): Promise<PropertyContext> {
+export async function getPropertyContext(db: AdminDb, propertyId: string): Promise<PropertyContext> {
   const cached = propertyContextCache.get(propertyId);
   if (cached) return cached;
 

--- a/src/services/outboxService.ts
+++ b/src/services/outboxService.ts
@@ -1,0 +1,81 @@
+/**
+ * outboxService — the manual-send queue's shared operations, used by BOTH the
+ * `/api/automation` endpoint (iPhone/Mac Shortcut path) and the admin Gate-2
+ * send screen, so "mark sent" behaves identically everywhere.
+ *
+ * Plain server module (NOT 'use server').
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { OutboxMessage } from '@/types';
+
+const logger = loggers.campaign;
+
+export interface MarkSentResult {
+  success: boolean;
+  reason?: 'not-found' | 'wrong-property';
+}
+
+/**
+ * Mark a queued outbox message as sent: record the final (possibly edited) text,
+ * flip the linked gateway claim `queued → sent`, and set the guest's
+ * `lastCampaignAt` — so the frequency cap counts the REAL send, not the queue.
+ * Idempotent (a second call on an already-sent row is a no-op success).
+ *
+ * `expectedPropertyId` (optional) scopes the operation — the API path passes it
+ * so a token for one property can't mark another property's message.
+ */
+export async function markOutboxSent(
+  outboxId: string,
+  opts?: { finalText?: string | null; expectedPropertyId?: string }
+): Promise<MarkSentResult> {
+  const db = await getAdminDb();
+  const ref = db.collection('outbox').doc(outboxId);
+  const doc = await ref.get();
+  if (!doc.exists) return { success: false, reason: 'not-found' };
+
+  const row = doc.data() as {
+    propertyId?: string;
+    guestId?: string;
+    body?: string;
+    status?: string;
+    messageLogId?: string | null;
+  };
+  if (opts?.expectedPropertyId && row.propertyId && row.propertyId !== opts.expectedPropertyId) {
+    return { success: false, reason: 'wrong-property' };
+  }
+  if (row.status === 'sent') return { success: true }; // idempotent
+
+  const sentText = opts?.finalText ?? row.body ?? null;
+  await ref.update({ status: 'sent', sentAt: FieldValue.serverTimestamp(), finalText: sentText });
+
+  if (row.messageLogId) {
+    try {
+      await db.collection('messageLog').doc(row.messageLogId).update({
+        status: 'sent',
+        finalText: sentText,
+        at: FieldValue.serverTimestamp(),
+      });
+    } catch {
+      logger.warn('markOutboxSent: messageLog update failed (non-blocking)', { outboxId, messageLogId: row.messageLogId });
+    }
+  }
+  if (row.guestId) {
+    try {
+      await db.collection('guests').doc(row.guestId).update({ lastCampaignAt: FieldValue.serverTimestamp() });
+    } catch {
+      logger.warn('markOutboxSent: lastCampaignAt update failed (non-blocking)', { guestId: row.guestId });
+    }
+  }
+  return { success: true };
+}
+
+/** All outbox rows for a campaign, oldest first, timestamps serialized for the client. */
+export async function fetchOutboxForCampaign(campaignId: string): Promise<OutboxMessage[]> {
+  const db = await getAdminDb();
+  const snap = await db.collection('outbox').where('campaignId', '==', campaignId).get();
+  const { convertTimestampsToISOStrings } = await import('@/lib/utils');
+  const rows = snap.docs.map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as OutboxMessage);
+  rows.sort((a, b) => String(a.createdAt ?? '').localeCompare(String(b.createdAt ?? '')));
+  return rows;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -442,6 +442,12 @@ export interface CampaignStats {
   failed: number;
 }
 
+/** An owner-written message variant for the manual message step (per language). */
+export interface MessageVariant {
+  language: LanguageCode;
+  body: string; // may contain {name} / {property} / {link}
+}
+
 export interface Campaign {
   id: string;
   name: string;
@@ -451,6 +457,8 @@ export interface Campaign {
   variables?: Record<string, string>;   // default template variables
   segmentId?: string;                    // reference to a saved segment (optional)
   segmentDefinition: SegmentDefinition;  // inline snapshot always present
+  audienceGuestIds?: string[];           // hand-picked audience (manual message-step campaigns)
+  messageVariants?: MessageVariant[];    // owner-written copy variants (set at approve)
   scheduleAt?: SerializableTimestamp | null;
   status: CampaignStatus;
   stats?: CampaignStats;


### PR DESCRIPTION
## What

The **message step** on top of the audience picker — the owner-driven flow to actually reach past guests over WhatsApp, ban-safely:

**pick guests → write copy → review the real messages → approve to queue → send each one by hand.**

The server never touches WhatsApp. Sending is one-tap `wa.me` (official click-to-chat, pre-fills text, no auto-send) from the owner's own number — that's what keeps the number ban-safe.

## Flow (Admin)

1. `/admin/campaigns` → **New campaign** → `/admin/campaigns/new` (audience picker)
2. Pick eligible guests, name it, **Continue** → creates a draft, opens the workspace
3. `/admin/campaigns/[id]` **Gate 1 (draft):** write 2–3 short variants per language (`{name}`/`{property}`/`{link}` tokens, STOP line auto-appended), **Preview** the exact rendered messages, **Approve & queue**
4. Same route **Gate 2 (sending):** per-message **Open WhatsApp** + **Mark sent** (text editable until sent), progress bar, **Mark campaign complete**

## Backend

- **`campaignService`**: `createManualCampaign`, `markCampaignQueued` (records the **real** super-admin approver + copy), `markCampaignSent`
- **`outboxService`** (new): `markOutboxSent` + `fetchOutboxForCampaign` — shared by the admin Gate-2 screen **and** the `/api/automation` Shortcut path so "mark sent" behaves identically (records final text, flips the gateway claim, advances the guest's frequency cap). `/api/automation/outbox_sent` refactored to delegate to it.
- **6 server actions**, all `requireSuperAdmin`; approve captures the actual admin email instead of a hardcoded `'super-admin'`.
- **types**: `MessageVariant` + `Campaign.audienceGuestIds` / `messageVariants`.

Every queued message still routes through the Execution Gateway (`deliveryMode: 'manual_queue'`), so consent / suppression / dedup / future-booking / frequency-cap guardrails run before anything reaches the outbox.

## IA

- Campaigns list: primary **New campaign** CTA; manual campaigns route to the workspace, while the automated segment/dry-run path is tucked into a disclosure.
- Nav: **Campaigns + Ads** moved into a new **Growth** group.

## Tests

- `outboxService` (6) + existing `/api/automation` route (11, still green after the refactor) + `campaignMessaging` (5) — **22 passing**
- `npm run build` passes; new routes register as dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)