### PR TITLE
feat: opportunity-engine landing — prepared campaign → Gate-1 review → outbox

### DIFF
--- a/scripts/land-campaign.ts
+++ b/scripts/land-campaign.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env npx tsx
+/**
+ * land-campaign — turn a validated planner brief + copywriter drafts into a reviewable DRAFT
+ * campaign in Firestore (the Opportunity-Engine "landing"). This is the operator entry point;
+ * the eventual in-app orchestration calls the same `createProposedCampaign` after the LLM stages.
+ *
+ * It does NOT queue or send anything — it writes a status:'draft' campaign with the per-guest
+ * bodies and the campaign-level proposal. The owner reviews it at Gate 1 in /admin/campaigns,
+ * then approves → outbox → Gate-2 wa.me. All guardrails re-run at send time regardless.
+ *
+ * Usage:
+ *   npx tsx scripts/land-campaign.ts --brief /tmp/brief.json --drafts /tmp/drafts.json \
+ *     [--name "Autumn gap – RO past guests"] [--plan-pack /tmp/plan.json] [--copy-pack /tmp/copy.json]
+ *
+ * If --plan-pack / --copy-pack are given, it re-validates (validatePlan / validateDrafts) and
+ * REFUSES to land on any hard error — defense in depth. Without them it trusts upstream validation
+ * and warns. Exit 0 = landed, 1 = rejected/failed.
+ */
+import * as fs from 'fs';
+import { validatePlan } from '../src/lib/growth/validatePlan';
+import { validateDrafts, type GuestForDraftValidation } from '../src/lib/growth/validateDrafts';
+import { briefGuestIds, type CampaignBrief, type DraftMessage } from '../src/lib/growth/contracts';
+import { createProposedCampaign } from '../src/services/campaignService';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const readJson = (p: string) => JSON.parse(fs.readFileSync(p, 'utf8'));
+
+async function main() {
+  const briefFile = arg('brief');
+  const draftsFile = arg('drafts');
+  if (!briefFile || !draftsFile) {
+    console.error('required: --brief <brief.json> --drafts <drafts.json> [--name ...] [--plan-pack ...] [--copy-pack ...]');
+    process.exit(2);
+  }
+
+  const brief = readJson(briefFile) as CampaignBrief;
+  const drafts = readJson(draftsFile) as DraftMessage[];
+  const planPackFile = arg('plan-pack');
+  const copyPackFile = arg('copy-pack');
+
+  // ── re-validate if the packs are provided (the same gates the orchestrator runs) ──
+  if (planPackFile) {
+    const pv = validatePlan(readJson(planPackFile), { act: brief.act, audience: brief.audience, offer: brief.offer });
+    console.log(`plan validation — ${pv.ok ? 'PASS' : 'REJECT'} (selected ${pv.stats.selected} · eligible ${pv.stats.eligible} · cap ${pv.stats.runCap})`);
+    pv.errors.forEach((e) => console.log(`  ✖ ${e}`));
+    pv.warnings.forEach((w) => console.log(`  ⚠ ${w}`));
+    if (!pv.ok) { console.error('refusing to land — plan invalid'); process.exit(1); }
+  } else {
+    console.log('⚠ no --plan-pack given — trusting upstream validatePlan');
+  }
+
+  if (copyPackFile) {
+    const copyPack = readJson(copyPackFile);
+    const guests: GuestForDraftValidation[] = (copyPack.guests ?? copyPack).map((g: {
+      guestId: string; careFlags?: string[]; groundedFacts?: Array<{ key: string; value: unknown }>; thread?: unknown[];
+    }) => ({
+      guestId: g.guestId,
+      careFlags: g.careFlags ?? [],
+      groundedFacts: g.groundedFacts ?? [],
+      thread: g.thread ?? [],
+    }));
+    const dv = validateDrafts(guests, drafts);
+    console.log(`draft validation — ${dv.ok ? 'PASS' : 'REJECT'}`);
+    dv.errors.forEach((e) => console.log(`  ✖ ${e}`));
+    dv.perGuest.forEach((p) => { p.errors.forEach((e) => console.log(`  ✖ ${p.guestId}: ${e}`)); p.warnings.forEach((w) => console.log(`  ⚠ ${p.guestId}: ${w}`)); });
+    if (!dv.ok) { console.error('refusing to land — drafts invalid'); process.exit(1); }
+  } else {
+    console.log('⚠ no --copy-pack given — trusting upstream validateDrafts');
+  }
+
+  const name = arg('name') || `${brief.occasion.name ?? 'Campaign'} — ${briefGuestIds(brief).length} recipients`;
+  const campaignId = await createProposedCampaign({ name, brief, drafts });
+
+  console.log(`\n✅ landed draft campaign ${campaignId}`);
+  console.log(`   ${briefGuestIds(brief).length} recipients · offer ${brief.offer.discountPct ?? 0}% · occasion "${brief.occasion.name ?? '(none)'}"`);
+  console.log(`   review at /admin/campaigns/${campaignId} → approve → outbox → wa.me`);
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/admin/campaigns/[id]/page.tsx
+++ b/src/app/admin/campaigns/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getCampaign } from '@/services/campaignService';
 import type { MessageVariant } from '@/types';
 import { MessageComposer } from '../_components/message-composer';
 import { OutboxSender } from '../_components/outbox-sender';
+import { ProposalReview } from '../_components/proposal-review';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,14 +29,19 @@ export default async function CampaignWorkspacePage({
   const isDraft = campaign.status === 'draft';
   const variants = (campaign.messageVariants ?? []) as MessageVariant[];
   const audienceCount = campaign.audienceGuestIds?.length ?? 0;
+  // A landed Opportunity-Engine proposal has per-guest drafts already written — Gate 1
+  // reviews those instead of the manual variant composer.
+  const isProposal = ((campaign as unknown as { perGuestDrafts?: unknown[] }).perGuestDrafts?.length ?? 0) > 0;
 
   return (
     <AdminPage
       title={campaign.name}
       description={
-        isDraft
-          ? 'Write the message, preview exactly what each guest will get, then approve to queue it for sending.'
-          : 'Send each queued message from your own WhatsApp, one tap at a time.'
+        !isDraft
+          ? 'Send each queued message from your own WhatsApp, one tap at a time.'
+          : isProposal
+            ? 'Review the prepared campaign — each recipient’s own message and why they were chosen — then approve to queue it.'
+            : 'Write the message, preview exactly what each guest will get, then approve to queue it for sending.'
       }
     >
       <div className="mb-4">
@@ -46,10 +52,12 @@ export default async function CampaignWorkspacePage({
         </Link>
       </div>
 
-      {isDraft ? (
-        <MessageComposer campaignId={id} audienceCount={audienceCount} initialVariants={variants} />
-      ) : (
+      {!isDraft ? (
         <OutboxSender campaignId={id} status={campaign.status} />
+      ) : isProposal ? (
+        <ProposalReview campaignId={id} />
+      ) : (
+        <MessageComposer campaignId={id} audienceCount={audienceCount} initialVariants={variants} />
       )}
     </AdminPage>
   );

--- a/src/app/admin/campaigns/_components/proposal-review.tsx
+++ b/src/app/admin/campaigns/_components/proposal-review.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+/**
+ * Gate 1 — review a PREPARED proposal (the Opportunity-Engine path).
+ *
+ * Unlike the manual composer, the copy is already written: the planner picked the audience and
+ * the copywriter drafted a bespoke message per recipient. The owner reads the "what & why now",
+ * then each recipient's own message with the reason it was chosen, edits or excludes any, and
+ * approves. "Approve & queue" pushes the reviewed bodies through the gateway into the outbox — it
+ * sends nothing; the owner sends manually in Gate 2. All guardrails re-run at send time.
+ */
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Send, Trash2, Sparkles, Tag, CheckCircle2, Circle, AlertTriangle } from 'lucide-react';
+import { fetchProposalAction, approveProposalAction, discardDraftCampaignAction, type ProposalReviewRow } from '../actions';
+import type { CampaignProposal } from '@/lib/growth/contracts';
+
+export function ProposalReview({ campaignId }: { campaignId: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [approving, startApprove] = useTransition();
+  const [discarding, startDiscard] = useTransition();
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [proposal, setProposal] = useState<CampaignProposal | null>(null);
+  const [rows, setRows] = useState<ProposalReviewRow[]>([]);
+  const [bodies, setBodies] = useState<Record<string, string>>({});
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let alive = true;
+    fetchProposalAction(campaignId).then((res) => {
+      if (!alive) return;
+      if (res.success && res.proposal && res.rows) {
+        setProposal(res.proposal);
+        setRows(res.rows);
+        setBodies(Object.fromEntries(res.rows.map((r) => [r.guestId, r.body])));
+      } else {
+        setError(res.error ?? 'Failed to load proposal');
+      }
+      setLoading(false);
+    });
+    return () => { alive = false; };
+  }, [campaignId]);
+
+  const toggle = (guestId: string) =>
+    setExcluded((prev) => { const next = new Set(prev); next.has(guestId) ? next.delete(guestId) : next.add(guestId); return next; });
+
+  const includedCount = rows.filter((r) => !excluded.has(r.guestId)).length;
+
+  const approve = () =>
+    startApprove(async () => {
+      const edits = rows.map((r) => ({ guestId: r.guestId, body: bodies[r.guestId] ?? r.body, include: !excluded.has(r.guestId) }));
+      const res = await approveProposalAction(campaignId, edits);
+      if (res.success) {
+        toast({
+          title: `Queued ${res.queued ?? 0} message${res.queued === 1 ? '' : 's'}`,
+          description: 'Nothing sent yet — send them from the list on the next screen.',
+        });
+        router.refresh(); // status → sending: page swaps to the send list (Gate 2)
+      } else {
+        toast({ title: 'Could not queue', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  const discard = () =>
+    startDiscard(async () => {
+      const res = await discardDraftCampaignAction(campaignId);
+      if (res.success) router.push('/admin/campaigns');
+      else { toast({ title: 'Could not discard', description: res.error, variant: 'destructive' }); setConfirmDiscard(false); }
+    });
+
+  if (loading) return <div className="flex items-center gap-2 py-12 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading the prepared campaign…</div>;
+  if (error) return <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">{error}</div>;
+
+  const offer = proposal?.offer;
+
+  return (
+    <div className="space-y-6">
+      {/* What & why now */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-muted-foreground" />
+            {proposal?.occasion.name || 'Prepared campaign'}
+          </CardTitle>
+          <CardDescription>{proposal?.occasion.point}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {offer && (offer.discountPct || offer.description) && (
+            <div className="flex items-center gap-2">
+              <Tag className="h-4 w-4 text-muted-foreground" />
+              {offer.discountPct ? <Badge variant="secondary">{offer.discountPct}% off</Badge> : null}
+              <span className="text-muted-foreground">{offer.description}</span>
+            </div>
+          )}
+          {proposal?.rationale && (
+            <p className="text-muted-foreground"><span className="font-medium text-foreground">Why: </span>{proposal.rationale}</p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            {includedCount} of {rows.length} recipient{rows.length === 1 ? '' : 's'} selected. Each message was written for that
+            person and is grounded in what we know about them. Edit anything before you approve.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Per-recipient messages */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Recipients &amp; messages</CardTitle>
+          <CardDescription>Review each message, edit if needed, and untick anyone you don’t want to contact this round.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {rows.map((r) => {
+            const isOut = excluded.has(r.guestId);
+            return (
+              <div key={r.guestId} className={`rounded-md border p-3 ${isOut ? 'opacity-50' : ''}`}>
+                <div className="mb-2 flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium">{r.name}</span>
+                      <Badge variant="outline" className="uppercase text-[10px]">{r.language}</Badge>
+                      {(r.careFlags ?? []).map((f) => (
+                        <Badge key={f} variant="outline" className="border-amber-300 text-[10px] text-amber-700">
+                          <AlertTriangle className="mr-1 h-3 w-3" />{f}
+                        </Badge>
+                      ))}
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">{r.phone ?? 'no number on file'} · {r.angle}</p>
+                  </div>
+                  <Button size="sm" variant="ghost" className="h-7 shrink-0 text-xs" onClick={() => toggle(r.guestId)}>
+                    {isOut ? <><Circle className="mr-1 h-3.5 w-3.5" /> Excluded</> : <><CheckCircle2 className="mr-1 h-3.5 w-3.5 text-green-600" /> Included</>}
+                  </Button>
+                </div>
+                <Textarea
+                  value={bodies[r.guestId] ?? r.body}
+                  onChange={(e) => setBodies((prev) => ({ ...prev, [r.guestId]: e.target.value }))}
+                  rows={5}
+                  disabled={isOut}
+                  className="text-sm"
+                />
+                {r.factsUsed.length > 0 && (
+                  <p className="mt-1 text-[11px] text-muted-foreground">Grounded in: {r.factsUsed.join(', ')}</p>
+                )}
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 border-t pt-4">
+        <Button onClick={approve} disabled={approving || includedCount === 0}>
+          {approving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Send className="mr-1 h-4 w-4" />}
+          Approve &amp; queue ({includedCount})
+        </Button>
+        {confirmDiscard ? (
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">Delete this draft?</span>
+            <Button size="sm" variant="destructive" className="h-7" onClick={discard} disabled={discarding}>
+              {discarding ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Yes, discard'}
+            </Button>
+            <Button size="sm" variant="ghost" className="h-7" onClick={() => setConfirmDiscard(false)} disabled={discarding}>Cancel</Button>
+          </div>
+        ) : (
+          <Button size="sm" variant="ghost" className="h-7 px-2 text-xs text-destructive hover:text-destructive" onClick={() => setConfirmDiscard(true)}>
+            <Trash2 className="mr-1 h-3.5 w-3.5" /> Discard draft
+          </Button>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Approving queues the messages to your outbox — nothing sends automatically. You send each one by hand in the next
+        screen. Consent, frequency-cap and booking checks run again at that point.
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -7,8 +7,10 @@ import type { Campaign, SegmentDefinition, MessageVariant, OutboxMessage } from 
 import { PREDEFINED_SEGMENTS, previewAudience } from '@/services/segmentService';
 import { listCampaigns, createCampaign, approveCampaign, sendCampaign, createManualCampaign, markCampaignQueued, markCampaignSent, deleteCampaign, getCampaign } from '@/services/campaignService';
 import { buildAudience, type AudienceCandidate } from '@/services/audienceService';
-import { renderMessages, queueMessages, type RenderedMessage, type SkippedRender } from '@/services/campaignMessaging';
+import { renderMessages, queueMessages, queueDrafts, type RenderedMessage, type SkippedRender } from '@/services/campaignMessaging';
 import { fetchOutboxForCampaign, markOutboxSent } from '@/services/outboxService';
+import { getGuestById } from '@/services/guestService';
+import type { CampaignProposal, ProposedDraft } from '@/lib/growth/contracts';
 
 const logger = loggers.campaign;
 
@@ -263,6 +265,95 @@ export async function approveAndQueueAction(
   } catch (error) {
     logger.error('approveAndQueueAction failed', error as Error);
     return { success: false, error: 'Failed to queue messages' };
+  }
+}
+
+// ── Opportunity-Engine proposal review (Gate 1 for landed campaigns) ──────────
+
+/** One recipient row shown in the proposal review — the draft + resolved name/phone. */
+export interface ProposalReviewRow extends ProposedDraft {
+  name: string;
+  phone: string | null;
+}
+
+/**
+ * Gate 1 (proposal): load a landed campaign's proposal + per-guest drafts, with guest names
+ * resolved for display. Read-only. Returns an error if the campaign has no perGuestDrafts
+ * (i.e. it's a plain manual campaign — the variant composer handles those).
+ */
+export async function fetchProposalAction(
+  campaignId: string
+): Promise<{ success: boolean; proposal?: CampaignProposal; rows?: ProposalReviewRow[]; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const campaign = await getCampaign(campaignId);
+    if (!campaign) return { success: false, error: 'Campaign not found' };
+    const drafts = (campaign as unknown as { perGuestDrafts?: ProposedDraft[] }).perGuestDrafts;
+    const proposal = (campaign as unknown as { proposal?: CampaignProposal }).proposal;
+    if (!drafts?.length || !proposal) return { success: false, error: 'This campaign has no prepared proposal' };
+
+    const rows: ProposalReviewRow[] = await Promise.all(
+      drafts.map(async (d) => {
+        const g = await getGuestById(d.guestId).catch(() => null);
+        const name = [g?.firstName, g?.lastName].filter(Boolean).join(' ') || d.guestId;
+        return { ...d, name, phone: g?.normalizedPhone || g?.phone || null };
+      })
+    );
+    return { success: true, proposal, rows };
+  } catch (error) {
+    logger.error('fetchProposalAction failed', error as Error);
+    return { success: false, error: 'Failed to load proposal' };
+  }
+}
+
+/**
+ * Gate 1 (proposal) approve: queue the owner-reviewed per-guest bodies through the gateway
+ * (all guardrails re-run) and move the campaign to `sending`. `edits` carries any body the owner
+ * changed and each recipient's include flag — an excluded recipient is simply not queued.
+ */
+export async function approveProposalAction(
+  campaignId: string,
+  edits: Array<{ guestId: string; body: string; include: boolean }>
+): Promise<{ success: boolean; queued?: number; error?: string }> {
+  let approver: string;
+  try {
+    const user = await requireSuperAdmin();
+    approver = user.email || user.uid;
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  try {
+    const campaign = await getCampaign(campaignId);
+    if (!campaign) return { success: false, error: 'Campaign not found' };
+    const drafts = (campaign as unknown as { perGuestDrafts?: ProposedDraft[] }).perGuestDrafts;
+    if (!drafts?.length) return { success: false, error: 'This campaign has no prepared proposal' };
+
+    // Apply the owner's edits/exclusions onto the stored drafts (server-side is the source of truth).
+    const editBy = new Map(edits.map((e) => [e.guestId, e]));
+    const selected = drafts
+      .map((d) => { const e = editBy.get(d.guestId); return { guestId: d.guestId, body: (e?.body ?? d.body), include: e ? e.include : true }; })
+      .filter((d) => d.include && d.body.trim().length > 0);
+
+    if (selected.length === 0) return { success: false, error: 'No recipients selected' };
+
+    const res = await queueDrafts({
+      campaignId,
+      propertyId: campaign.propertyId,
+      drafts: selected.map(({ guestId, body }) => ({ guestId, body })),
+    });
+    // Move to sending. Bodies live in the outbox, so no message variants are stored.
+    await markCampaignQueued(campaignId, { approvedBy: approver, variants: [] });
+    revalidatePath(`/admin/campaigns/${campaignId}`);
+    return { success: true, queued: res.queued };
+  } catch (error) {
+    logger.error('approveProposalAction failed', error as Error);
+    return { success: false, error: 'Failed to queue proposal' };
   }
 }
 

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -58,11 +58,76 @@ export interface DraftMessage {
   careHandled?: string;          // how a careFlag was addressed (e.g. resolved-issue PS)
 }
 
-// ── pure guards ──────────────────────────────────────────────────────────────
+// ── landing: planner brief + copywriter drafts → a reviewable draft campaign ──
+/**
+ * One recipient's fully-prepared row, ready for Gate-1 review: the planner's per-guest
+ * reasoning (`angle`, `careFlags`) joined to the copywriter's bespoke `body`. This is what
+ * the owner sees and edits in Admin, and what queues to the outbox verbatim on approve.
+ */
+export interface ProposedDraft {
+  guestId: string;
+  angle: string;              // from the brief — why this guest (shown at Gate 1)
+  careFlags?: string[];       // carried from the brief for the reviewer's context
+  language: LanguageCode;
+  body: string;               // the copywriter's per-guest message
+  factsUsed: string[];        // grounding contract (already validated)
+  careHandled?: string;
+}
+
+/** The campaign-level "what & why now" stored alongside the per-guest drafts. */
+export interface CampaignProposal {
+  intent: CampaignIntent;
+  occasion: { name: string | null; point: string };
+  offer: { discountPct: number | null; description: string };
+  generalAngle: string;
+  rationale: string;
+  opportunity: Opportunity;
+}
+
+// ── pure guards / joins ──────────────────────────────────────────────────────
 export function briefGuestIds(brief: Pick<CampaignBrief, 'audience'>): string[] {
   return brief.audience.map((a) => a.guestId);
 }
 
 export function isDeclined(brief: Pick<CampaignBrief, 'act' | 'audience'>): boolean {
   return !brief.act && brief.audience.length === 0;
+}
+
+/**
+ * Join a validated brief + drafts into per-guest reviewable rows. Pure. Assumes both were
+ * already validated (validatePlan + validateDrafts) so coverage is 1:1 — a guest in the brief
+ * with no matching draft is dropped here (the validators are the gate, not this join).
+ */
+export function toProposedDrafts(
+  brief: Pick<CampaignBrief, 'audience'>,
+  drafts: DraftMessage[]
+): ProposedDraft[] {
+  const draftFor = new Map(drafts.map((d) => [d.guestId, d]));
+  const rows: ProposedDraft[] = [];
+  for (const a of brief.audience) {
+    const d = draftFor.get(a.guestId);
+    if (!d) continue;
+    rows.push({
+      guestId: a.guestId,
+      angle: a.angle,
+      careFlags: a.careFlags,
+      language: d.language,
+      body: d.body,
+      factsUsed: d.factsUsed,
+      careHandled: d.careHandled,
+    });
+  }
+  return rows;
+}
+
+/** Extract the campaign-level proposal metadata from a brief. Pure. */
+export function toCampaignProposal(brief: CampaignBrief): CampaignProposal {
+  return {
+    intent: brief.intent,
+    occasion: brief.occasion,
+    offer: brief.offer,
+    generalAngle: brief.generalAngle,
+    rationale: brief.rationale,
+    opportunity: brief.opportunity,
+  };
 }

--- a/src/services/campaignMessaging.ts
+++ b/src/services/campaignMessaging.ts
@@ -160,3 +160,45 @@ export async function queueMessages(input: RenderInput & { campaignId: string })
   });
   return { queued, results, skipped };
 }
+
+/**
+ * Queue pre-drafted per-guest bodies (the Opportunity-Engine path). Unlike `queueMessages`,
+ * there is no variant rotation or token fill — each recipient's body is bespoke and used
+ * verbatim. Every message still routes through `executeSend` with `deliveryMode:'manual_queue'`,
+ * so the SAME guardrails (consent, suppression, active-future-booking, frequency-cap, dedup)
+ * run at send time — the landed proposal is a suggestion, never a bypass. Bodies are the
+ * owner-reviewed text from the campaign doc's `perGuestDrafts` (already through validateDrafts).
+ */
+export async function queueDrafts(input: {
+  campaignId: string;
+  propertyId: string;
+  drafts: Array<{ guestId: string; body: string }>;
+}): Promise<QueueResult> {
+  const results: QueueResult['results'] = [];
+  const skipped: SkippedRender[] = [];
+  let queued = 0;
+
+  for (const d of input.drafts) {
+    if (!d.body?.trim()) { skipped.push({ guestId: d.guestId, reason: 'no-variant-for-language' }); continue; }
+    const res = await executeSend({
+      guestId: d.guestId,
+      propertyId: input.propertyId,
+      channel: 'whatsapp',
+      templateName: MANUAL_QUEUE_TEMPLATE,
+      campaignId: input.campaignId,
+      deliveryMode: 'manual_queue',
+      body: d.body,
+    });
+    if (res.status === 'queued') queued++;
+    results.push({ guestId: d.guestId, status: res.status, reason: res.reason });
+  }
+
+  logger.info('queueDrafts complete', {
+    campaignId: input.campaignId,
+    propertyId: input.propertyId,
+    drafts: input.drafts.length,
+    queued,
+    skipped: skipped.length,
+  });
+  return { queued, results, skipped };
+}

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -109,6 +109,63 @@ export async function createManualCampaign(input: {
   return ref.id;
 }
 
+/**
+ * Land a validated Opportunity-Engine proposal as a reviewable DRAFT campaign.
+ *
+ * The planner brief + copywriter drafts (both already through validatePlan/validateDrafts)
+ * are joined into per-guest rows and written onto the campaign doc. It reuses the same
+ * whatsapp/manual/status:'draft' shape as `createManualCampaign` — so the existing admin
+ * workspace and Gate-2 send path work unchanged — and adds two fields the Gate-1 UI reads:
+ *   `proposal`       — the campaign-level "what & why now" (occasion, offer, rationale)
+ *   `perGuestDrafts` — each recipient's bespoke body + the planner's reason, edited then queued
+ * Nothing is queued or sent here; the owner reviews in Admin, then approves → outbox.
+ */
+export async function createProposedCampaign(input: {
+  name: string;
+  brief: import('@/lib/growth/contracts').CampaignBrief;
+  drafts: import('@/lib/growth/contracts').DraftMessage[];
+}): Promise<string> {
+  const { briefGuestIds, isDeclined, toProposedDrafts, toCampaignProposal } = await import('@/lib/growth/contracts');
+  if (isDeclined(input.brief)) {
+    throw new Error('createProposedCampaign: brief declined to act (no audience) — nothing to land');
+  }
+  const guestIds = briefGuestIds(input.brief);
+  const perGuestDrafts = toProposedDrafts(input.brief, input.drafts);
+  if (perGuestDrafts.length === 0) {
+    throw new Error('createProposedCampaign: no per-guest drafts after join — validate drafts before landing');
+  }
+  const proposal = toCampaignProposal(input.brief);
+
+  const db = await getAdminDb();
+  const ref = await db.collection('campaigns').add({
+    name: input.name,
+    propertyId: input.brief.propertyId,
+    channel: 'whatsapp',
+    templateName: 'manual',
+    variables: {},
+    segmentDefinition: { propertyId: input.brief.propertyId },
+    audienceGuestIds: guestIds,
+    messageVariants: [],       // per-guest bodies live in perGuestDrafts, not per-language variants
+    perGuestDrafts,
+    proposal,
+    source: 'opportunity-engine',
+    scheduleAt: null,
+    status: 'draft',
+    stats: emptyStats(),
+    approvedBy: null,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    sentAt: null,
+  });
+  logger.info('Proposed campaign landed', {
+    campaignId: ref.id,
+    propertyId: input.brief.propertyId,
+    recipients: perGuestDrafts.length,
+    occasion: proposal.occasion.name,
+  });
+  return ref.id;
+}
+
 /** Approve a manual campaign: store the copy, record the approver, move to sending. */
 export async function markCampaignQueued(
   id: string,


### PR DESCRIPTION
## What

Wires the Opportunity-Engine pipeline's tail: a validated planner **CampaignBrief** + copywriter **DraftMessage[]** become a reviewable **draft campaign** the owner approves and sends from Admin.

```
brief + drafts → createProposedCampaign → DRAFT campaign { proposal, perGuestDrafts }
   → /admin/campaigns/[id]  ProposalReview (Gate 1: review/edit/exclude per recipient)
   → approveProposalAction → queueDrafts → status:sending
   → OutboxSender (Gate 2, existing) → wa.me one-tap → mark sent
```

## Why it's low-risk

- **Purely additive.** The live manual-variant composer, the outbox, and the execution gateway are untouched.
- The send path **already** carried a per-recipient body (`SendRequest.body`, "required for manual_queue"), so per-guest bodies needed **no** outbox/gateway change.
- Every guardrail (consent, suppression, active-future-booking, frequency-cap, dedup) **re-runs at send time** — the landed proposal is a suggestion, never a bypass.

## Files

- `src/lib/growth/contracts.ts` — `ProposedDraft`, `CampaignProposal`, `toProposedDrafts`, `toCampaignProposal`
- `src/services/campaignService.ts` — `createProposedCampaign`
- `src/services/campaignMessaging.ts` — `queueDrafts`
- `src/app/admin/campaigns/actions.ts` — `fetchProposalAction`, `approveProposalAction`
- `src/app/admin/campaigns/_components/proposal-review.tsx` — Gate-1 UI
- `src/app/admin/campaigns/[id]/page.tsx` — route landed proposals to the review
- `scripts/land-campaign.ts` — operator entry (optional re-validation)

## Test

`npm run build` passes. Landing + Gate-1 read path verified against live Firestore (draft doc shape, per-guest bodies, name resolution); test campaigns cleaned up. No outbox writes in these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)