### PR TITLE
feat: whatsapp-backfill skill + no-chat/empty markers (RO backfill complete)

### DIFF
--- a/.claude/skills/whatsapp-backfill/SKILL.md
+++ b/.claude/skills/whatsapp-backfill/SKILL.md
@@ -42,92 +42,116 @@ npx tsx scripts/whatsapp-thread.ts queue --lang ro             # all, with threa
 Each row: `guestId  phone(E.164)  name  status`. Process in **batches of ~10–15 with a
 check-in between**. `--missing` skips completed guests, so stop/resume anytime.
 
-## Per-guest routine
-Track the **previous guest's `lastPpt`** (newest message fingerprint) to prove the chat switched.
+## ⚠️ THE ONE RULE THAT MATTERS: wait for the phone-pull to FINISH before grabbing
+WhatsApp Web shows the newest message instantly, then pulls the rest **from the phone
+asynchronously — 10–20+ seconds**, progressively. Grabbing too early captures only the 1
+visible message and silently truncates the thread. **This corrupted dozens of threads before it
+was caught** (e.g. a guest saved as "1 msg" actually had 27). The retrievable history is done
+loading **only when the clickable "get older messages from your phone" button is GONE.** Poll for
+its absence — do NOT trust a message-count plateau (the count stalls mid-pull, then jumps).
 
-**1. Search + open (one `browser_batch`)** — coords: search box `(215,85)`, sole result `(297,241)`:
-```
-browser_batch actions:
-  computer left_click (215,85) · computer key "cmd+a" · computer type "<phone>" ·
-  computer wait 1.5 · computer left_click (297,241) · computer wait 2
-```
+Two different top-of-chat indicators — learn to tell them apart:
+| Top-of-chat element (`data-pre-plain-text` regex) | Meaning | Action |
+|---|---|---|
+| Clickable **"get older messages from your phone"** button | more history, **pullable** now | click it, WAIT, re-poll until the button disappears, THEN grab |
+| Static grey banner **"Use WhatsApp on your phone to see older messages"** | older history exists but is **phone-only** (Web won't push it; scrolling up won't convert it) | grab what's shown; this thread is **web-partial** by necessity, not a bug |
+| Neither | Web has the complete history | grab; it's genuinely complete |
 
-**2. Verify the chat switched** (`javascript_tool`) — its `lastPpt` MUST differ from the prior guest:
+## Per-guest routine (size-independent — coordinates rescale and break; use `find` + ref-click)
+
+**1. Search** (`browser_batch`) — the search box is a stable element; `find` it once and reuse the
+ref across guests. `cmd+a` then type replaces the prior query:
+```
+browser_batch: computer left_click ref=<searchBoxRef> · computer key "cmd+a" ·
+               computer type "<phone>" · computer wait 2
+```
+Then check results via `javascript_tool`: if `document.body.innerText` contains
+"No chats, contacts or messages found" → **no chat**: `mark --status no-chat` + next guest.
+Otherwise `find` the first result row under the "Chats" heading and ref-click it; `wait 3`.
+(JS `.click()` on the row does NOT fire WhatsApp's React handler — you must ref-click via the extension.)
+
+**2. Poll the pull-state** (`javascript_tool`) — clicks the pull button if present, reports state:
 ```js
-(() => { const e=document.querySelectorAll('[data-pre-plain-text]'); const l=e.length?e[e.length-1].getAttribute('data-pre-plain-text'):null; return JSON.stringify({rendered:e.length,lastPpt:l}); })()
-```
-- If `rendered===0` or `lastPpt` equals the prior guest → **not switched**: wait 2s and re-check, or re-run step 1. **Never extract an unswitched chat** (it saves the wrong guest — this has happened).
-- If no chat exists for the number (search finds nothing / empty), **skip the guest and log it**.
-
-**3. Scroll-collect the full thread** (`javascript_tool`) — sets `window.__waRows` + a done flag
-(the call returns `{}` *before* the async finishes):
-```js
-window.__waRows=null; window.__waDone=false;
-(async () => {
-  const sleep=ms=>new Promise(r=>setTimeout(r,ms));
-  const clean=t=>(t||'').replace(/(https?:\/\/[^\s?]+)\?[^\s]*/g,'$1').replace(/\s+/g,' ').trim();
-  const acc=new Map();
-  const grab=()=>document.querySelectorAll('[data-pre-plain-text]').forEach(el=>{const k=el.getAttribute('data-pre-plain-text');if(k){const t=clean(el.innerText);acc.set(k+'||'+t,{ppt:k,text:t});}});
-  const pane=()=>{let p=document.querySelector('[data-pre-plain-text]');for(let i=0;i<40&&p;i++){if(p.scrollHeight>p.clientHeight+100&&/(auto|scroll)/.test(getComputedStyle(p).overflowY))return p;p=p.parentElement;}return null;};
-  grab();                                                 // collect rendered FIRST — covers short/non-scrollable chats
-  let lastN=-1,stable=0;                                  // Phase 1: click "get older" + scroll-top until msg COUNT stabilizes
-  for(let i=0;i<40&&stable<5;i++){                        //   ALWAYS click the button (a fully-phone-side chat has 0 rendered);
-    const b=[...document.querySelectorAll('button')].find(e=>/get older messages/i.test(e.textContent||'')); //  its pull is slow.
-    if(b)b.click();
-    const p=pane(); if(p)p.scrollTop=0;
-    await sleep(800); grab();
-    const n=document.querySelectorAll('[data-pre-plain-text]').length;
-    if(n===lastN)stable++; else{stable=0;lastN=n;}
-  }
-  const p=pane();                                         // Phase 2: walk top->bottom collecting each window (if scrollable)
-  if(p){ p.scrollTop=0; await sleep(400); grab();
-    for(let g=0,lt=-1,st=0;g<800;g++){grab();if(p.scrollTop>=p.scrollHeight-p.clientHeight-5){grab();break;}p.scrollTop+=Math.floor(p.clientHeight*0.5);await sleep(130);if(p.scrollTop===lt){if(++st>4)break;}else st=0;lt=p.scrollTop;}
-    grab(); }
-  window.__waRows=[...acc.values()];window.__waDone=true;
+(() => {
+  const btn=[...document.querySelectorAll('button,div[role="button"]')].find(b=>/get older messages/i.test(b.textContent||''));
+  if(btn) btn.click();                                       // kick the pull each poll
+  const banner=/Use WhatsApp on your phone to see older messages/i.test(document.body.innerText);
+  const e=document.querySelectorAll('[data-pre-plain-text]');
+  return JSON.stringify({rendered:e.length, hasPullBtn:!!btn, hasBanner:banner,
+    first:e.length?e[0].getAttribute('data-pre-plain-text'):null,
+    last:e.length?e[e.length-1].getAttribute('data-pre-plain-text'):null});
 })()
 ```
-WhatsApp **virtualizes** long threads (~50 msgs in the DOM at once), so a single `querySelectorAll`
-silently truncates them — scroll-and-collect is mandatory. But `grab()` must run FIRST (short chats
-have no scroll pane), Phase 1 must ALWAYS click "get older messages" (a fully-phone-side chat renders
-0 until pulled, and the pull is slow — track by message COUNT), and Phase 2 only scrolls when a pane
-exists. A truly empty/media-only chat legitimately returns 0 → skip + log.
+- Verify `first`/`last` differ from the previous guest (proves the chat switched — never extract a stale chat).
+- **While `hasPullBtn===true`: `computer wait 7`, then re-run this JS. Repeat until `hasPullBtn===false`.**
+  A rich thread pulls in waves (1 → 26 → 48…); keep going until the button is gone.
+- `hasPullBtn===false` → the pull is complete; `rendered` is now the full retrievable count.
 
-**4. Wait for done** (`javascript_tool`, repeat every ~5s until `done:true`; ~10–35s by thread size):
+**3. Grab + download** (`javascript_tool`) — once the button is gone. `rendered<50` fits the DOM, so a
+direct grab is complete; only if `rendered>=~45` do a scroll-collect (Phase 2 below) to defeat
+virtualization:
 ```js
-JSON.stringify({done:window.__waDone===true,count:window.__waRows?window.__waRows.length:0,earliest:window.__waRows&&window.__waRows[0]?window.__waRows[0].ppt:null,latest:window.__waRows&&window.__waRows.length?window.__waRows[window.__waRows.length-1].ppt:null})
+(() => {
+  const clean=t=>(t||'').replace(/(https?:\/\/[^\s?]+)\?[^\s]*/g,'$1').replace(/\s+/g,' ').trim();
+  const acc=new Map();
+  document.querySelectorAll('[data-pre-plain-text]').forEach(el=>{const k=el.getAttribute('data-pre-plain-text');if(k)acc.set(k+'||'+clean(el.innerText),{ppt:k,text:clean(el.innerText)});});
+  const rows=[...acc.values()];
+  if(!rows.length) return JSON.stringify({count:0});
+  const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(rows)],{type:'application/json'}));a.download='wa-<guestId>.json';document.body.appendChild(a);a.click();a.remove();
+  return JSON.stringify({count:rows.length, first:rows[0].ppt, last:rows[rows.length-1].ppt});
+})()
 ```
-**Sanity check**: `count>0`, and `(count, earliest, latest)` must NOT equal the previous guest's
-(identical ⇒ stale chat ⇒ go back to step 1). `earliest`'s date is the retrievable limit (varies).
+Scroll-collect (only for `>=~45`): `let p=<scroll pane>; p.scrollTop=0; await sleep(400); grab();`
+then `for(...) { grab(); if(atBottom)break; p.scrollTop+=clientHeight*0.5; await sleep(140); } grab();`
+accumulating into the same `acc`. A long thread virtualizes to ~50 in the DOM at once.
 
-**5. Download** (`javascript_tool`) — to `~/Downloads/wa-<guestId>.json`:
-```js
-(() => {const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(window.__waRows)],{type:'application/json'}));a.download='wa-<guestId>.json';document.body.appendChild(a);a.click();a.remove();return window.__waRows.length;})()
+**4. Save + clean up** (`Bash`) — idempotent (dedupe-append). **Guard the `rm` behind a confirmed
+save** (a browser download can lag disk by a second — an immediate save may `ENOENT`; keep the file
+so you can retry instead of losing data):
 ```
+F=~/Downloads/wa-<guestId>.json
+OUT=$(npx tsx scripts/whatsapp-thread.ts save --guest <guestId> --phone <phone> --rows "$F" 2>&1)
+echo "$OUT" | grep -iE 'saved|error|ENOENT'
+echo "$OUT" | grep -q 'Saved ' && rm -f "$F" || echo "!! KEPT FILE — save failed, retry"
+```
+`save` prints `parsed N → +added, total`. Update the prior-guest `first`/`last` and move on.
 
-**6. Save + clean up** (`Bash`) — idempotent (dedupe-append), then delete the transient file:
-```
-npx tsx scripts/whatsapp-thread.ts save --guest <guestId> --phone <phone> --rows ~/Downloads/wa-<guestId>.json
-rm -f ~/Downloads/wa-<guestId>.json
-```
-`save` prints `parsed N → +added, total` — record the tally. Update the prior-guest `lastPpt` to
-this guest's `latest` and move on.
+**Empty / no retrievable text** (`rendered===0` after the pull finished, or an all-media/system chat):
+- **Outbound photo-share** (a "Buna <Name>!… doua poze…" outreach sent WITH photos): the text is a
+  photo **caption**, which has NO `data-pre-plain-text` (systematic — accepted as "caption loss").
+  Screenshot to confirm, then `mark --status empty`.
+- **Disappearing-messages** chat (system notice "…uses a default timer for disappearing messages"):
+  content is gone → `mark --status empty`.
+- Otherwise media/call-only → `mark --status empty`.
 
 ## Guards (why each step exists)
 - **ONE tab** — a 2nd WhatsApp Web tab de-syncs the session.
-- **Verify-switch (step 2)** — extracting before the chat switches saves the *previous* guest's thread.
-- **Wait-for-done (step 4)** — the extractor's `{}` returns before the scroll finishes; reading early gives `unset`.
-- **Idempotent `save`** — re-running a guest only appends genuinely-new messages (safe to retry).
-- **Query strings stripped** in the extractor — satisfies the browser's anti-exfil guard + drops tokens.
+- **Wait for the pull button to be GONE (step 2)** — THE fix for the truncation bug: the phone-pull is
+  async and slow; a message-count plateau is not "done", the button's absence is. Poll it.
+- **Verify-switch** — `first`/`last` must differ from the prior guest, else you save the *previous* thread.
+- **Guarded `rm`** — the browser download can lag disk; keep the file if `save` didn't confirm.
+- **Idempotent `save`** — re-running/re-auditing a guest only appends genuinely-new messages (safe).
+- **Query strings stripped** in the grab — satisfies the browser's anti-exfil guard + drops tokens.
 - **Direction** = the `data-pre-plain-text` sender vs the owner name (`Bogdan Coman`), handled at parse time.
+
+## Re-audit an existing thread (catch prior truncations)
+Same routine, but compare the pulled `rendered` count to the stored `messageCount`
+(`show --guest <id>`): if `rendered > saved`, an earlier pass truncated it — grab + save (append).
+If a stored thread's count is *larger* than the current `rendered`, the sync horizon has just shifted
+(Web shows less now); your stored data is the more complete one — leave it. A banner-only thread was
+never truncatable (nothing was ever Web-pullable beyond what showed), so `rendered==saved` there is complete.
 
 ## Error handling
 | Symptom | Action |
 |---|---|
-| Chat didn't switch (step 2 unchanged) | wait 2s, re-check; if still stale, re-run step 1 |
-| No chat / "No chats found" for the number | `mark --status no-chat` + continue (records the signal, keeps backfill resumable) |
-| `count===0` after done (chat opened but empty/media-only) | re-open + retry once; if still 0, `mark --status empty` + continue |
+| `hasPullBtn` stays true across polls | keep waiting + re-polling; rich threads pull in waves (can take 30–60s) |
+| Chat didn't switch (`first`/`last` unchanged from prior) | wait 2s, re-check; if still stale, re-run step 1 |
+| No chat / "No chats found" for the number | `mark --status no-chat` + continue |
+| `rendered===0` after the pull finished | screenshot; photo-share caption / disappearing-msgs / media-only → `mark --status empty` |
+| `rendered` grows *after* you thought it was done (late-load) | you grabbed too early — re-poll until button gone, re-grab, `save` (append) |
+| `find` returns a stale ref (old guest's row) | its a11y snapshot lags the search; re-verify the search result text via JS, re-`find` |
 | Extractor stuck / tool errors 2–3× | stop, report to the user, don't hammer |
-| Phone offline (shallow earliest) | note it; deep history needs the phone awake — flag for a later re-run |
+| `javascript_tool` "couldn't determine which page" | re-run `tabs_context_mcp` once, then retry the action |
 
 ## Scale & safety
 - ~30–90s per guest (scroll-collect dominates). 100 guests ≈ 1.5–2.5h → run in batches.

--- a/.claude/skills/whatsapp-backfill/SKILL.md
+++ b/.claude/skills/whatsapp-backfill/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: whatsapp-backfill
+description: >-
+  Collect past-guest WhatsApp conversation history (verbatim) into the
+  whatsappThreads vault by driving WhatsApp Web read-only via the claude-in-chrome
+  browser tools. Use for the one-time RO-guest backfill and the incremental
+  recent-tail top-up before each engagement campaign. Not for sending — read-only.
+---
+
+# WhatsApp history backfill
+
+Drives **WhatsApp Web** (the owner's logged-in session) to collect each past guest's
+**verbatim** conversation into `whatsappThreads/{guestId}` — the data foundation for the
+engagement/intelligence layer (voice, engagement signal, grounding). See
+`plans/engagement-system.md` §7.0/§7.1. The pure/tested server half is
+`src/lib/whatsapp/parse-thread.ts` + `src/services/whatsappThreadService.ts`; the CLI is
+`scripts/whatsapp-thread.ts`. **This skill is the browser-orchestration playbook.**
+
+**READ-ONLY and ban-safe by construction** — it never sends, never bulk-acts, only reads
+the owner's own chats. Sending stays manual `wa.me` elsewhere.
+
+## Modes
+- **Backfill** (first pass): full history per guest (scroll-load all older + walk-collect).
+- **Top-up** (before a campaign): recent tail only — Phase 1 (load-older) can be skipped;
+  `save` dedupes against the stored thread and appends only new messages.
+
+## Prerequisites (confirm before starting)
+1. **WhatsApp Web is open and logged in** in the user's Chrome (`web.whatsapp.com`, tab title
+   shows an unread count, not a QR code).
+2. **Exactly ONE WhatsApp Web tab** — a second de-syncs the session into a never-settles state.
+3. **Phone unlocked and online** — required for "get older messages from your phone" to pull
+   deep history; without it, history is shallow.
+4. Browser tools loaded: `tabs_context_mcp, computer, javascript_tool, browser_batch`
+   (ToolSearch `select:` them). Get `tabs_context_mcp` once to learn the tab id.
+5. Don't drive the machine's mouse/keyboard while the browser is being controlled.
+
+## Work-list (resumable)
+```
+npx tsx scripts/whatsapp-thread.ts queue --lang ro --missing   # remaining backfill (no thread yet)
+npx tsx scripts/whatsapp-thread.ts queue --lang ro             # all, with thread status
+```
+Each row: `guestId  phone(E.164)  name  status`. Process in **batches of ~10–15 with a
+check-in between**. `--missing` skips completed guests, so stop/resume anytime.
+
+## Per-guest routine
+Track the **previous guest's `lastPpt`** (newest message fingerprint) to prove the chat switched.
+
+**1. Search + open (one `browser_batch`)** — coords: search box `(215,85)`, sole result `(297,241)`:
+```
+browser_batch actions:
+  computer left_click (215,85) · computer key "cmd+a" · computer type "<phone>" ·
+  computer wait 1.5 · computer left_click (297,241) · computer wait 2
+```
+
+**2. Verify the chat switched** (`javascript_tool`) — its `lastPpt` MUST differ from the prior guest:
+```js
+(() => { const e=document.querySelectorAll('[data-pre-plain-text]'); const l=e.length?e[e.length-1].getAttribute('data-pre-plain-text'):null; return JSON.stringify({rendered:e.length,lastPpt:l}); })()
+```
+- If `rendered===0` or `lastPpt` equals the prior guest → **not switched**: wait 2s and re-check, or re-run step 1. **Never extract an unswitched chat** (it saves the wrong guest — this has happened).
+- If no chat exists for the number (search finds nothing / empty), **skip the guest and log it**.
+
+**3. Scroll-collect the full thread** (`javascript_tool`) — sets `window.__waRows` + a done flag
+(the call returns `{}` *before* the async finishes):
+```js
+window.__waRows=null; window.__waDone=false;
+(async () => {
+  const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+  let p=document.querySelector('[data-pre-plain-text]');
+  for(let i=0;i<40&&p;i++){if(p.scrollHeight>p.clientHeight+100&&/(auto|scroll)/.test(getComputedStyle(p).overflowY))break;p=p.parentElement;}
+  if(!p){window.__waRows=[];window.__waDone=true;return;}
+  const clean=t=>(t||'').replace(/(https?:\/\/[^\s?]+)\?[^\s]*/g,'$1').replace(/\s+/g,' ').trim();
+  const acc=new Map();
+  const grab=()=>document.querySelectorAll('[data-pre-plain-text]').forEach(el=>{const k=el.getAttribute('data-pre-plain-text');if(k){const t=clean(el.innerText);acc.set(k+'||'+t,{ppt:k,text:t});}});
+  let last=-1,stable=0;                                   // Phase 1: load ALL older (skip for top-up)
+  for(let i=0;i<30&&stable<4;i++){p.scrollTop=0;const b=[...document.querySelectorAll('button')].find(e=>/get older messages/i.test(e.textContent||''));if(b)b.click();await sleep(600);grab();if(p.scrollHeight===last)stable++;else{stable=0;last=p.scrollHeight;}}
+  p.scrollTop=0;await sleep(400);grab();                  // Phase 2: walk top->bottom, collect each window
+  for(let g=0,lt=-1,st=0;g<800;g++){grab();if(p.scrollTop>=p.scrollHeight-p.clientHeight-5){grab();break;}p.scrollTop+=Math.floor(p.clientHeight*0.5);await sleep(130);if(p.scrollTop===lt){if(++st>4)break;}else st=0;lt=p.scrollTop;}
+  grab();window.__waRows=[...acc.values()];window.__waDone=true;
+})()
+```
+WhatsApp **virtualizes** (~50 msgs in the DOM at once), so a single `querySelectorAll` silently
+truncates long threads — the scroll-and-collect is mandatory.
+
+**4. Wait for done** (`javascript_tool`, repeat every ~5s until `done:true`; ~10–35s by thread size):
+```js
+JSON.stringify({done:window.__waDone===true,count:window.__waRows?window.__waRows.length:0,earliest:window.__waRows&&window.__waRows[0]?window.__waRows[0].ppt:null,latest:window.__waRows&&window.__waRows.length?window.__waRows[window.__waRows.length-1].ppt:null})
+```
+**Sanity check**: `count>0`, and `(count, earliest, latest)` must NOT equal the previous guest's
+(identical ⇒ stale chat ⇒ go back to step 1). `earliest`'s date is the retrievable limit (varies).
+
+**5. Download** (`javascript_tool`) — to `~/Downloads/wa-<guestId>.json`:
+```js
+(() => {const a=document.createElement('a');a.href=URL.createObjectURL(new Blob([JSON.stringify(window.__waRows)],{type:'application/json'}));a.download='wa-<guestId>.json';document.body.appendChild(a);a.click();a.remove();return window.__waRows.length;})()
+```
+
+**6. Save + clean up** (`Bash`) — idempotent (dedupe-append), then delete the transient file:
+```
+npx tsx scripts/whatsapp-thread.ts save --guest <guestId> --phone <phone> --rows ~/Downloads/wa-<guestId>.json
+rm -f ~/Downloads/wa-<guestId>.json
+```
+`save` prints `parsed N → +added, total` — record the tally. Update the prior-guest `lastPpt` to
+this guest's `latest` and move on.
+
+## Guards (why each step exists)
+- **ONE tab** — a 2nd WhatsApp Web tab de-syncs the session.
+- **Verify-switch (step 2)** — extracting before the chat switches saves the *previous* guest's thread.
+- **Wait-for-done (step 4)** — the extractor's `{}` returns before the scroll finishes; reading early gives `unset`.
+- **Idempotent `save`** — re-running a guest only appends genuinely-new messages (safe to retry).
+- **Query strings stripped** in the extractor — satisfies the browser's anti-exfil guard + drops tokens.
+- **Direction** = the `data-pre-plain-text` sender vs the owner name (`Bogdan Coman`), handled at parse time.
+
+## Error handling
+| Symptom | Action |
+|---|---|
+| Chat didn't switch (step 2 unchanged) | wait 2s, re-check; if still stale, re-run step 1 |
+| No chat / no messages for the number | skip guest, log it, continue |
+| `count===0` after done | re-open + retry once; if still 0, skip + log |
+| Extractor stuck / tool errors 2–3× | stop, report to the user, don't hammer |
+| Phone offline (shallow earliest) | note it; deep history needs the phone awake — flag for a later re-run |
+
+## Scale & safety
+- ~30–90s per guest (scroll-collect dominates). 100 guests ≈ 1.5–2.5h → run in batches.
+- Writes real private conversations to the **admin-locked** `whatsappThreads` collection — do not
+  echo sensitive content back verbatim; report tallies/spans, not raw messages.
+- If the browser extension disconnects, `tabs_context_mcp` to re-establish; never reuse stale tab ids.

--- a/.claude/skills/whatsapp-backfill/SKILL.md
+++ b/.claude/skills/whatsapp-backfill/SKILL.md
@@ -65,21 +65,32 @@ browser_batch actions:
 window.__waRows=null; window.__waDone=false;
 (async () => {
   const sleep=ms=>new Promise(r=>setTimeout(r,ms));
-  let p=document.querySelector('[data-pre-plain-text]');
-  for(let i=0;i<40&&p;i++){if(p.scrollHeight>p.clientHeight+100&&/(auto|scroll)/.test(getComputedStyle(p).overflowY))break;p=p.parentElement;}
-  if(!p){window.__waRows=[];window.__waDone=true;return;}
   const clean=t=>(t||'').replace(/(https?:\/\/[^\s?]+)\?[^\s]*/g,'$1').replace(/\s+/g,' ').trim();
   const acc=new Map();
   const grab=()=>document.querySelectorAll('[data-pre-plain-text]').forEach(el=>{const k=el.getAttribute('data-pre-plain-text');if(k){const t=clean(el.innerText);acc.set(k+'||'+t,{ppt:k,text:t});}});
-  let last=-1,stable=0;                                   // Phase 1: load ALL older (skip for top-up)
-  for(let i=0;i<30&&stable<4;i++){p.scrollTop=0;const b=[...document.querySelectorAll('button')].find(e=>/get older messages/i.test(e.textContent||''));if(b)b.click();await sleep(600);grab();if(p.scrollHeight===last)stable++;else{stable=0;last=p.scrollHeight;}}
-  p.scrollTop=0;await sleep(400);grab();                  // Phase 2: walk top->bottom, collect each window
-  for(let g=0,lt=-1,st=0;g<800;g++){grab();if(p.scrollTop>=p.scrollHeight-p.clientHeight-5){grab();break;}p.scrollTop+=Math.floor(p.clientHeight*0.5);await sleep(130);if(p.scrollTop===lt){if(++st>4)break;}else st=0;lt=p.scrollTop;}
-  grab();window.__waRows=[...acc.values()];window.__waDone=true;
+  const pane=()=>{let p=document.querySelector('[data-pre-plain-text]');for(let i=0;i<40&&p;i++){if(p.scrollHeight>p.clientHeight+100&&/(auto|scroll)/.test(getComputedStyle(p).overflowY))return p;p=p.parentElement;}return null;};
+  grab();                                                 // collect rendered FIRST — covers short/non-scrollable chats
+  let lastN=-1,stable=0;                                  // Phase 1: click "get older" + scroll-top until msg COUNT stabilizes
+  for(let i=0;i<40&&stable<5;i++){                        //   ALWAYS click the button (a fully-phone-side chat has 0 rendered);
+    const b=[...document.querySelectorAll('button')].find(e=>/get older messages/i.test(e.textContent||'')); //  its pull is slow.
+    if(b)b.click();
+    const p=pane(); if(p)p.scrollTop=0;
+    await sleep(800); grab();
+    const n=document.querySelectorAll('[data-pre-plain-text]').length;
+    if(n===lastN)stable++; else{stable=0;lastN=n;}
+  }
+  const p=pane();                                         // Phase 2: walk top->bottom collecting each window (if scrollable)
+  if(p){ p.scrollTop=0; await sleep(400); grab();
+    for(let g=0,lt=-1,st=0;g<800;g++){grab();if(p.scrollTop>=p.scrollHeight-p.clientHeight-5){grab();break;}p.scrollTop+=Math.floor(p.clientHeight*0.5);await sleep(130);if(p.scrollTop===lt){if(++st>4)break;}else st=0;lt=p.scrollTop;}
+    grab(); }
+  window.__waRows=[...acc.values()];window.__waDone=true;
 })()
 ```
-WhatsApp **virtualizes** (~50 msgs in the DOM at once), so a single `querySelectorAll` silently
-truncates long threads — the scroll-and-collect is mandatory.
+WhatsApp **virtualizes** long threads (~50 msgs in the DOM at once), so a single `querySelectorAll`
+silently truncates them — scroll-and-collect is mandatory. But `grab()` must run FIRST (short chats
+have no scroll pane), Phase 1 must ALWAYS click "get older messages" (a fully-phone-side chat renders
+0 until pulled, and the pull is slow — track by message COUNT), and Phase 2 only scrolls when a pane
+exists. A truly empty/media-only chat legitimately returns 0 → skip + log.
 
 **4. Wait for done** (`javascript_tool`, repeat every ~5s until `done:true`; ~10–35s by thread size):
 ```js

--- a/.claude/skills/whatsapp-backfill/SKILL.md
+++ b/.claude/skills/whatsapp-backfill/SKILL.md
@@ -124,8 +124,8 @@ this guest's `latest` and move on.
 | Symptom | Action |
 |---|---|
 | Chat didn't switch (step 2 unchanged) | wait 2s, re-check; if still stale, re-run step 1 |
-| No chat / no messages for the number | skip guest, log it, continue |
-| `count===0` after done | re-open + retry once; if still 0, skip + log |
+| No chat / "No chats found" for the number | `mark --status no-chat` + continue (records the signal, keeps backfill resumable) |
+| `count===0` after done (chat opened but empty/media-only) | re-open + retry once; if still 0, `mark --status empty` + continue |
 | Extractor stuck / tool errors 2–3× | stop, report to the user, don't hammer |
 | Phone offline (shallow earliest) | note it; deep history needs the phone awake — flag for a later re-run |
 

--- a/scripts/whatsapp-thread.ts
+++ b/scripts/whatsapp-thread.ts
@@ -45,6 +45,7 @@
 // Usage:
 //   npx tsx scripts/whatsapp-thread.ts queue [--lang ro|en|all] [--missing]
 //   npx tsx scripts/whatsapp-thread.ts save --guest <id> --phone <e164> --rows <file.json> [--owner "Bogdan Coman"] [--fmt MDY|DMY]
+//   npx tsx scripts/whatsapp-thread.ts mark --guest <id> --phone <e164> --status no-chat|empty   # record a guest with no retrievable messages
 //   npx tsx scripts/whatsapp-thread.ts show --guest <id>
 import * as dotenv from 'dotenv';
 import * as path from 'path';
@@ -52,7 +53,7 @@ import * as fs from 'fs';
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 
-import { getBackfillQueue, upsertThreadMessages, getThread } from '../src/services/whatsappThreadService';
+import { getBackfillQueue, upsertThreadMessages, getThread, markThread } from '../src/services/whatsappThreadService';
 import { parseWhatsAppRows, type RawRow } from '../src/lib/whatsapp/parse-thread';
 
 const DEFAULT_OWNER = process.env.WHATSAPP_OWNER_NAME || 'Bogdan Coman';
@@ -93,6 +94,19 @@ async function main() {
     });
     const res = await upsertThreadMessages({ guestId, phone, messages });
     console.log(`Saved ${guestId}: parsed ${messages.length} messages → +${res.added} new, ${res.total} total.`);
+    return;
+  }
+
+  if (cmd === 'mark') {
+    const guestId = flag('guest');
+    const phone = flag('phone');
+    const status = flag('status') as 'no-chat' | 'empty';
+    if (!guestId || !phone || (status !== 'no-chat' && status !== 'empty')) {
+      console.error('mark requires --guest <id> --phone <e164> --status no-chat|empty');
+      process.exit(1);
+    }
+    await markThread(guestId, phone, status);
+    console.log(`Marked ${guestId} as ${status}.`);
     return;
   }
 

--- a/src/services/whatsappThreadService.ts
+++ b/src/services/whatsappThreadService.ts
@@ -45,6 +45,7 @@ export async function upsertThreadMessages(input: {
       phone: input.phone,
       messages: merged,
       messageCount: merged.length,
+      status: 'ok',
       ...(lastMessageTs ? { lastMessageTs } : {}),
       lastFetchedAt: now,
       ...(snap.exists ? {} : { firstFetchedAt: now }),
@@ -54,6 +55,30 @@ export async function upsertThreadMessages(input: {
 
   logger.info('WhatsApp thread upserted', { guestId: input.guestId, added, total: merged.length });
   return { added, total: merged.length };
+}
+
+/**
+ * Record a processed guest that has NO retrievable messages — either no WhatsApp
+ * chat exists (`no-chat`) or the chat is empty/media-only (`empty`). This is a real
+ * signal (no WhatsApp presence / never engaged) AND it makes the backfill resumable
+ * (the guest now has a doc, so `getBackfillQueue({onlyMissing})` skips it).
+ */
+export async function markThread(guestId: string, phone: string, status: 'no-chat' | 'empty'): Promise<void> {
+  const db = await getAdminDb();
+  const ref = db.collection('whatsappThreads').doc(guestId);
+  const snap = await ref.get();
+  const now = FieldValue.serverTimestamp();
+  await ref.set(
+    {
+      guestId,
+      phone,
+      status,
+      ...(snap.exists ? {} : { messages: [], messageCount: 0, firstFetchedAt: now }),
+      lastFetchedAt: now,
+    },
+    { merge: true }
+  );
+  logger.info('WhatsApp thread marked', { guestId, status });
 }
 
 /** Read a stored thread (timestamps serialized for any caller). */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -429,6 +429,7 @@ export interface WhatsAppThread {
   phone: string;              // E.164, the number the thread belongs to
   messages: WhatsAppMessage[];
   messageCount: number;
+  status?: 'ok' | 'no-chat' | 'empty'; // 'no-chat'/'empty' = processed, nothing to store (still a signal + resumable)
   lastMessageTs?: string;     // ts of the newest captured message — drives incremental top-up
   firstFetchedAt?: SerializableTimestamp;
   lastFetchedAt?: SerializableTimestamp;


### PR DESCRIPTION
The reusable **whatsapp-backfill** skill + supporting CLI/service used to collect the
past-guest WhatsApp conversation vault (the data foundation for the engagement/reasoner layer).

## What this branch adds
- `.claude/skills/whatsapp-backfill/SKILL.md` — the browser-orchestration playbook (drives WhatsApp Web **read-only**, ban-safe).
- `scripts/whatsapp-thread.ts` — `mark --status no-chat|empty` command (records guests with no retrievable messages; keeps the backfill resumable).
- `src/services/whatsappThreadService.ts` — `markThread()` helper.
- `src/types/index.ts` — `status` field on `WhatsAppThread`.

## Outcome (data already in Firestore, not in this diff)
The one-time RO-guest backfill is **complete: 103/103 guests** — 949 messages, 40 threads with a guest reply.

## Key methodology fix (last commit)
The phone-pull ("get older messages from your phone") is **async and slow** (10–20s, in waves). Grabbing on a message-count plateau silently truncated threads (a guest saved as "1 msg" actually had 27). The skill now **polls the pull button until it's gone, then grabs**. Also documents the "Use WhatsApp on your phone" banner (older history is phone-only = web-partial), photo-outreach caption / disappearing-msgs → empty, size-independent find+ref-click, and a re-audit procedure.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)