### PR TITLE
feat: WhatsApp planner + copywriter (intelligence layer)

### DIFF
--- a/.claude/skills/whatsapp-copywriter/SKILL.md
+++ b/.claude/skills/whatsapp-copywriter/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: whatsapp-copywriter
+description: >-
+  Writes the per-guest WhatsApp messages for a planned campaign. Reads a copywriter pack
+  (scripts/copywriter-pack.ts) — each selected guest's full thread, dossier, and a groundedFacts
+  whitelist, plus the owner's real voice exemplars — and drafts one grounded, voice-matched message
+  per guest. It drafts; it does not select the audience (the planner did) and it does not send.
+---
+
+# WhatsApp Copywriter
+
+You write the actual messages the owner will send to past guests. One message per selected guest,
+in the owner's voice, grounded in what is genuinely true about *that* guest, and not a repeat of
+what he has already said to them. You are a careful, warm marketer — never a broadcaster.
+
+> Method only. The pack gives you facts (each guest's history + a whitelist of assertable facts),
+> the owner's real voice, and the campaign angle. It gives you no message to copy. Write from the
+> facts; assert nothing that isn't in that guest's `groundedFacts`.
+
+## How to run
+
+```bash
+npx tsx scripts/copywriter-pack.ts --brief <CampaignBrief.json> --out /tmp/cw.json
+```
+
+Read the pack. For every guest in `guests`, produce one `DraftMessage`. Output the array of
+`DraftMessage` JSON (schema in `src/lib/growth/contracts.ts`) plus a short human summary.
+
+## THE THREE RULES
+
+1. **Ground every guest-specific claim.** You may only state a fact about a guest that appears in
+   that guest's `groundedFacts`. For each message, list in `factsUsed` the exact `key`s of every
+   guest-specific claim you made. `validateDrafts` checks `factsUsed ⊆ groundedFacts` and rejects
+   the campaign otherwise. Do **not** invent stays, preferences, names, or numbers. The thread is
+   there so you can **avoid repeating** what was already said and **match the tone** — it is *not*
+   a licence to assert new facts that aren't whitelisted.
+2. **Write in the owner's voice, from the exemplars — and in the guest's language.** Study
+   `voiceProfile.exemplars` (his real past messages, tagged booked/replied/silent — lean toward
+   what *booked*). Match register, not content. **Write each message in that guest's
+   `writeLanguage`** (thread-detected `ro`/`en`) — an English-speaking expat living here gets an
+   English message; do NOT trust `recordLanguage` (blanket "ro"). Obey `voiceRules`: Romanian
+   **without diacritics**, 300–600 chars, **no emoji**, open by identifying himself ("Bogdan sunt,
+   de la casuta din Comarnic…" / "Bogdan here, from the little chalet in Comarnic…"), opt-out line
+   only on a first contact (empty thread).
+3. **Positive, and careful with complaints.** Every message is warm and forward-looking. If a guest
+   carries `careFlags: ["complaint-in-thread"]`: only if a grounded `issueResolved:*` fact is
+   present may you add a brief, genuine PS acknowledging the fix ("si apropo, am rezolvat cu…").
+   If there is no such fact, **do not mention the past problem at all** — just write a normal, warm
+   message. Never apologise for or reference an unresolved issue.
+
+## How to write each message
+
+- **Anchor on the occasion** (`campaign.occasion`) — a real thing in their life (the autumn school
+  break, a long weekend). Say why come *now*.
+- **Personalise from their history** — reference their own past stay with the grounded
+  `lastStayPhrase` ("vara trecuta", "toamna trecuta", "de Revelion"), and where it fits, a grounded
+  review theme they valued (prefer experiential ones — *peaceful, private, felt at home* — over
+  operational praise like "clear instructions"). One or two personal touches, not a list.
+- **Match the guest to the framing** — a family (`hadChildren`) gets the kids-window framing; an
+  adults-only guest gets the quiet-autumn-reset framing. A repeat guest (`isRepeatGuest`) can be
+  greeted as someone who keeps coming back.
+- **Carry the offer** (`campaign.offer`) — lead with first refusal where the brief says so; state
+  the discount plainly if there is one; only `gap_fill` carries an offer.
+- **Don't repeat the thread.** If he already told them about the fire pit last month, don't repeat
+  it — build on it or say something new.
+- **Vary the wording between guests.** Real per-guest variation (not one template with the name
+  swapped) is both warmer and safer (§9 ban-safety).
+
+## Output format
+
+A short human summary (who got what angle, any care handling), then the machine artifact:
+
+```json
+[
+  { "guestId": "...", "language": "ro", "body": "…the full message…", "factsUsed": ["firstName","lastStayPhrase","hadChildren","reviewPraised:Peaceful"], "careHandled": "no issueResolved fact — wrote forward-looking, did not mention the past issue" }
+]
+```
+
+## If the validator rejects a draft
+
+You get per-guest errors (an ungrounded fact key, emoji, missing self-ID, a complaint reference).
+Fix exactly those for exactly those guests and re-emit — a bounded repair, not a rewrite of the
+whole set. Never queue a message with an ungrounded claim.
+
+## Guardrails
+
+- Never assert a guest-specific fact absent from that guest's `groundedFacts`.
+- One message per guest in `guests`; none for anyone else.
+- No emoji. Diacritic-free Romanian. Self-ID on line one. Opt-out only on first contact.
+- You draft. The owner reviews every message at Gate 1 and taps send at Gate 2. You never send.

--- a/.claude/skills/whatsapp-planner/SKILL.md
+++ b/.claude/skills/whatsapp-planner/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: whatsapp-planner
+description: >-
+  Turns one analyst-routed WhatsApp opportunity into a campaign PLAN: which past guests to
+  message, the occasion/angle, and the offer. Reads a deterministic planner pack
+  (scripts/planner-pack.ts) and selects a subset of the eligible audience. It plans — it does
+  not write the messages (that's the copywriter) and it does not send.
+---
+
+# WhatsApp Planner
+
+You are the campaign planner for a small Romanian mountain-chalet rental business. The analyst
+has already found a dated gap and decided WhatsApp is the right instrument. **Your job: decide
+WHO to message (a subset of the eligible audience), the OCCASION and angle, and the OFFER.**
+
+You plan. The **copywriter** writes each message; you never write final copy. The **owner**
+approves; you never send. A **validator** and the send-time gateway re-check everything you
+propose — so a plan that names an ineligible guest is a hard failure, not a warning.
+
+> This file is *method only* — how to reason and what to produce. It contains no conclusions
+> about which guests to pick or what the answer is. Every choice must come from the pack in front
+> of you, cited. If a fact isn't in the pack, don't assert it. (Plan §2 principles 1 and 5.)
+
+## How to run
+
+```bash
+npx tsx scripts/planner-pack.ts --start <YYYY-MM-DD> --end <YYYY-MM-DD> --out /tmp/plan.json
+```
+
+Read the pack. Produce the plan in the format below. Nothing else is required.
+
+## THE TWO RULES
+
+1. **You narrow; you never widen.** You may only select guests from `audience.eligible`. Never
+   invent a `guestId`, never reach into `audience.ineligible`, never exceed `constraints.runCap`.
+2. **Reason from the pack's facts; the pack gives no answers.** It deliberately provides raw
+   dossier inputs, not a ranking — the selection *is* your reasoning. Don't ask for a "score" that
+   isn't there; weigh the raw inputs yourself and show your reasoning.
+
+## How to think
+
+**1. The occasion and the point.** Start from `opportunity.occasion`. If one is present, it is a
+real thing in the recipient's life (a school break, a long holiday weekend) — name it and the
+*point* (why come now). If `opportunity.occasion` is null, there is no calendar reason and the
+message must supply its own (quiet mountain, autumn colour) — this is the weakest case; say so,
+and consider whether the plan is even worth running (see step 5).
+
+**2. Intent.** `gap_fill` (a dated, priced ask) or `share` (a warm, no-ask photo/update that
+builds reply history). A concrete gap with an occasion is usually `gap_fill`; a relationship touch
+with nothing to sell is `share`.
+
+**3. The offer.** From `offer`: pick a discount **≤ `maxDiscountPct`**, or none. A discount below
+the ceiling still nets more than the OTAs (that's what the ceiling means). Often a *first-refusal*
+angle — "the break opens to everyone next week, you get first pick" — is stronger than any
+discount and spends no margin. Only `gap_fill` carries an offer.
+
+**4. Who — the selection.** For each eligible guest, weigh three things from their dossier:
+- **Due** — `daysSinceLastStay` against `method.returnClock`. Near or past the window = due.
+- **Fit** — does this window suit them? Use `method.returnSeasonTransitionsToThisTarget`
+  (a guest whose `lastStaySeason` is a strong *source* season for this target fits — NOT "same
+  season"), `lastHadChildren` vs whether the occasion is a family window, `typicalNights` vs the
+  gap's nights, and `reviewThemes` vs the occasion.
+- **Relationship** — `tier` and `daysSinceLastOutbound`. Warm repeat/engaged guests are safe
+  ground; `unknown` (never contacted) is a real growth pool; a `complaintSignals > 0` guest is
+  fine to include but flag it so the copywriter handles the past issue with care (never hard-sell
+  someone with an unresolved problem).
+
+Prefer guests the window genuinely suits over the merely warm. Select up to the run cap; fewer,
+better-fitting is better than filling the cap. **Every pick gets a one-line reason** grounded in
+its dossier fields.
+
+**5. Or don't act.** If too few eligible guests actually fit, or there's no occasion and no
+credible angle, set `act: false` and say why. A thin, forced campaign burns goodwill; declining is
+a valid, valuable output. Do not pad the list to look busy.
+
+## Output format
+
+```
+PLAN — <property> · <window> · <occasion or "no occasion">
+
+act: true | false        (if false, give the reason and stop)
+
+OCCASION & POINT
+  <the occasion, and why-come-now in one or two sentences>
+
+INTENT: gap_fill | share
+OFFER: <e.g. "10% off direct + firewood" or "first refusal, no discount"> — clears the ceiling? <yes, cite maxDiscountPct>
+
+AUDIENCE (<n> of <eligibleCount> eligible; cap <runCap>)
+  For each selected guest:
+    <firstName> (<guestId>) · tier · <one-line reason from the dossier: due? fit? relationship?>
+  Note any picks the copywriter must handle carefully (complaintSignals, issue in thread).
+
+ANGLE FOR THE COPYWRITER
+  The general message the copywriter will particularise per guest — the occasion, the point, the
+  offer, the tone. NOT final copy; a brief.
+
+REJECTED
+  Who/what you considered and dropped, and why (e.g. "the 13 unknown-tier summer guests: due but
+  the occasion is a family window and they last came as couples").
+
+CONFIDENCE
+  What's solid, what's a judgment call, what's thin (cite counts).
+```
+
+Then emit, at the very end, the **typed artifact** the next stages consume — a `CampaignBrief`
+JSON object conforming to `src/lib/growth/contracts.ts`, inside a fenced block. This is the
+machine handoff (the copywriter and `validatePlan` read it; the human reads the report above):
+
+```json
+{
+  "propertyId": "...",
+  "opportunity": { "id":"...", "propertyId":"...", "source":"named_period", "window":{"start":"...","end":"...","nights":0}, "daysOut":0, "occasion":{...}, "instrument":"whatsapp" },
+  "act": true,
+  "intent": "gap_fill",
+  "occasion": { "name": "...", "point": "..." },
+  "offer": { "discountPct": 10, "description": "first refusal + 10% off direct" },
+  "audience": [ { "guestId": "...", "angle": "due + summer→autumn fit + kids", "careFlags": ["complaint-in-thread"] } ],
+  "generalAngle": "the brief the copywriter will particularise per guest",
+  "rationale": "one paragraph"
+}
+```
+
+Every `audience[].guestId` must be in `audience.eligible` from the pack; `offer.discountPct` ≤
+`offer.maxDiscountPct` (or null). `validatePlan` (`src/lib/growth/validatePlan.ts`) enforces both.
+
+## If the validator rejects your brief
+
+`validatePlan` may reject the brief (an ineligible/invented id, over-cap, over-ceiling discount).
+When that happens you get the specific errors back — **fix exactly those and re-emit the brief**
+(re-select from `audience.eligible` only, or lower the discount to the ceiling). This is a bounded
+repair, not a redesign; after a second failed attempt it escalates to the human. Never work around
+a rejection by dropping the flagged ids and keeping the rest silently — re-reason the selection.
+
+## Guardrails
+
+- Every `audience[].guestId` must appear in `audience.eligible`. No exceptions.
+- Never exceed `constraints.runCap`. Never select from `ineligible`.
+- The offer must clear `offer.maxDiscountPct`.
+- You produce a plan and a brief. You do not write final messages and you do not send.
+- Reactivation is Romanian-only — already applied in the pack; don't second-guess it.
+- If the pack is missing or its `opportunity` is empty, say so and stop.

--- a/scripts/audit-guest-data.ts
+++ b/scripts/audit-guest-data.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env npx tsx
+/**
+ * audit-guest-data — data-quality audit of the reactivation audience, prompted by two issues the
+ * copywriter surfaced on a live draft run: a foreign guest filed as Romanian (Artem), and a
+ * firstName that disagrees with how the owner addresses the guest in-thread (Nica vs "Cristi").
+ *
+ * Read-only. Reports the guests to fix before a real send; changes nothing.
+ *
+ * Usage: npx tsx scripts/audit-guest-data.ts [--property prahova-mountain-chalet]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { getAdminDb } from '../src/lib/firebaseAdminSafe';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
+const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : null;
+
+// crude language sniff: Romanian vs English by stopword hits.
+const RO = /\b(si|sa|va|nu|ca|la|cu|de|pe|este|sunt|multumesc|buna|ziua|zile|casa|casuta|noapte|rezervare)\b/gi;
+const EN = /\b(the|and|you|for|are|is|we|thanks|thank|hello|hi|please|room|night|booking|stay|great)\b/gi;
+
+async function main() {
+  const db = await getAdminDb();
+  const [gSnap, bSnap, tSnap] = await Promise.all([
+    db.collection('guests').get(), db.collection('bookings').get(), db.collection('whatsappThreads').get(),
+  ]);
+  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
+  const owner = (process.env.WHATSAPP_OWNER_NAME || 'Bogdan Coman').split(' ')[0];
+
+  const guests = gSnap.docs.map(d => ({ id: d.id, ...(d.data() as any) })).filter(g => (g.propertyIds || []).includes(PROPERTY));
+  const isROclass = (g: any) => (g.language || '').toLowerCase() === 'ro' || ['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase());
+  const reachable = guests.filter(g => g.normalizedPhone && !g.unsubscribed);
+  const roClass = reachable.filter(isROclass);
+
+  console.log(`=== reactivation audience: ${roClass.length} RO-classified of ${reachable.length} reachable (property ${PROPERTY}) ===\n`);
+
+  // 1. classification basis — language tag vs country
+  const langOnly = roClass.filter(g => (g.language || '').toLowerCase() === 'ro' && !['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase()));
+  console.log(`1. CLASSIFIED RO BY LANGUAGE TAG BUT COUNTRY IS NOT RO: ${langOnly.length}`);
+  langOnly.forEach(g => console.log(`   ${g.id.slice(0, 8)} ${(g.firstName || '?').padEnd(12)} country=${g.country || '(none)'}`));
+
+  // 2. foreign-looking threads (owner or guest writing in English) among RO-classified
+  console.log(`\n2. RO-CLASSIFIED GUESTS WHOSE THREAD LOOKS ENGLISH (likely foreign, mis-filed):`);
+  let foreignThread = 0;
+  for (const g of roClass) {
+    const t = threads.get(g.id); const msgs = (t?.messages || []) as any[];
+    if (msgs.length < 3) continue;
+    const text = msgs.map(m => m.text || '').join(' ');
+    const ro = (text.match(RO) || []).length, en = (text.match(EN) || []).length;
+    if (en > ro && en >= 5) { foreignThread++; console.log(`   ${g.id.slice(0, 8)} ${(g.firstName || '?').padEnd(12)} country=${g.country || '?'} · EN hits ${en} vs RO ${ro} · ${msgs.length} msgs`); }
+  }
+  if (!foreignThread) console.log('   (none)');
+
+  // 3. name mismatch: how the owner addresses them ("Buna X") vs guest.firstName
+  console.log(`\n3. NAME MISMATCH (owner writes "Buna <X>" ≠ guest.firstName):`);
+  let mism = 0;
+  for (const g of roClass) {
+    const t = threads.get(g.id); const msgs = (t?.messages || []) as any[];
+    const greetings = msgs.filter(m => m.direction === 'out').map(m => (m.text || '').match(/\b(?:buna|salut|hei|hello|hi)\b[\s,!]+([A-ZȘȚĂÎÂ][a-zșțăîâ]+)/i)).filter(Boolean).map((x: any) => x[1]);
+    const addressed = [...new Set(greetings)];
+    const fn = (g.firstName || '').trim();
+    if (fn && addressed.length && !addressed.some((a: string) => a.toLowerCase() === fn.toLowerCase()) && !addressed.some((a: string) => a.toLowerCase() === owner.toLowerCase())) {
+      mism++; console.log(`   ${g.id.slice(0, 8)} record="${fn}" · addressed as ${JSON.stringify(addressed)}`);
+    }
+  }
+  if (!mism) console.log('   (none)');
+
+  // 4. foreign repeat guests — the exceptions to "foreigners don't return"
+  console.log(`\n4. FOREIGN REPEAT GUESTS (2+ stays, country not RO) — exceptions to the RO-only rule:`);
+  let fr = 0;
+  for (const g of guests) {
+    if (isROclass(g)) continue;
+    const stays = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter((b: any) => b && b.status !== 'cancelled' && toD(b.checkInDate)).length;
+    if (stays >= 2) { fr++; console.log(`   ${g.id.slice(0, 8)} ${(g.firstName || '?').padEnd(12)} country=${g.country || '?'} · ${stays} stays`); }
+  }
+  if (!fr) console.log('   (none)');
+
+  console.log(`\n=== SUMMARY ===`);
+  console.log(`  RO-classified reachable: ${roClass.length}`);
+  console.log(`  ├ by language tag only (country not RO): ${langOnly.length}  ← verify these are really Romanian`);
+  console.log(`  ├ thread looks English (likely foreign): ${foreignThread}  ← fix classification before a real send`);
+  console.log(`  └ name mismatch vs thread: ${mism}  ← fix firstName before a real send`);
+  console.log(`  Foreign repeat guests (out of RO scope today): ${fr}  ← decision: is reactivation "RO-only" or "RO + any repeat"?`);
+}
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/copywriter-pack.ts
+++ b/scripts/copywriter-pack.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env npx tsx
+/**
+ * copywriter-pack — the deterministic FACT PACK the WhatsApp copywriter drafts from.
+ *
+ * Given a planner CampaignBrief, for EACH selected guest it assembles: their full verbatim
+ * WhatsApp thread (for non-repetition + tone), their dossier, and — the crux — a `groundedFacts`
+ * whitelist: the explicit list of guest-specific facts the copywriter is ALLOWED to assert, each
+ * with provenance. Plus a shared voice profile (the owner's own past messages, outcome-labeled)
+ * and the voice rules. Facts + method + constraints, no conclusions (plan §2 pr.5 / §7.5–7.6).
+ *
+ * The grounding contract (plan §7.5): the copywriter tags every guest-specific claim with a
+ * groundedFacts key; validateDrafts checks factsUsed ⊆ groundedFacts. The thread is context for
+ * avoiding repetition and matching tone — it is NOT a source of new assertable facts (extracting
+ * checkable claims from free prose is undecidable; the whitelist is what keeps "only-true" enforceable).
+ *
+ * Usage:
+ *   npx tsx scripts/copywriter-pack.ts --brief /tmp/brief-autumn.json --out /tmp/cw-autumn.json
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import * as fs from 'fs';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { getAdminDb } from '../src/lib/firebaseAdminSafe';
+import { detectLanguage } from '../src/lib/growth/audience';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const briefFile = arg('brief'); const OUT = arg('out');
+const AS_OF = new Date(`${arg('as-of', new Date().toISOString().slice(0, 10))}T00:00:00Z`);
+if (!briefFile) { console.error('required: --brief <CampaignBrief.json>'); process.exit(1); }
+
+const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const days = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
+const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'winter' : m <= 5 ? 'spring' : m <= 8 ? 'summer' : 'autumn'; };
+function lastStayPhrase(last: Date | null): string | null {
+  if (!last) return null;
+  const y = last.getUTCFullYear(), nowY = AS_OF.getUTCFullYear();
+  const s = ({ winter: 'iarna', spring: 'primavara', summer: 'vara', autumn: 'toamna' } as any)[seasonOf(last)];
+  if (last.getUTCMonth() + 1 === 12 && last.getUTCDate() >= 27) return 'de Revelion';
+  return y === nowY ? `${s} aceasta` : y === nowY - 1 ? `${s} trecuta` : `in ${s} lui ${y}`;
+}
+
+async function main() {
+  const brief = JSON.parse(fs.readFileSync(briefFile, 'utf8'));
+  const wantIds: string[] = brief.audience.map((a: any) => a.guestId);
+  const careByGuest = new Map(brief.audience.map((a: any) => [a.guestId, a.careFlags || []]));
+
+  const db = await getAdminDb();
+  const [gSnap, bSnap, rSnap, tSnap] = await Promise.all([
+    db.collection('guests').get(), db.collection('bookings').get(),
+    db.collection('reviews').get(), db.collection('whatsappThreads').get(),
+  ]);
+  const guestById = new Map(gSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
+  const reviewsBy = new Map<string, any[]>();
+  rSnap.docs.forEach(d => { const r: any = { id: d.id, ...d.data() }; if (!r.guestId) return; (reviewsBy.get(r.guestId) || reviewsBy.set(r.guestId, []).get(r.guestId)!).push(r); });
+
+  // ── voice profile: the owner's own substantive outbound, outcome-labeled (§7.6) ──
+  const owner = process.env.WHATSAPP_OWNER_NAME || 'Bogdan Coman';
+  const exemplars: any[] = [];
+  tSnap.docs.forEach(d => {
+    const t: any = d.data(); const g = guestById.get(d.id);
+    const stays = g ? (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean) : [];
+    (t.messages || []).forEach((m: any, i: number) => {
+      if (m.direction !== 'out' || (m.text || '').length < 260) return;
+      const after = (t.messages || []).slice(i + 1);
+      const replied = after.some((x: any) => x.direction === 'in' && (+new Date(x.ts) - +new Date(m.ts)) / 86400000 <= 14);
+      const booked = stays.some((b: any) => { const c = toD(b.createdAt); return c && +c > +new Date(m.ts) && (+c - +new Date(m.ts)) / 86400000 <= 90; });
+      exemplars.push({ text: m.text, len: (m.text || '').length, outcome: booked ? 'booked' : replied ? 'replied' : 'silent', date: String(m.ts).slice(0, 10) });
+    });
+  });
+  // a diverse, outcome-varied set (prefer booked, then replied, then some silent; cap ~10)
+  exemplars.sort((a, b) => (b.outcome === 'booked' ? 1 : 0) - (a.outcome === 'booked' ? 1 : 0) || b.len - a.len);
+  const voiceExemplars = [
+    ...exemplars.filter(e => e.outcome === 'booked').slice(0, 3),
+    ...exemplars.filter(e => e.outcome === 'replied').slice(0, 5),
+    ...exemplars.filter(e => e.outcome === 'silent').slice(0, 2),
+  ].map(e => ({ outcome: e.outcome, date: e.date, text: e.text }));
+
+  // ── per-guest packs ──
+  const guests = wantIds.map(gid => {
+    const g: any = guestById.get(gid);
+    if (!g) return { guestId: gid, error: 'guest not found' };
+    const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
+      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
+      .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
+    const lastBk: any = stayB.length ? stayB[stayB.length - 1] : null;
+    const last = lastBk ? toD(lastBk.checkInDate) : null;
+    const rv = reviewsBy.get(gid) || [];
+    const reviewThemes = [...new Set(rv.flatMap((r: any) => { const t = r.tags; return Array.isArray(t) ? t : t && typeof t === 'object' ? Object.values(t).flat() : []; }))]
+      .filter(x => typeof x === 'string' && !/^\+\d+ more$/i.test(x));  // drop the "+N more" truncation artifact
+    const th = threads.get(gid);
+    const thread = ((th?.messages || []) as any[]).filter(m => m.ts < ymd(AS_OF)).map(m => ({ ts: m.ts, dir: m.direction, text: m.text }));
+    const totalBookings = g.totalBookings ?? stayB.length;
+    // which language to actually WRITE in — detected from the thread, because the `language` field
+    // is a blanket "ro" default across the base and does not reflect how the guest communicates.
+    const threadText = thread.map(m => m.text || '').join(' ');
+    const detected = detectLanguage(threadText);
+    const writeLanguage = detected === 'unknown' ? (g.language || 'ro') : detected;
+
+    // groundedFacts — the assertable whitelist (structured facts only; provenance attached).
+    const groundedFacts: any[] = [];
+    if (g.firstName) groundedFacts.push({ key: 'firstName', value: g.firstName, source: `guests/${gid}` });
+    if (last) groundedFacts.push({ key: 'lastStayPhrase', value: lastStayPhrase(last), source: `bookings/${lastBk.id}` });
+    if (last) groundedFacts.push({ key: 'lastStaySeason', value: seasonOf(last), source: `bookings/${lastBk.id}` });
+    if (lastBk?.numberOfGuests) groundedFacts.push({ key: 'partySize', value: lastBk.numberOfGuests, source: `bookings/${lastBk.id}` });
+    if (lastBk && (lastBk.numberOfChildren ?? 0) > 0) groundedFacts.push({ key: 'hadChildren', value: true, source: `bookings/${lastBk.id}` });
+    if (totalBookings >= 2) groundedFacts.push({ key: 'isRepeatGuest', value: totalBookings, source: `guests/${gid}` });
+    reviewThemes.forEach(t => groundedFacts.push({ key: `reviewPraised:${t}`, value: t, source: `reviews/${(rv[0] || {}).id || gid}` }));
+    // NOTE: no `issueResolved:*` facts are emitted here — the pack cannot know a problem was fixed.
+    // Those are owner-supplied (a future input); until then a complaint guest gets neutral treatment.
+
+    return {
+      guestId: gid,
+      firstName: g.firstName || null,
+      writeLanguage,                          // WRITE in this (thread-detected); the field is unreliable
+      recordLanguage: g.language || null,     // for reference only — blanket "ro", do not trust
+      threadLanguageDetected: detected,
+      careFlags: careByGuest.get(gid) || [],
+      dossier: {
+        tier: totalBookings >= 2 ? 'repeat' : 'single',
+        totalBookings,
+        lastStay: last ? ymd(last) : null,
+        lastStayPhrase: lastStayPhrase(last),
+        lastStaySeason: last ? seasonOf(last) : null,
+        partySize: lastBk?.numberOfGuests ?? null,
+        hadChildren: lastBk ? (lastBk.numberOfChildren ?? 0) > 0 : null,
+        reviewThemes,
+      },
+      groundedFacts,
+      thread,
+      threadNote: thread.length ? `${thread.length} prior messages — read to AVOID repeating what was already said, and to match tone. Do NOT assert a new guest-specific fact from the thread that is not in groundedFacts.` : 'no prior WhatsApp history — a first contact; include the opt-out line.',
+    };
+  });
+
+  const pack = {
+    meta: { generatedFor: brief.propertyId, asOf: ymd(AS_OF), generator: 'scripts/copywriter-pack.ts', briefId: brief.opportunity?.id },
+    campaign: { occasion: brief.occasion, offer: brief.offer, intent: brief.intent, generalAngle: brief.generalAngle },
+    voiceProfile: {
+      note: 'Imitate this register — these are the owner\'s REAL past messages, tagged by outcome (booked/replied/silent). Copy the voice, not the content. Prefer what "booked".',
+      exemplars: voiceExemplars,
+    },
+    voiceRules: {
+      language: 'Write each message in that guest\'s writeLanguage (thread-detected: "ro" or "en"). Romanian is written WITHOUT diacritics (matches the owner). Do NOT trust recordLanguage — it is a blanket "ro" default. An English-speaking expat living here (RO phone) gets an English message.',
+      length: '300–600 characters, 3–6 short sentences',
+      noEmoji: true,
+      selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',
+      optOut: 'include a soft opt-out line only on a FIRST contact (no prior thread); otherwise rely on WhatsApp block/report',
+      grounding: 'assert ONLY facts present in that guest\'s groundedFacts; tag each claim in factsUsed with its key. No emoji. No invented stays/preferences.',
+      sentiment: 'always positive. For a careFlag complaint: if (and only if) an issueResolved:* fact is present, you MAY add a warm PS acknowledging the fix; otherwise do NOT mention the past problem at all — write a normal forward-looking message.',
+    },
+    guests,
+  };
+
+  const json = JSON.stringify(pack, null, 2);
+  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB) · ${guests.length} guests · ${voiceExemplars.length} voice exemplars`); }
+  else console.log(json);
+}
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/planner-pack.ts
+++ b/scripts/planner-pack.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env npx tsx
+/**
+ * planner-pack — the deterministic FACT PACK the WhatsApp planner reasons over.
+ *
+ * Given ONE opportunity (a dated gap the analyst routed to WhatsApp), it computes the eligible
+ * Romanian audience with a per-guest dossier, the offer constraint, and the calendar occasion —
+ * facts + method + constraints, NO conclusions (plan §2 principle 5). The planner SKILL then
+ * selects a subset + angle + offer; a validator checks guestId ∈ eligible before anything queues;
+ * the executionGateway re-runs every gate at send time (the real backstop).
+ *
+ * Deliberately NOT pre-computed: any composite "fit"/"selection" score. Ranking the audience is
+ * the reasoning we want the planner to do, not a function we hand it. The pack gives raw inputs
+ * (recency, season match, kids, LOS shape, review themes); the planner weighs them.
+ *
+ * Usage:
+ *   npx tsx scripts/planner-pack.ts --start 2026-10-24 --end 2026-11-01 --out /tmp/plan.json
+ *   npx tsx scripts/planner-pack.ts --start 2026-08-21 --end 2026-08-31 --property prahova-mountain-chalet
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import * as fs from 'fs';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { getAdminDb } from '../src/lib/firebaseAdminSafe';
+import { isRomaniaBased } from '../src/lib/growth/audience';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
+const START = arg('start'); const END = arg('end');
+const AS_OF = new Date(`${arg('as-of', new Date().toISOString().slice(0, 10))}T00:00:00Z`);
+const OUT = arg('out');
+const RUN_CAP = Number(arg('cap', '20'));
+const FREQ_CAP_DAYS = 14;                                  // matches GROWTH_ENGINE_LIMITS.frequencyCapDays
+const PACING_FLOOR: Record<string, number> = { repeat: 14, engaged: 14, responsive: 30, unknown: 45, silent: 90 };
+
+if (!START || !END) { console.error('required: --start <YYYY-MM-DD> --end <YYYY-MM-DD>'); process.exit(1); }
+
+const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const days = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
+const round = (n: number, d = 0) => Number(n.toFixed(d));
+const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'winter' : m <= 5 ? 'spring' : m <= 8 ? 'summer' : 'autumn'; };
+const norm = (p: string) => (p || '').replace(/[^0-9]/g, '');
+
+// Romanian "when they last stayed" phrase — coarse, for the copywriter to refine.
+function lastStayPhrase(last: Date | null): string | null {
+  if (!last) return null;
+  const m = last.getUTCMonth() + 1, y = last.getUTCFullYear(), nowY = AS_OF.getUTCFullYear();
+  const season = ({ winter: 'iarna', spring: 'primăvara', summer: 'vara', autumn: 'toamna' } as any)[seasonOf(last)];
+  if (m === 12 && (last.getUTCDate() >= 27)) return 'de Revelion';
+  const rel = y === nowY ? `${season} aceasta` : y === nowY - 1 ? `${season} trecută` : `în ${season} lui ${y}`;
+  return rel;
+}
+
+async function main() {
+  const db = await getAdminDb();
+  const [bSnap, gSnap, rSnap, tSnap, sSnap, hSnap] = await Promise.all([
+    db.collection('bookings').get(),
+    db.collection('guests').get(),
+    db.collection('reviews').get(),
+    db.collection('whatsappThreads').get(),
+    db.collection('suppressionList').get(),
+    db.collection('holidays').get(),
+  ]);
+
+  const price = (b: any) => b.pricing?.total ?? b.pricing?.totalPrice ?? 0;
+  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
+  const reviewsBy = new Map<string, any[]>();
+  rSnap.docs.forEach(d => { const r: any = { id: d.id, ...d.data() }; if (!r.guestId) return; (reviewsBy.get(r.guestId) || reviewsBy.set(r.guestId, []).get(r.guestId)!).push(r); });
+  const suppressed = new Set(sSnap.docs.map(d => norm((d.data() as any).normalizedPhone || '').slice(-9)).filter(Boolean));
+
+  // ---------- opportunity ----------
+  const start = new Date(`${START}T00:00:00Z`), end = new Date(`${END}T00:00:00Z`);
+  const nights = days(start, end);
+  const targetSeason = seasonOf(start);
+  // occasion: a holiday/school-break overlapping the window
+  const occ = hSnap.docs.map(d => d.data() as any)
+    .filter(h => h.startDate <= END && h.endDate >= START)
+    .sort((a, b) => String(a.startDate).localeCompare(String(b.startDate)))[0];
+
+  // ---------- offer constraint (net-to-owner ADR; the inequality from plan §0.5) ----------
+  // net ADR by channel from the last ~18 months of stays (amounts are net-to-owner, plan §7.11).
+  const recentNights: { src: string; rate: number }[] = [];
+  bookingById.forEach((b: any) => {
+    const ci = toD(b.checkInDate), co = toD(b.checkOutDate);
+    if (b.propertyId !== PROPERTY || b.status === 'cancelled' || !ci || !co) return;
+    if (days(ci, AS_OF) > 550 || ci > AS_OF) return;
+    const los = Math.max(1, days(ci, co)); const per = price(b) / los;
+    for (let d = new Date(ci); d < co; d = new Date(+d + 86400000)) recentNights.push({ src: b.source || '?', rate: per });
+  });
+  const netAdr = (src: string) => { const a = recentNights.filter(n => n.src === src); return a.length ? round(a.reduce((s, n) => s + n.rate, 0) / a.length) : null; };
+  const directNet = netAdr('direct'), airbnbNet = netAdr('airbnb'), bookingNet = netAdr('booking.com');
+  const otaNetToBeat = Math.max(airbnbNet ?? 0, bookingNet ?? 0) || null;
+  const maxDiscountPct = directNet && otaNetToBeat ? Math.max(0, Math.floor((1 - otaNetToBeat / directNet) * 100)) : null;
+
+  // ---------- per-guest dossiers + eligibility (Romanian reachable) ----------
+  const guests = gSnap.docs.map(d => ({ id: d.id, ...(d.data() as any) })).filter(g => (g.propertyIds || []).includes(PROPERTY));
+  const dossiers: any[] = [];
+  for (const g of guests) {
+    const reachable = !!g.normalizedPhone && !g.unsubscribed;
+    if (!reachable) continue;
+
+    const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
+      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
+      .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
+    // operating constraint: reactivation = guests BASED IN ROMANIA (RO phone / country), or a
+    // proven repeat returner — NOT "ethnically Romanian". Foreign expats living here qualify;
+    // one-off foreign tourists (foreign phone, single stay) do not. See src/lib/growth/audience.ts.
+    if (!isRomaniaBased({ normalizedPhone: g.normalizedPhone, phone: g.phone, country: g.country, stays: stayB.length })) continue;
+    const stays = stayB.map((b: any) => toD(b.checkInDate)!);
+    const last = stays.length ? stays[stays.length - 1] : null;
+    const lastBk: any = stayB.length ? stayB[stayB.length - 1] : null;
+
+    const th = threads.get(g.id);
+    const msgs = (th?.messages || []) as any[];
+    const inbound = msgs.filter(m => m.direction === 'in' && m.ts < ymd(AS_OF)).length;
+    const outbound = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).length;
+    const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
+    const daysSinceOut = lastOut ? days(new Date(`${lastOut}T00:00:00Z`), AS_OF) : null;
+
+    const totalBookings = g.totalBookings ?? stays.length;
+    const tier = totalBookings >= 2 ? 'repeat' : inbound >= 3 ? 'engaged' : inbound >= 1 ? 'responsive' : outbound >= 1 ? 'silent' : 'unknown';
+
+    // coarse complaint signal (the copywriter does the real sentiment read over the full thread)
+    const complaintRe = /problem|nu merge|stricat|defect|rece|frig|murdar|nu funct|nu mai merge|scurgere|presiune/i;
+    const complaintSignals = msgs.filter(m => m.direction === 'in' && complaintRe.test(m.text || '')).length;
+
+    // review themes (raw — the planner matches to the occasion; not pre-scored).
+    // review.tags is {category: [attribute strings]} — flatten the attributes to a clean list.
+    const rv = reviewsBy.get(g.id) || [];
+    const reviewText = rv.map(r => r.comment || '').filter(Boolean).join(' ').slice(0, 400);
+    const reviewTags = [...new Set(rv.flatMap(r => {
+      const t = r.tags;
+      if (Array.isArray(t)) return t;
+      if (t && typeof t === 'object') return Object.values(t).flat();
+      return [];
+    }))].filter(x => typeof x === 'string');
+
+    // eligibility gates (mirror executionGateway; the gateway re-checks at send)
+    const reasons: string[] = [];
+    if (suppressed.has(norm(g.normalizedPhone || '').slice(-9))) reasons.push('suppressed');
+    if (g.unsubscribed) reasons.push('unsubscribed');
+    const activeFuture = stayB.some((b: any) => { const e = toD(b.checkOutDate) ?? toD(b.checkInDate); return e && +e >= Date.UTC(AS_OF.getUTCFullYear(), AS_OF.getUTCMonth(), AS_OF.getUTCDate()); });
+    if (activeFuture) reasons.push('active-future-booking');
+    const lastCampaignAt = toD(g.lastCampaignAt);
+    if (lastCampaignAt && days(lastCampaignAt, AS_OF) < FREQ_CAP_DAYS) reasons.push('frequency-cap');
+    if (daysSinceOut !== null && daysSinceOut < PACING_FLOOR[tier]) reasons.push(`pacing-floor-${tier}(${PACING_FLOOR[tier]}d)`);
+
+    dossiers.push({
+      guestId: g.id,
+      firstName: g.firstName || null,
+      eligible: reasons.length === 0,
+      ineligibleReasons: reasons,
+      tier,
+      totalBookings,
+      lastStay: last ? ymd(last) : null,
+      daysSinceLastStay: last ? days(last, AS_OF) : null,
+      lastStaySeason: last ? seasonOf(last) : null,       // raw — match against returnSeasonTransitions, NOT "same season"
+      lastStayPhrase: lastStayPhrase(last),
+      lastPartySize: lastBk?.numberOfGuests ?? null,
+      lastHadChildren: lastBk ? (lastBk.numberOfChildren ?? 0) > 0 : null,
+      typicalNights: stays.length ? round(stayB.reduce((s: number, b: any) => s + Math.max(1, days(toD(b.checkInDate)!, toD(b.checkOutDate)!)), 0) / stays.length, 1) : null,
+      hasReviewText: reviewText.length > 40,
+      reviewThemes: reviewTags,
+      reviewText: reviewText || null,
+      complaintSignals,
+      inboundMessages: inbound,
+      daysSinceLastOutbound: daysSinceOut,
+    });
+  }
+
+  const eligible = dossiers.filter(d => d.eligible);
+
+  // live return-season-transition matrix over Romania-based repeat guests (the fit signal: a guest
+  // whose last-stay season → target season is a common transition is a good fit, NOT "same season").
+  const transitions = new Map<string, number>();
+  guests.forEach(g => {
+    const st = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
+      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
+      .map((b: any) => toD(b.checkInDate)!).sort((a: Date, b: Date) => +a - +b);
+    if (!isRomaniaBased({ normalizedPhone: g.normalizedPhone, phone: g.phone, country: g.country, stays: st.length })) return;
+    for (let i = 1; i < st.length; i++) transitions.set(`${seasonOf(st[i - 1])}->${seasonOf(st[i])}`, (transitions.get(`${seasonOf(st[i - 1])}->${seasonOf(st[i])}`) || 0) + 1);
+  });
+  const transitionsToTarget = Object.fromEntries([...transitions.entries()].filter(([k]) => k.endsWith(`->${targetSeason}`)).sort((a, b) => b[1] - a[1]));
+
+  const pack = {
+    meta: { generatedFor: PROPERTY, asOf: ymd(AS_OF), generator: 'scripts/planner-pack.ts' },
+    opportunity: {
+      window: { start: START, end: END, nights },
+      daysOut: days(AS_OF, start),
+      targetSeason,
+      occasion: occ ? { name: occ.name, type: occ.type, startDate: occ.startDate, endDate: occ.endDate, source: occ.source ?? null } : null,
+      occasionNote: occ ? 'a real holiday/school-break overlaps this window — a true reason to borrow' : 'NO calendar occasion overlaps this window — the message must supply its own reason, the weakest case',
+    },
+    offer: {
+      note: 'Amounts are net-to-owner (plan §7.11). The inequality: directNet × (1 − discount) must stay above otaNetToBeat, or a discount gives away the direct-channel advantage. The planner picks a discount ≤ maxDiscountPct, or none (a first-refusal/no-discount angle is often stronger — plan §7.0).',
+      directNetAdr: directNet, airbnbNetAdr: airbnbNet, bookingNetAdr: bookingNet,
+      otaNetToBeat, maxDiscountPct,
+    },
+    constraints: {
+      runCap: RUN_CAP,
+      note: `Select AT MOST ${RUN_CAP} guests. Reactivation is Romanian-only (already applied). Quiet hours 21:00→09:00 Bucharest are enforced at send. Every selected guestId must be in the eligible set below (a validator rejects the whole plan otherwise).`,
+      pacingFloorsDays: PACING_FLOOR,
+      frequencyCapDays: FREQ_CAP_DAYS,
+    },
+    method: {
+      note: 'Choose WHO (a subset of eligible), the occasion/angle, and the offer. This pack gives raw dossier inputs, NOT a ranking — the selection is your reasoning. Weigh: is the guest DUE (days-since-stay against the return clock)? Does the window FIT them (see below), and does the OCCASION suit them (a school break is a kids window; a quiet weekend suits adults-only)? Prefer people the window actually suits over the merely warm. Do not exceed the run cap. Give a per-guest reason and say what you rejected.',
+      returnClock: { medianDays: 147, p25: 76, p75: 278, note: 'days-since-last-stay near/after this range = due' },
+      fitInputs: 'Per dossier: lastStaySeason (match via returnSeasonTransitionsToThisTarget below, NOT "same season"), lastHadChildren (vs whether this is a family window), typicalNights (vs the gap\'s nights), reviewThemes (vs the occasion — e.g. "Peaceful"/"Private" suit a quiet escape).',
+      returnSeasonTransitionsToThisTarget: transitionsToTarget,
+      returnSeasonTransitionsNote: `how often a guest whose last stay was in season X returned in ${targetSeason} (X->${targetSeason}). A guest whose lastStaySeason is a strong source here fits this window even though it is a different season.`,
+    },
+    audience: {
+      romaniaBasedReachable: dossiers.length,
+      eligibleCount: eligible.length,
+      ineligibleCount: dossiers.length - eligible.length,
+      eligible,
+      ineligible: dossiers.filter(d => !d.eligible).map(d => ({ guestId: d.guestId, tier: d.tier, reasons: d.ineligibleReasons })),
+    },
+  };
+
+  const json = JSON.stringify(pack, null, 2);
+  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB) · ${eligible.length} eligible of ${dossiers.length} RO`); }
+  else console.log(json);
+}
+main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/validate-plan.ts
+++ b/scripts/validate-plan.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env npx tsx
+/**
+ * validate-plan — CLI wrapper around src/lib/growth/validatePlan.ts (the pure planner-stage gate).
+ * Runs the same check the in-app orchestration will, on a planner pack + the planner's selection.
+ *
+ * Usage:
+ *   npx tsx scripts/validate-plan.ts --pack /tmp/plan-autumn.json --ids '["id1","id2"]' [--discount 10] [--no-act]
+ *
+ * Exit code 0 = valid, 1 = rejected — so it can gate a pipeline.
+ */
+import * as fs from 'fs';
+import { validatePlan } from '../src/lib/growth/validatePlan';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const packFile = arg('pack');
+const idsRaw = arg('ids', '[]')!;
+const discount = arg('discount');
+const act = !process.argv.includes('--no-act');
+
+if (!packFile) { console.error('required: --pack <planner-pack.json> --ids \'["..."]\''); process.exit(2); }
+
+const pack = JSON.parse(fs.readFileSync(packFile, 'utf8'));
+let ids: string[];
+try { ids = JSON.parse(idsRaw); } catch { console.error('--ids must be a JSON array'); process.exit(2); }
+
+// Adapt CLI args into a minimal CampaignBrief shape (the real pipeline passes a full brief file).
+const res = validatePlan(pack, {
+  act,
+  audience: ids.map((guestId) => ({ guestId, angle: '' })),
+  offer: { discountPct: discount != null ? Number(discount) : null, description: '' },
+});
+
+console.log(`plan validation — ${res.ok ? 'PASS ✅' : 'REJECT ❌'}`);
+console.log(`  selected ${res.stats.selected} · eligible ${res.stats.eligible} · cap ${res.stats.runCap}`);
+res.errors.forEach((e) => console.log(`  ✖ ${e}`));
+res.warnings.forEach((w) => console.log(`  ⚠ ${w}`));
+process.exit(res.ok ? 0 : 1);

--- a/src/lib/growth/audience.ts
+++ b/src/lib/growth/audience.ts
@@ -1,0 +1,51 @@
+/**
+ * audience — the shared predicate for who the reactivation engine may reach.
+ *
+ * Owner's framing (2026-07-24): the criterion is "lives in Romania" (can realistically come to the
+ * chalet), NOT "is ethnically Romanian." A foreigner with a Romanian phone who speaks English still
+ * qualifies — the language field just tells the copywriter which language to write in (and is
+ * unreliable anyway: everyone is blanket-tagged "ro", so detect from the thread, not the field).
+ *
+ * Signal, in order of trust:
+ *   1. Romanian phone (+40) — strongest "based here" signal.
+ *   2. country === RO.
+ *   3. a repeat guest (2+ stays) — a proven returner is worth reaching regardless of where they
+ *      live (Artem ×3, Bianca ×2 are foreign but came back). Owner-endorsed extension.
+ *
+ * NOTE: the `language: "ro"` tag is a blanket default across the base and does NOT reflect the
+ * language the guest actually communicates in — do not use it to decide Romanian-ness.
+ *
+ * Pure — importable by every pack and by the eventual in-app orchestration.
+ */
+
+/** True if the phone is a Romanian number (+40 / 0040 / bare 40…). */
+export function hasRomanianPhone(phone: string | undefined | null): boolean {
+  const p = (phone || '').replace(/[^0-9+]/g, '');
+  if (p.startsWith('+40') || p.startsWith('0040')) return true;
+  // bare national/E.164-without-plus: 40 followed by a 9-digit RO subscriber number
+  if (/^40\d{9}$/.test(p)) return true;
+  return false;
+}
+
+export interface RomaniaBasedInput {
+  normalizedPhone?: string | null;
+  phone?: string | null;
+  country?: string | null;
+  stays?: number;   // non-cancelled stays (for the repeat-returner extension)
+}
+
+/** Is this guest reachable domestically for reactivation ("lives in Romania", or a proven repeat)? */
+export function isRomaniaBased(g: RomaniaBasedInput): boolean {
+  if (hasRomanianPhone(g.normalizedPhone) || hasRomanianPhone(g.phone)) return true;
+  if (['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase())) return true;
+  if ((g.stays ?? 0) >= 2) return true;   // repeat returner — worth it regardless of location
+  return false;
+}
+
+/** Coarse thread-language sniff for the copywriter: which language to actually write in. */
+export function detectLanguage(text: string): 'ro' | 'en' | 'unknown' {
+  const ro = (text.match(/\b(si|sa|va|nu|ca|la|cu|de|pe|este|sunt|multumesc|buna|ziua|casa|casuta|noapte|rezervare|zile)\b/gi) || []).length;
+  const en = (text.match(/\b(the|and|you|for|are|is|we|thanks|thank|hello|hi|please|room|night|booking|stay|great)\b/gi) || []).length;
+  if (ro === 0 && en === 0) return 'unknown';
+  return en > ro ? 'en' : 'ro';
+}

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -1,0 +1,68 @@
+/**
+ * contracts — the typed artifacts the Opportunity-Engine stages pass to each other.
+ *
+ * The pipeline is analyst → planner → copywriter → the existing admin/outbox flow. Each stage
+ * emits a human-readable report AND a JSON object conforming to the schema here; the next stage
+ * consumes that object. In the skill/prototype phase the "bus" is just files on disk; the same
+ * types are reused unchanged when the chain is orchestrated in-app. Keeping the contracts in one
+ * place is what lets disparate agents communicate structurally (plan §2 principle 4).
+ *
+ * Pure types + a couple of pure guards — no Firestore, no network.
+ */
+import type { LanguageCode } from '@/types';
+
+// ── analyst → planner ────────────────────────────────────────────────────────
+/** One routed opportunity the analyst decided WhatsApp should act on (plan §3.1). */
+export interface Opportunity {
+  id: string;
+  propertyId: string;
+  source: 'gap' | 'named_period' | 'cancellation';
+  window: { start: string; end: string; nights: number };   // YYYY-MM-DD
+  daysOut: number;
+  occasion?: { name: string; type: string; startDate: string; endDate: string; source?: string | null } | null;
+  valueAtRisk?: number | null;                              // nights × baseline ADR, if known
+  instrument: 'whatsapp';                                   // the analyst routed it here
+  rationale?: string;
+}
+
+// ── planner → copywriter / validator / createManualCampaign ──────────────────
+export type CampaignIntent = 'gap_fill' | 'share';
+
+/** One selected recipient, with the planner's per-guest reasoning. */
+export interface BriefAudienceEntry {
+  guestId: string;
+  angle: string;                 // why this guest, in one line (due? fit? relationship?)
+  careFlags?: string[];          // e.g. ['complaint-in-thread'] — the copywriter must handle gently
+}
+
+/** The planner's typed output — validated before anything queues (plan §7.4). */
+export interface CampaignBrief {
+  propertyId: string;
+  opportunity: Opportunity;
+  act: boolean;                  // false = decline; audience must then be empty
+  intent: CampaignIntent;
+  occasion: { name: string | null; point: string };   // the "what & why now"
+  offer: { discountPct: number | null; description: string };
+  audience: BriefAudienceEntry[];                       // ⊆ the eligible set (enforced by validatePlan)
+  generalAngle: string;                                 // the brief the copywriter particularises
+  rationale: string;
+}
+
+// ── copywriter → grounding validator / outbox ────────────────────────────────
+/** One drafted, per-guest message (plan §7.5). `factsUsed` is the grounding contract. */
+export interface DraftMessage {
+  guestId: string;
+  language: LanguageCode;
+  body: string;
+  factsUsed: string[];           // every guest-specific claim, each keyed to a groundedFacts entry
+  careHandled?: string;          // how a careFlag was addressed (e.g. resolved-issue PS)
+}
+
+// ── pure guards ──────────────────────────────────────────────────────────────
+export function briefGuestIds(brief: Pick<CampaignBrief, 'audience'>): string[] {
+  return brief.audience.map((a) => a.guestId);
+}
+
+export function isDeclined(brief: Pick<CampaignBrief, 'act' | 'audience'>): boolean {
+  return !brief.act && brief.audience.length === 0;
+}

--- a/src/lib/growth/validateDrafts.ts
+++ b/src/lib/growth/validateDrafts.ts
@@ -1,0 +1,94 @@
+/**
+ * validateDrafts — the deterministic gate between the WhatsApp copywriter (an LLM) and the outbox.
+ * The COPYWRITER-stage validator; the planner-stage one is validatePlan. It enforces the three
+ * duties from plan §7.6–7.7:
+ *
+ *   1. Grounding   — every declared factsUsed key exists in that guest's groundedFacts. This is a
+ *                    DECLARED-fact check, not prose-claim extraction (undecidable): the copywriter
+ *                    must declare each guest-specific claim, and we verify the declarations are all
+ *                    grounded. Also: no affection/"we-fixed-it" claim for a complaint guest unless a
+ *                    grounded issueResolved:* fact backs it.
+ *   2. Voice       — no emoji; self-ID present; length in range; opt-out iff first contact.
+ *   3. Coverage    — exactly one draft per selected guest, each with matching phone/language later
+ *                    (phone/lang are re-checked at send by executionGateway).
+ *
+ * Pure — importable by the prototype CLI and the eventual in-app orchestration. A failure feeds
+ * back to the copywriter (bounded repair, §7.4 pattern); never queue an ungrounded message.
+ */
+import type { DraftMessage } from './contracts';
+
+export interface GuestForDraftValidation {
+  guestId: string;
+  careFlags?: string[];
+  groundedFacts: Array<{ key: string; value: unknown }>;
+  thread: Array<unknown>;               // length 0 ⇒ first contact ⇒ opt-out required
+}
+
+export interface DraftRules {
+  minChars?: number; maxChars?: number;
+  selfIdMarkers?: string[];             // any one must appear (case-insensitive, diacritic-loose)
+  optOutMarkers?: string[];             // any one must appear on a first contact
+}
+
+const DEFAULTS: Required<DraftRules> = {
+  minChars: 200, maxChars: 700,
+  selfIdMarkers: ['bogdan', 'comarnic', 'casuta', 'căsuța'],
+  optOutMarkers: ['stop', 'dezabon', 'nu va mai', 'nu mai doriti', 'nu mai vreti', 'spuneti-mi', 'scrieti-mi', 'nu va mai deranjez'],
+};
+const EMOJI = /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{2B00}-\u{2BFF}️]/u;
+const COMPLAINT_WORDS = /problem|scuze|imi pare rau|îmi pare rău|neplac|deranj|presiune|defect|stricat|reparat|rezolvat/i;
+const loose = (s: string) => s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+
+export interface DraftsValidationResult {
+  ok: boolean;
+  perGuest: Array<{ guestId: string; errors: string[]; warnings: string[] }>;
+  errors: string[];   // campaign-level (coverage)
+}
+
+export function validateDrafts(
+  guests: GuestForDraftValidation[],
+  drafts: DraftMessage[],
+  rules: DraftRules = {}
+): DraftsValidationResult {
+  const r = { ...DEFAULTS, ...rules };
+  const byGuest = new Map(guests.map((g) => [g.guestId, g]));
+  const draftFor = new Map(drafts.map((d) => [d.guestId, d]));
+  const campaignErrors: string[] = [];
+
+  // coverage: exactly one draft per selected guest, and no draft for an unselected guest.
+  for (const g of guests) if (!draftFor.has(g.guestId)) campaignErrors.push(`no draft for selected guest ${g.guestId}`);
+  for (const d of drafts) if (!byGuest.has(d.guestId)) campaignErrors.push(`draft for a guest not in the brief: ${d.guestId}`);
+  const dupes = drafts.map((d) => d.guestId).filter((id, i, a) => a.indexOf(id) !== i);
+  if (dupes.length) campaignErrors.push(`multiple drafts for: ${[...new Set(dupes)].join(', ')}`);
+
+  const perGuest = drafts.filter((d) => byGuest.has(d.guestId)).map((d) => {
+    const g = byGuest.get(d.guestId)!;
+    const errors: string[] = []; const warnings: string[] = [];
+    const facts = new Set(g.groundedFacts.map((f) => f.key));
+    const body = d.body || '';
+
+    // 1. grounding — declared facts must all be whitelisted
+    const ungrounded = (d.factsUsed || []).filter((k) => !facts.has(k));
+    if (ungrounded.length) errors.push(`ungrounded factsUsed (not in groundedFacts): ${ungrounded.join(', ')}`);
+
+    // sentiment: complaint guest + no grounded resolution ⇒ must not touch the problem
+    const isComplaint = (g.careFlags || []).includes('complaint-in-thread');
+    const hasResolved = [...facts].some((k) => k.startsWith('issueResolved'));
+    if (isComplaint && !hasResolved && COMPLAINT_WORDS.test(body)) {
+      errors.push('references a past problem for a complaint guest with no grounded issueResolved fact — write forward-looking, do not mention it');
+    }
+
+    // 2. voice
+    if (EMOJI.test(body)) errors.push('contains emoji (forbidden)');
+    if (!r.selfIdMarkers.some((m) => loose(body).includes(loose(m)))) errors.push('no self-identification (open by saying who is writing)');
+    if (body.length < r.minChars) errors.push(`too short (${body.length} < ${r.minChars})`);
+    else if (body.length > r.maxChars) warnings.push(`long (${body.length} > ${r.maxChars})`);
+    const firstContact = (g.thread || []).length === 0;
+    if (firstContact && !r.optOutMarkers.some((m) => loose(body).includes(loose(m)))) warnings.push('first contact but no opt-out line found');
+
+    return { guestId: d.guestId, errors, warnings };
+  });
+
+  const ok = campaignErrors.length === 0 && perGuest.every((p) => p.errors.length === 0);
+  return { ok, perGuest, errors: campaignErrors };
+}

--- a/src/lib/growth/validatePlan.ts
+++ b/src/lib/growth/validatePlan.ts
@@ -1,0 +1,94 @@
+/**
+ * validatePlan — the deterministic gate between the WhatsApp planner (an LLM) and anything that
+ * queues. Enforces plan §2 principle 1 ("the LLM narrows, never widens") in CODE, not in a human
+ * spot-check: a planner is a language model, so the guarantee that it only ever selected eligible,
+ * in-cap, offer-legal guests has to be a pure function that runs every time.
+ *
+ * This is the PLANNER-stage validator (narrows-never-widens · run cap · offer inequality). The
+ * COPYWRITER-stage duties (grounding: only-true facts · voice conformance · self-ID/opt-out) are a
+ * separate validator that ships with the copywriter (§7.7). Keep them separate; they check
+ * different artifacts.
+ *
+ * Pure — no Firestore, no network — so it is exhaustively unit-testable and safe to import from
+ * both the prototype CLI (scripts/validate-plan.ts) and the eventual in-app orchestration.
+ * The executionGateway re-runs its own gates at send time regardless; this is the earlier,
+ * campaign-level backstop that stops a bad plan from ever reaching the outbox.
+ */
+
+import type { CampaignBrief } from './contracts';
+
+/** The subset of the planner pack this validator needs. */
+export interface PlannerPackForValidation {
+  constraints: { runCap: number };
+  offer: { maxDiscountPct: number | null };
+  audience: {
+    eligible: Array<{ guestId: string }>;
+    ineligible?: Array<{ guestId: string }>;
+  };
+}
+
+export interface PlanValidationResult {
+  ok: boolean;
+  errors: string[];   // hard failures — reject the whole plan (feed back to the planner; §7.4 repair loop)
+  warnings: string[]; // worth surfacing at Gate 1 but not blocking
+  stats: { selected: number; eligible: number; runCap: number };
+}
+
+/**
+ * Validate a planner CampaignBrief against its pack. The errors are written to be repair-prompt-
+ * ready: on failure, feed them back to the planner (bounded to 1–2 retries), then escalate to the
+ * human. Never silently drop the offending ids and proceed — that hides a reasoning defect.
+ */
+export function validatePlan(
+  pack: PlannerPackForValidation,
+  brief: Pick<CampaignBrief, 'act' | 'audience' | 'offer'>
+): PlanValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const eligible = new Set(pack.audience.eligible.map((g) => g.guestId));
+  const ineligible = new Set((pack.audience.ineligible ?? []).map((g) => g.guestId));
+  const ids = brief.audience.map((a) => a.guestId);
+  const cap = pack.constraints.runCap;
+
+  // A plan that declined to act is valid iff it selected nobody.
+  if (!brief.act) {
+    if (ids.length > 0) {
+      errors.push(`act:false but ${ids.length} guest(s) selected — a declined plan must select nobody`);
+    }
+    return { ok: errors.length === 0, errors, warnings, stats: { selected: ids.length, eligible: eligible.size, runCap: cap } };
+  }
+
+  // 1. Narrows-never-widens: every selected id must be in the eligible set.
+  const notEligible = ids.filter((id) => !eligible.has(id));
+  if (notEligible.length) {
+    // Distinguish "reached into the ineligible set" from "invented an id" — different failure modes.
+    const fromIneligible = notEligible.filter((id) => ineligible.has(id));
+    const invented = notEligible.filter((id) => !ineligible.has(id));
+    if (fromIneligible.length) errors.push(`selected ${fromIneligible.length} INELIGIBLE guest(s): ${fromIneligible.join(', ')}`);
+    if (invented.length) errors.push(`selected ${invented.length} UNKNOWN guest id(s) not in the pack: ${invented.join(', ')}`);
+  }
+
+  // 2. No duplicates.
+  const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+  if (dupes.length) errors.push(`duplicate guest id(s): ${[...new Set(dupes)].join(', ')}`);
+
+  // 3. Run cap.
+  if (ids.length > cap) errors.push(`selected ${ids.length} > run cap ${cap}`);
+
+  // 4. Empty acting plan.
+  if (ids.length === 0) errors.push('act:true but no guests selected');
+
+  // 5. Offer inequality: a discount must not exceed the ceiling that keeps direct above OTA net.
+  const d = brief.offer?.discountPct;
+  if (d != null && d > 0) {
+    const ceiling = pack.offer.maxDiscountPct;
+    if (ceiling == null) {
+      warnings.push(`a ${d}% discount was set but the pack has no maxDiscountPct (missing net-ADR data) — confirm the offer manually`);
+    } else if (d > ceiling) {
+      errors.push(`discount ${d}% exceeds the ceiling ${ceiling}% — it would give away the direct-channel margin (§0.5 offer inequality)`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings, stats: { selected: ids.length, eligible: eligible.size, runCap: cap } };
+}


### PR DESCRIPTION
The execution half of the Opportunity Engine. Following the analyst pattern: each stage is an LLM skill reasoning over a deterministic fact pack, tied by typed contracts and gated by pure-function validators. Prototype runtime (Claude Code skills); the pure `src/lib/growth/` pieces are built to be reused by the eventual in-app orchestration.

## Pipeline
`analyst → planner → copywriter → (existing Gate-1/outbox/wa.me)`, handoffs as typed artifacts:
`Opportunity → CampaignBrief → DraftMessage`.

## What's in it
- **`src/lib/growth/contracts.ts`** — the typed handoffs between stages.
- **`src/lib/growth/audience.ts`** — `isRomaniaBased` (reactivation = *lives in Romania* by phone/country, or a proven repeat returner — not ethnicity; foreign expats living here qualify) + `detectLanguage` (the `language` field is a blanket `ro`; write in the thread-detected language).
- **`src/lib/growth/validatePlan.ts`** — planner-stage gate: narrows-never-widens, run cap, offer inequality (principle 1, enforced in code).
- **`src/lib/growth/validateDrafts.ts`** — copywriter-stage gate: grounding (`factsUsed ⊆ groundedFacts`), no emoji, self-ID, length, sentiment (no false warmth, no unresolved-issue reference).
- **`scripts/planner-pack.ts`** + **`.claude/skills/whatsapp-planner`** — who + occasion + offer → `CampaignBrief`. No pre-computed selection score (the ranking is the planner's reasoning, principle 5).
- **`scripts/copywriter-pack.ts`** + **`.claude/skills/whatsapp-copywriter`** — per-guest grounded, voice-matched drafts from each guest's full thread + a `groundedFacts` whitelist + outcome-labeled voice exemplars → `DraftMessage[]`.
- **`scripts/validate-plan.ts`**, **`scripts/audit-guest-data.ts`** — CLI wrappers.

## Validation
Blind cold runs of both skills reproduced correct behaviour (planner: 20/20 selections in-eligible, first-refusal-over-discount, family-window fit; copywriter: grounded, voice-matched, self-flagged two real data issues). Injected-violation tests confirm both validators reject ineligible/invented ids, over-ceiling discounts, ungrounded claims, and emoji.

## Scope / runtime
Non-runtime: nothing here is imported by the running app — the scripts run via `npx tsx` and the skills run in Claude Code. `npm run build` passes. The `src/lib/growth/` functions are pure and ready to be imported by the in-app orchestration (the next phase). Two guest records were corrected in Firestore separately (name fixes surfaced by the audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)