### PR TITLE
feat: campaign polish — property-specific link preview + compose safeguards

### DIFF
--- a/src/app/admin/campaigns/_components/message-composer.tsx
+++ b/src/app/admin/campaigns/_components/message-composer.tsx
@@ -16,10 +16,10 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Eye, Send, Plus, X, Users } from 'lucide-react';
+import { Loader2, Eye, Send, Plus, X, Users, Trash2 } from 'lucide-react';
 import type { MessageVariant, LanguageCode } from '@/types';
 import type { RenderedMessage, SkippedRender } from '@/services/campaignMessaging';
-import { previewCampaignMessagesAction, approveAndQueueAction } from '../actions';
+import { previewCampaignMessagesAction, approveAndQueueAction, discardDraftCampaignAction } from '../actions';
 
 const LANGS: { code: LanguageCode; label: string }[] = [
   { code: 'ro', label: 'Romanian' },
@@ -45,6 +45,8 @@ export function MessageComposer({
   const { toast } = useToast();
   const [previewing, startPreview] = useTransition();
   const [approving, startApprove] = useTransition();
+  const [discarding, startDiscard] = useTransition();
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
 
   // Group variants by language into editable text lists (default: one empty each).
   const [byLang, setByLang] = useState<Record<LanguageCode, string[]>>(() => {
@@ -56,13 +58,22 @@ export function MessageComposer({
 
   const [rendered, setRendered] = useState<RenderedMessage[] | null>(null);
   const [skipped, setSkipped] = useState<SkippedRender[]>([]);
+  // Any edit after a preview makes the preview stale — you must re-preview before
+  // approving, so "approve exactly what you saw" always holds.
+  const [dirty, setDirty] = useState(false);
 
-  const setVariant = (lang: LanguageCode, i: number, value: string) =>
+  const setVariant = (lang: LanguageCode, i: number, value: string) => {
     setByLang((prev) => ({ ...prev, [lang]: prev[lang].map((v, idx) => (idx === i ? value : v)) }));
-  const addVariant = (lang: LanguageCode) =>
+    setDirty(true);
+  };
+  const addVariant = (lang: LanguageCode) => {
     setByLang((prev) => ({ ...prev, [lang]: [...prev[lang], ''] }));
-  const removeVariant = (lang: LanguageCode, i: number) =>
+    setDirty(true);
+  };
+  const removeVariant = (lang: LanguageCode, i: number) => {
     setByLang((prev) => ({ ...prev, [lang]: prev[lang].filter((_, idx) => idx !== i) }));
+    setDirty(true);
+  };
 
   // Flatten to MessageVariant[], dropping blanks.
   const toVariants = (): MessageVariant[] =>
@@ -78,6 +89,7 @@ export function MessageComposer({
       if (res.success) {
         setRendered(res.rendered ?? []);
         setSkipped(res.skipped ?? []);
+        setDirty(false);
       } else {
         toast({ title: 'Preview failed', description: res.error, variant: 'destructive' });
       }
@@ -94,6 +106,17 @@ export function MessageComposer({
         router.refresh(); // status → sending: page swaps to the send list (Gate 2)
       } else {
         toast({ title: 'Could not queue', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  const discard = () =>
+    startDiscard(async () => {
+      const res = await discardDraftCampaignAction(campaignId);
+      if (res.success) {
+        router.push('/admin/campaigns');
+      } else {
+        toast({ title: 'Could not discard', description: res.error, variant: 'destructive' });
+        setConfirmDiscard(false);
       }
     });
 
@@ -154,14 +177,39 @@ export function MessageComposer({
               {previewing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Eye className="mr-1 h-4 w-4" />}
               Preview messages
             </Button>
-            <Button onClick={approve} disabled={!rendered || rendered.length === 0 || approving}>
+            <Button onClick={approve} disabled={!rendered || rendered.length === 0 || approving || dirty}>
               {approving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Send className="mr-1 h-4 w-4" />}
-              Approve &amp; queue{rendered ? ` (${rendered.length})` : ''}
+              Approve &amp; queue{rendered && !dirty ? ` (${rendered.length})` : ''}
             </Button>
           </div>
-          {!rendered && hasCopy && (
-            <p className="text-xs text-muted-foreground">Preview first — you approve exactly what you saw.</p>
+          {(!rendered || dirty) && hasCopy && (
+            <p className="text-xs text-muted-foreground">
+              {dirty ? 'Copy changed — preview again before approving.' : 'Preview first — you approve exactly what you saw.'}
+            </p>
           )}
+
+          <div className="pt-2">
+            {confirmDiscard ? (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-muted-foreground">Delete this draft?</span>
+                <Button size="sm" variant="destructive" className="h-7" onClick={discard} disabled={discarding}>
+                  {discarding ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Yes, discard'}
+                </Button>
+                <Button size="sm" variant="ghost" className="h-7" onClick={() => setConfirmDiscard(false)} disabled={discarding}>
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+                onClick={() => setConfirmDiscard(true)}
+              >
+                <Trash2 className="mr-1 h-3.5 w-3.5" /> Discard draft
+              </Button>
+            )}
+          </div>
         </CardContent>
       </Card>
 

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -5,7 +5,7 @@ import { loggers } from '@/lib/logger';
 import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
 import type { Campaign, SegmentDefinition, MessageVariant, OutboxMessage } from '@/types';
 import { PREDEFINED_SEGMENTS, previewAudience } from '@/services/segmentService';
-import { listCampaigns, createCampaign, approveCampaign, sendCampaign, createManualCampaign, markCampaignQueued, markCampaignSent, getCampaign } from '@/services/campaignService';
+import { listCampaigns, createCampaign, approveCampaign, sendCampaign, createManualCampaign, markCampaignQueued, markCampaignSent, deleteCampaign, getCampaign } from '@/services/campaignService';
 import { buildAudience, type AudienceCandidate } from '@/services/audienceService';
 import { renderMessages, queueMessages, type RenderedMessage, type SkippedRender } from '@/services/campaignMessaging';
 import { fetchOutboxForCampaign, markOutboxSent } from '@/services/outboxService';
@@ -323,5 +323,30 @@ export async function markCampaignSentAction(
   } catch (error) {
     logger.error('markCampaignSentAction failed', error as Error);
     return { success: false, error: 'Failed to update campaign' };
+  }
+}
+
+/** Discard an abandoned DRAFT campaign (guarded — never removes a queued/sent one). */
+export async function discardDraftCampaignAction(
+  campaignId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const campaign = await getCampaign(campaignId);
+    if (!campaign) return { success: false, error: 'Campaign not found' };
+    if (campaign.status !== 'draft') {
+      return { success: false, error: 'Only draft campaigns can be discarded' };
+    }
+    await deleteCampaign(campaignId);
+    revalidatePath('/admin/campaigns');
+    return { success: true };
+  } catch (error) {
+    logger.error('discardDraftCampaignAction failed', error as Error);
+    return { success: false, error: 'Failed to discard campaign' };
   }
 }

--- a/src/app/calendar/[token]/_lib/fetch-public-calendar.ts
+++ b/src/app/calendar/[token]/_lib/fetch-public-calendar.ts
@@ -81,7 +81,7 @@ function nightsBetween(checkIn: Date, checkOut: Date): number {
  * A token matching `shareCalendarToken` → 'full'; one matching `guestCalendarToken`
  * → 'anonymized'. Returns null if no property has this token.
  */
-export async function resolvePropertyByToken(token: string): Promise<{ propertyId: string; propertyName: string; mode: CalendarMode } | null> {
+export async function resolvePropertyByToken(token: string): Promise<{ propertyId: string; propertyName: string; mode: CalendarMode; imageUrl?: string } | null> {
   if (!token) return null;
   const db = await getAdminDb();
   const [fullSnap, guestSnap] = await Promise.all([
@@ -92,10 +92,20 @@ export async function resolvePropertyByToken(token: string): Promise<{ propertyI
   if (!doc) return null;
   const mode: CalendarMode = !fullSnap.empty ? 'full' : 'anonymized';
   const data = doc.data();
+
+  // Pick a hero image for the link preview (og:image): featured first, then the
+  // lowest sortOrder, then whatever is first.
+  const images = Array.isArray(data.images) ? (data.images as Array<{ url?: string; isFeatured?: boolean; sortOrder?: number }>) : [];
+  const hero =
+    images.find((i) => i?.isFeatured) ??
+    [...images].sort((a, b) => (a?.sortOrder ?? 999) - (b?.sortOrder ?? 999))[0] ??
+    images[0];
+
   return {
     propertyId: doc.id,
     propertyName: typeof data.name === 'string' ? data.name : 'Property',
     mode,
+    imageUrl: typeof hero?.url === 'string' ? hero.url : undefined,
   };
 }
 

--- a/src/app/calendar/[token]/page.tsx
+++ b/src/app/calendar/[token]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { resolvePropertyByToken, fetchPublicCalendarData } from './_lib/fetch-public-calendar';
 import { PublicCalendar } from './_components/public-calendar';
@@ -6,6 +7,35 @@ export const dynamic = 'force-dynamic';
 
 interface PageProps {
   params: Promise<{ token: string }>;
+}
+
+/**
+ * Property-specific link preview (og:*) for the share URL — this is what shows in
+ * a WhatsApp/Signal/etc. card when the owner sends the calendar link to a guest.
+ * Without it the page inherits the generic site metadata ("RentalSpot — Your
+ * Vacation Getaway"), which reads impersonal for a one-to-one message. `noindex`
+ * keeps the token URL out of search engines (it's a private share link; it does
+ * NOT affect link-preview crawlers, which ignore robots directives).
+ */
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { token } = await params;
+  const property = await resolvePropertyByToken(token);
+  if (!property) return { robots: { index: false, follow: false } };
+
+  const title = property.propertyName;
+  const description =
+    property.mode === 'anonymized'
+      ? 'Vezi ce date sunt libere și rezervă-ți sejurul.'
+      : 'Calendar rezervări';
+  const images = property.imageUrl ? [property.imageUrl] : undefined;
+
+  return {
+    title,
+    description,
+    robots: { index: false, follow: false },
+    openGraph: { title, description, type: 'website', images, siteName: title },
+    twitter: { card: 'summary_large_image', title, description, images },
+  };
 }
 
 export default async function PublicCalendarPage({ params }: PageProps) {

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -134,6 +134,13 @@ export async function markCampaignSent(id: string): Promise<void> {
   });
 }
 
+/** Hard-delete a campaign doc — used to discard an abandoned draft. */
+export async function deleteCampaign(id: string): Promise<void> {
+  const db = await getAdminDb();
+  await db.collection('campaigns').doc(id).delete();
+  logger.info('Campaign deleted', { campaignId: id });
+}
+
 export async function getCampaign(id: string): Promise<Campaign | null> {
   const db = await getAdminDb();
   const doc = await db.collection('campaigns').doc(id).get();


### PR DESCRIPTION
Three improvements surfaced by the end-to-end self-test.

## 1. Property-specific link preview (the polish)
The `/calendar/[token]` share link the owner sends guests inherited the **generic** site card — *"RentalSpot — Your Vacation Getaway"*, naming both properties — which reads impersonal in a one-to-one WhatsApp message. Added `generateMetadata` that resolves the token → property and emits a **property-specific** `og:title` + description + **hero image** (~290KB, comfortably under WhatsApp's preview limit). Also `noindex`, so the private token URL stays out of search engines (doesn't affect link-preview crawlers, which ignore robots directives).

`resolvePropertyByToken` now also returns the hero image (featured → lowest `sortOrder` → first).

## 2. Re-preview enforcement (correctness)
Editing the copy after a Preview left the stale preview on screen but **Approve stayed enabled** — you could queue text you never previewed, breaking the "approve exactly what you saw" promise. Any edit now marks the preview dirty and **disables Approve until you re-preview** (with a hint).

## 3. Discard draft (UX gap)
A mistaken draft campaign had **no removal path** in the UI. Added a guarded `deleteCampaign` + `discardDraftCampaignAction` (**draft-only** — never touches a queued/sent campaign) and a two-click inline confirm in the composer.

## Tests
- Message-step suites — **51 passing**; `npm run build` passes; `/calendar/[token]` + campaign routes compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)