### PR TITLE
feat: campaign framing — typed offers, date-targeted updates, channel-aware copywriter

### DIFF
--- a/scripts/copywriter-pack.ts
+++ b/scripts/copywriter-pack.ts
@@ -44,6 +44,7 @@ async function main() {
   const brief = JSON.parse(fs.readFileSync(briefFile, 'utf8'));
   const wantIds: string[] = brief.audience.map((a: any) => a.guestId);
   const careByGuest = new Map(brief.audience.map((a: any) => [a.guestId, a.careFlags || []]));
+  const framingUpdates: any[] = brief.updates || [];   // campaign news to weave in, date-targeted
 
   const db = await getAdminDb();
   const [gSnap, bSnap, rSnap, tSnap] = await Promise.all([
@@ -87,6 +88,18 @@ async function main() {
       .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
     const lastBk: any = stayB.length ? stayB[stayB.length - 1] : null;
     const last = lastBk ? toD(lastBk.checkInDate) : null;
+    // booking-channel history — so the copywriter presents the offer the RIGHT way per guest
+    // (a direct booker already knows they get the best price; an OTA booker needs the explicit offer).
+    const channels = stayB.map((b: any) => String(b.source || '').toLowerCase()).filter(Boolean);
+    const directCount = channels.filter((c: string) => c === 'direct').length;
+    const otaCount = channels.length - directCount;
+    const lastChannel = channels.length ? channels[channels.length - 1] : null;
+    const booksDirect = directCount > 0;
+    // campaign updates that are genuinely NEW to this guest (their last stay predates the update).
+    // This is the TRUTH gate — the copywriter still decides whether/how to mention each.
+    const applicableUpdates = framingUpdates.filter((u: any) => {
+      const eff = toD(u.effectiveDate); return eff && last && +last < +eff;
+    }).map((u: any) => ({ id: u.id, text: u.text }));
     const rv = reviewsBy.get(gid) || [];
     const reviewThemes = [...new Set(rv.flatMap((r: any) => { const t = r.tags; return Array.isArray(t) ? t : t && typeof t === 'object' ? Object.values(t).flat() : []; }))]
       .filter(x => typeof x === 'string' && !/^\+\d+ more$/i.test(x));  // drop the "+N more" truncation artifact
@@ -107,7 +120,9 @@ async function main() {
     if (lastBk?.numberOfGuests) groundedFacts.push({ key: 'partySize', value: lastBk.numberOfGuests, source: `bookings/${lastBk.id}` });
     if (lastBk && (lastBk.numberOfChildren ?? 0) > 0) groundedFacts.push({ key: 'hadChildren', value: true, source: `bookings/${lastBk.id}` });
     if (totalBookings >= 2) groundedFacts.push({ key: 'isRepeatGuest', value: totalBookings, source: `guests/${gid}` });
+    if (booksDirect) groundedFacts.push({ key: 'booksDirect', value: { directBookings: directCount, otaBookings: otaCount }, source: `bookings(guests/${gid})` });
     reviewThemes.forEach(t => groundedFacts.push({ key: `reviewPraised:${t}`, value: t, source: `reviews/${(rv[0] || {}).id || gid}` }));
+    applicableUpdates.forEach((u: any) => groundedFacts.push({ key: `update:${u.id}`, value: u.text, source: 'campaign.updates' }));
     // NOTE: no `issueResolved:*` facts are emitted here — the pack cannot know a problem was fixed.
     // Those are owner-supplied (a future input); until then a complaint guest gets neutral treatment.
 
@@ -127,7 +142,9 @@ async function main() {
         partySize: lastBk?.numberOfGuests ?? null,
         hadChildren: lastBk ? (lastBk.numberOfChildren ?? 0) > 0 : null,
         reviewThemes,
+        bookingChannel: { lastChannel, directCount, otaCount },
       },
+      applicableUpdates,   // campaign news the copywriter MAY mention (already date-filtered to this guest)
       groundedFacts,
       thread,
       threadNote: thread.length ? `${thread.length} prior messages — read to AVOID repeating what was already said, and to match tone. Do NOT assert a new guest-specific fact from the thread that is not in groundedFacts.` : 'no prior WhatsApp history — a first contact; include the opt-out line.',
@@ -136,7 +153,7 @@ async function main() {
 
   const pack = {
     meta: { generatedFor: brief.propertyId, asOf: ymd(AS_OF), generator: 'scripts/copywriter-pack.ts', briefId: brief.opportunity?.id },
-    campaign: { occasion: brief.occasion, offer: brief.offer, intent: brief.intent, generalAngle: brief.generalAngle },
+    campaign: { occasion: brief.occasion, offer: brief.offer, updates: framingUpdates, intent: brief.intent, generalAngle: brief.generalAngle },
     voiceProfile: {
       note: 'Imitate this register — these are the owner\'s REAL past messages, tagged by outcome (booked/replied/silent). Copy the voice, not the content. Prefer what "booked".',
       exemplars: voiceExemplars,
@@ -148,6 +165,8 @@ async function main() {
       selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',
       optOut: 'include a soft opt-out line only on a FIRST contact (no prior thread); otherwise rely on WhatsApp block/report',
       grounding: 'assert ONLY facts present in that guest\'s groundedFacts; tag each claim in factsUsed with its key. No emoji. No invented stays/preferences.',
+      offerPresentation: 'The offer (campaign.offer) is set by the owner — never inflate or invent one, only phrase it. Adapt HOW you present it per guest: a guest with a `booksDirect` fact already knows they get your best price directly, so acknowledge that warmly (e.g. "si asa cum stii deja, iti pot da cea mai buna oferta direct") rather than quoting a discount as if it were news; a guest who has only booked via an OTA gets the explicit offer. For a free-night/value offer, describe the value in words, not a bare percentage. Tag `booksDirect` in factsUsed when you use that angle.',
+      updates: 'Each guest\'s `applicableUpdates` lists campaign news that is genuinely new SINCE THAT guest\'s last stay (already date-filtered — a guest who was here after a change does not see it). Decide per guest whether an update is worth mentioning and how to weave it in — do not force it into every message. You may mention ONLY updates in that guest\'s applicableUpdates, tagging factsUsed with the `update:<id>` key.',
       sentiment: 'always positive. For a careFlag complaint: if (and only if) an issueResolved:* fact is present, you MAY add a warm PS acknowledging the fix; otherwise do NOT mention the past problem at all — write a normal forward-looking message.',
     },
     guests,

--- a/src/app/admin/campaigns/_components/proposal-review.tsx
+++ b/src/app/admin/campaigns/_components/proposal-review.tsx
@@ -101,6 +101,16 @@ export function ProposalReview({ campaignId }: { campaignId: string }) {
               <span className="text-muted-foreground">{offer.description}</span>
             </div>
           )}
+          {(proposal?.updates?.length ?? 0) > 0 && (
+            <div className="rounded-md border border-dashed p-2">
+              <p className="mb-1 text-xs font-medium">News woven in (only for guests who last stayed before each date):</p>
+              <ul className="space-y-0.5 text-xs text-muted-foreground">
+                {proposal!.updates!.map((u) => (
+                  <li key={u.id}>• {u.text} <span className="opacity-60">(since {u.effectiveDate})</span></li>
+                ))}
+              </ul>
+            </div>
+          )}
           {proposal?.rationale && (
             <p className="text-muted-foreground"><span className="font-medium text-foreground">Why: </span>{proposal.rationale}</p>
           )}

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -35,17 +35,66 @@ export interface BriefAudienceEntry {
   careFlags?: string[];          // e.g. ['complaint-in-thread'] — the copywriter must handle gently
 }
 
-/** The planner's typed output — validated before anything queues (plan §7.4). */
+/**
+ * The offer, as part of the campaign FRAMING (owner-editable). A superset so a plain percent
+ * offer stays `{discountPct}` (back-compat) while richer forms carry their own params. Whatever
+ * the form, `effectiveDiscountPct()` derives the economic size the margin guard checks — the
+ * copywriter only ever PHRASES this (channel-aware), never inflates it.
+ */
+export interface CampaignOffer {
+  type?: 'percent' | 'free_night' | 'fixed' | 'none';
+  discountPct?: number | null;   // percent offers (also the back-compat field)
+  freeNightAfter?: number;       // free_night: stay N nights, the (N+1)th is free
+  amount?: number;               // fixed: absolute amount off (currency = RON)
+  description: string;           // human phrasing shown at the gate; the copywriter may reword per guest
+}
+
+/**
+ * A campaign-level UPDATE to announce (part of the framing). `effectiveDate` is what makes it
+ * TRUTHFUL to call "new": the copywriter-pack surfaces an update to a guest ONLY if their last
+ * stay predates it (they haven't experienced it). Whether it's worth mentioning to that guest,
+ * and how, is the copywriter's judgment — this only bounds it to guests it's genuinely new to.
+ */
+export interface CampaignUpdate {
+  id: string;                    // stable slug, e.g. 'fire-pit'
+  text: string;                  // what changed, in the owner's words
+  effectiveDate: string;         // YYYY-MM-DD — only guests whose last stay is BEFORE this hear it as new
+}
+
+/** The planner's typed output — the draft FRAMING the human gate edits before the copywriter runs (§7.4). */
 export interface CampaignBrief {
   propertyId: string;
   opportunity: Opportunity;
   act: boolean;                  // false = decline; audience must then be empty
   intent: CampaignIntent;
   occasion: { name: string | null; point: string };   // the "what & why now"
-  offer: { discountPct: number | null; description: string };
+  offer: CampaignOffer;
+  updates?: CampaignUpdate[];                           // news to weave in, date-targeted (framing)
   audience: BriefAudienceEntry[];                       // ⊆ the eligible set (enforced by validatePlan)
   generalAngle: string;                                 // the brief the copywriter particularises
   rationale: string;
+}
+
+/**
+ * Derive the economic size of an offer as a percentage, for the margin guard. Pure.
+ * - percent    → discountPct
+ * - free_night → 1/(freeNightAfter+1)  (stay 3 get 4th free = 25%)
+ * - none       → 0
+ * - fixed      → null (can't be a % without an ADR; the guard warns rather than blocks)
+ */
+export function effectiveDiscountPct(offer: CampaignOffer | undefined | null): number | null {
+  if (!offer) return null;
+  const type = offer.type ?? (offer.discountPct != null ? 'percent' : 'none');
+  switch (type) {
+    case 'none': return 0;
+    case 'percent': return offer.discountPct ?? 0;
+    case 'free_night': {
+      const n = offer.freeNightAfter ?? 0;
+      return n > 0 ? Math.round((1 / (n + 1)) * 100) : null;
+    }
+    case 'fixed': return null;
+    default: return offer.discountPct ?? null;
+  }
 }
 
 // ── copywriter → grounding validator / outbox ────────────────────────────────
@@ -78,7 +127,8 @@ export interface ProposedDraft {
 export interface CampaignProposal {
   intent: CampaignIntent;
   occasion: { name: string | null; point: string };
-  offer: { discountPct: number | null; description: string };
+  offer: CampaignOffer;
+  updates?: CampaignUpdate[];
   generalAngle: string;
   rationale: string;
   opportunity: Opportunity;
@@ -126,6 +176,7 @@ export function toCampaignProposal(brief: CampaignBrief): CampaignProposal {
     intent: brief.intent,
     occasion: brief.occasion,
     offer: brief.offer,
+    updates: brief.updates ?? [],
     generalAngle: brief.generalAngle,
     rationale: brief.rationale,
     opportunity: brief.opportunity,

--- a/src/lib/growth/validatePlan.ts
+++ b/src/lib/growth/validatePlan.ts
@@ -16,6 +16,7 @@
  */
 
 import type { CampaignBrief } from './contracts';
+import { effectiveDiscountPct } from './contracts';
 
 /** The subset of the planner pack this validator needs. */
 export interface PlannerPackForValidation {
@@ -79,14 +80,17 @@ export function validatePlan(
   // 4. Empty acting plan.
   if (ids.length === 0) errors.push('act:true but no guests selected');
 
-  // 5. Offer inequality: a discount must not exceed the ceiling that keeps direct above OTA net.
-  const d = brief.offer?.discountPct;
-  if (d != null && d > 0) {
+  // 5. Offer inequality: whatever the offer FORM (percent, free-night, fixed), its economic size
+  // must not exceed the ceiling that keeps direct above OTA net. effectiveDiscountPct() derives it.
+  const d = effectiveDiscountPct(brief.offer);
+  if (d == null && brief.offer?.type === 'fixed') {
+    warnings.push('a fixed-amount offer was set — its % value depends on the nightly rate; confirm it keeps direct above OTA net manually');
+  } else if (d != null && d > 0) {
     const ceiling = pack.offer.maxDiscountPct;
     if (ceiling == null) {
-      warnings.push(`a ${d}% discount was set but the pack has no maxDiscountPct (missing net-ADR data) — confirm the offer manually`);
+      warnings.push(`an offer worth ~${d}% was set but the pack has no maxDiscountPct (missing net-ADR data) — confirm the offer manually`);
     } else if (d > ceiling) {
-      errors.push(`discount ${d}% exceeds the ceiling ${ceiling}% — it would give away the direct-channel margin (§0.5 offer inequality)`);
+      errors.push(`offer worth ~${d}% exceeds the ceiling ${ceiling}% — it would give away the direct-channel margin (§0.5 offer inequality)`);
     }
   }
 


### PR DESCRIPTION
## What

Splits **what to say** (owner framing) from **how to say it** (copywriter), per owner feedback. Principle: **guardrails on truth and margin; intelligence on everything else.**

- **Typed offers** — `CampaignOffer` supports percent / free-night / fixed / none; `effectiveDiscountPct()` derives the economic size so the margin guard works for any form. "Stay 3 get 4th free" = 25% > 20% ceiling → correctly rejected.
- **Date-targeted updates** — `CampaignUpdate {text, effectiveDate}`. The copywriter-pack surfaces an update to a guest **only if their last stay predates it** (they haven't experienced it) — a truth gate implemented via the existing grounding whitelist, not a separate rule. Whether to mention it, and how, stays the LLM's call.
- **Channel-aware offer presentation** — per-guest `bookingChannel` (direct vs OTA) + a `booksDirect` grounded fact. A repeat direct guest gets *"si asa cum stii deja, iti pot da cea mai buna oferta direct"*; an OTA guest gets the explicit discount. The LLM decides presentation; it can only ever phrase — never inflate — the owner's offer.
- **Gate-1** now shows the campaign news items alongside the offer/rationale.

## Design line

Update eligibility is deterministic *only* as "which true facts are on the table" (grounding). Relevance, emphasis, offer presentation, and voice are the LLM's. This keeps the system intelligent while making false-novelty and margin-loss impossible.

## Test

`npm run build` passes. Verified against live Firestore: channel split (3 direct / 11 OTA), update reaches only the 9 who predate it, all 14 drafts pass grounding (incl. new `booksDirect` / `update:*` facts), and the margin guard rejects a 25% free-night offer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)