### PR TITLE
fix: manual send flow usable while dark-launched (decouple manual_queue from SEND_MODE)

### DIFF
--- a/scripts/seed-test-guest.ts
+++ b/scripts/seed-test-guest.ts
@@ -1,0 +1,91 @@
+// Seed (or delete) a single self-test guest so you appear in the campaign
+// audience picker and can run the message step end-to-end with your own number.
+//
+// It writes ONE clearly-marked guest doc (isTestGuest: true) and touches NO
+// bookings. The doc id is deterministic (`selftest-<digits>`) so re-runs are
+// idempotent and cleanup is a one-liner.
+//
+// Usage:
+//   npx tsx scripts/seed-test-guest.ts <phoneE164> [--name="Your Name"] [--lang=ro|en] [--property=<slug>]
+//   npx tsx scripts/seed-test-guest.ts <phoneE164> --delete
+//
+// Examples:
+//   npx tsx scripts/seed-test-guest.ts +40712345678 --name="Bogdan" --lang=ro
+//   npx tsx scripts/seed-test-guest.ts +40712345678 --delete
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import * as admin from 'firebase-admin';
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+const serviceAccountPath = process.env.FIREBASE_ADMIN_SERVICE_ACCOUNT_PATH;
+if (!serviceAccountPath) {
+  console.error('FIREBASE_ADMIN_SERVICE_ACCOUNT_PATH not set in .env.local');
+  process.exit(1);
+}
+
+admin.initializeApp({ credential: admin.credential.cert(path.resolve(serviceAccountPath)) });
+const db = admin.firestore();
+
+function argValue(flag: string): string | undefined {
+  const hit = process.argv.slice(2).find((a) => a.startsWith(`${flag}=`));
+  return hit ? hit.slice(flag.length + 1).replace(/^["']|["']$/g, '') : undefined;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const phoneRaw = args.find((a) => !a.startsWith('--'));
+  if (!phoneRaw) {
+    console.error('Provide your phone in E.164, e.g. +40712345678');
+    process.exit(1);
+  }
+  // Normalize to +<digits> (must match what wa.me will dial).
+  const digits = phoneRaw.replace(/[^\d]/g, '');
+  const e164 = phoneRaw.trim().startsWith('+') ? `+${digits}` : `+${digits}`;
+  const docId = `selftest-${digits}`;
+  const ref = db.collection('guests').doc(docId);
+
+  if (args.includes('--delete')) {
+    await ref.delete();
+    console.log(`Deleted test guest ${docId}.`);
+    return;
+  }
+
+  const name = argValue('--name') || 'Self Test';
+  const lang = (argValue('--lang') || 'ro') === 'en' ? 'en' : 'ro';
+  const property = argValue('--property') || 'prahova-mountain-chalet';
+
+  await ref.set(
+    {
+      firstName: name,
+      lastName: '(self-test)',
+      phone: e164,
+      normalizedPhone: e164,
+      language: lang,
+      country: lang === 'ro' ? 'RO' : undefined,
+      propertyIds: [property],       // ← how the picker scopes guests to a property
+      totalBookings: 1,
+      totalSpent: 0,
+      lastStayDate: admin.firestore.Timestamp.fromDate(new Date('2025-08-15')),
+      isTestGuest: true,             // marker for easy identification / cleanup
+      // Deliberately absent → keeps the guest ELIGIBLE:
+      //   unsubscribed / channelConsent  → not opted out
+      //   bookingIds                     → no active future booking
+      //   lastCampaignAt                 → not frequency-capped
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  console.log(`✅ Seeded eligible test guest:`);
+  console.log(`   id        ${docId}`);
+  console.log(`   name      ${name} (self-test)`);
+  console.log(`   phone     ${e164}`);
+  console.log(`   language  ${lang}`);
+  console.log(`   property  ${property}`);
+  console.log(`\nIt will show up (eligible) in the picker at /admin/campaigns/new for that property.`);
+  console.log(`Clean up afterwards:  npx tsx scripts/seed-test-guest.ts ${e164} --delete`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/services/__tests__/executionGateway.test.ts
+++ b/src/services/__tests__/executionGateway.test.ts
@@ -443,7 +443,7 @@ describe('executeSend — manual_queue driver (outbox)', () => {
     expect(outboxWrites).toHaveLength(1); // queued exactly once
   });
 
-  it('records dry-run intent (no outbox write) when not live', async () => {
+  it('queues to the outbox even when NOT live — manual_queue is human-sent, exempt from the dark-launch guard', async () => {
     delete process.env.GROWTH_ENGINE_ENABLED;
     delete process.env.GROWTH_ENGINE_SEND_MODE;
     const { db, outboxWrites } = makeDb();
@@ -451,7 +451,12 @@ describe('executeSend — manual_queue driver (outbox)', () => {
     mockGetGuestById.mockResolvedValue(guest());
 
     const res = await executeSend({ guestId: 'g1', propertyId: 'prahova-mountain-chalet', channel: 'whatsapp', templateName: 'winter_invite', campaignId: 'c1', deliveryMode: 'manual_queue', body: 'hi' });
-    expect(res.status).toBe('dry-run');
-    expect(outboxWrites).toHaveLength(0);
+
+    // The safety property is preserved: nothing auto-sends — only a queued row the owner sends by hand.
+    expect(mockSendWhatsApp).not.toHaveBeenCalled();
+    expect(res.status).toBe('queued');
+    expect(res.mode).toBe('dry-run'); // honest: the engine isn't live, but the human-sent queue still populates
+    expect(outboxWrites).toHaveLength(1);
+    expect(outboxWrites[0]).toMatchObject({ campaignId: 'c1', guestId: 'g1', status: 'approved_pending_send' });
   });
 });

--- a/src/services/executionGateway.ts
+++ b/src/services/executionGateway.ts
@@ -364,7 +364,13 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
   }
 
   // 4) DARK LAUNCH: default dry-run — record intent, deliver nothing.
-  if (mode !== 'live') {
+  //
+  // EXCEPTION: manual_queue is human-sent — the owner taps wa.me by hand and
+  // nothing ever leaves the server automatically. The dark-launch guard exists to
+  // prevent *automated provider* delivery (Twilio), which manual_queue never does,
+  // so it is exempt and writes its outbox row in any mode. Automated provider
+  // sends remain gated behind GROWTH_ENGINE_ENABLED + SEND_MODE=live.
+  if (mode !== 'live' && req.deliveryMode !== 'manual_queue') {
     const id = await writeMessageLog(db, {
       ...base,
       status: 'dry-run',
@@ -381,7 +387,7 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
     return { status: 'dry-run', messageLogId: id, mode: 'dry-run' };
   }
 
-  // 5) LIVE delivery (only when both flags are flipped).
+  // 5) LIVE path: provider delivery (live only) + manual_queue (any mode).
   //
   // IDEMPOTENT CLAIM (campaign sends): before delivering, atomically claim the
   // deterministic messageLog doc ({campaignId}__{guestId}__{templateName}) in a
@@ -463,7 +469,7 @@ export async function executeSend(req: SendRequest): Promise<SendResult> {
       outboxId: outboxRef.id,
       to: maskContact(contact),
     });
-    return { status: 'queued', providerId: outboxRef.id, messageLogId: claimId ?? outboxRef.id, mode: 'live' };
+    return { status: 'queued', providerId: outboxRef.id, messageLogId: claimId ?? outboxRef.id, mode };
   }
 
   // Property-brand the message: inject `property` (name) and `link` (guest


### PR DESCRIPTION
## Why

The engine is dark-launched — `GROWTH_ENGINE_ENABLED` + `GROWTH_ENGINE_SEND_MODE=live` are both off in prod (dry-run). The `manual_queue` branch sat **after** the dark-launch dry-run early-return in `executeSend`, so **Approve & queue recorded a dry-run and wrote no outbox row** — the Gate-2 send list was empty and the manual flow was unusable in production.

## The distinction

The two-switch guard exists to stop the **server from auto-delivering** via Twilio. `manual_queue` never auto-delivers — the owner sends each message **by hand** via a `wa.me` one-tap; the server only writes an outbox row. Gating it behind `SEND_MODE=live` conflated "queue a message for manual sending" with "arm the automated Twilio blaster."

## Change

- `manual_queue` is now **exempt** from the dark-launch guard — it writes its outbox row in any mode.
- **Automated provider sends stay fully gated** behind both switches (unchanged).
- The safety property is preserved: **nothing leaves the server without a human** tapping wa.me + Mark sent.
- Bonus: a queued result now returns the honest `mode` instead of a hardcoded `'live'`.

```diff
- if (mode !== 'live') {
+ // manual_queue is human-sent (nothing leaves the server automatically), so it is
+ // exempt from the dark-launch guard; automated provider sends stay gated.
+ if (mode !== 'live' && req.deliveryMode !== 'manual_queue') {
```

## Also

`scripts/seed-test-guest.ts` — seed (or `--delete`) one clearly-marked, eligible self-test guest with your own number so you appear in the audience picker and can run the message step end-to-end. Touches **no bookings**.

## Tests

- Updated the gateway test that asserted the old behavior → now locks in "queues to the outbox even when NOT live" **and still asserts no provider call**.
- `executionGateway` + `campaignMessaging` + `outboxService` — **40 passing**; `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)