### PR TITLE
feat: in-app copywriter + Gate-0 framing editor (self-service edit → regenerate loop)

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -132,6 +132,13 @@ env:
     availability:
         - RUNTIME
 
+# Anthropic API — the in-app copywriter (Opportunity Engine). Server-side only, RUNTIME.
+# The framing→per-guest adaptation calls Claude here; inert (copywriter degrades) until this is set.
+  - variable: ANTHROPIC_API_KEY
+    secret: projects/1061532538391/secrets/ANTHROPIC_API_KEY/versions/latest
+    availability:
+        - RUNTIME
+
 # Google Places API for review sync
   - variable: GOOGLE_PLACES_API_KEY
     secret: projects/1061532538391/secrets/GOOGLE_PLACES_API_KEY/versions/latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextn",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.114.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -135,6 +136,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.114.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.114.0.tgz",
+      "integrity": "sha512-zRFGTVMFEm77gt70Q0B+CDRKa9AcguydCcp6bD/dXWv8UkfsVFqCbaqU8+4B/pob3+Vy434LgtrBmwSvxfKr3g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
@@ -19987,6 +20009,19 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -24800,6 +24835,12 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -25977,9 +26018,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "manage-availability": "./scripts/manage-availability-data.sh"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.114.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/scripts/copywriter-pack.ts
+++ b/scripts/copywriter-pack.ts
@@ -1,179 +1,33 @@
 #!/usr/bin/env npx tsx
 /**
- * copywriter-pack — the deterministic FACT PACK the WhatsApp copywriter drafts from.
+ * copywriter-pack — CLI wrapper that writes the deterministic copywriter FACT PACK for a brief.
  *
- * Given a planner CampaignBrief, for EACH selected guest it assembles: their full verbatim
- * WhatsApp thread (for non-repetition + tone), their dossier, and — the crux — a `groundedFacts`
- * whitelist: the explicit list of guest-specific facts the copywriter is ALLOWED to assert, each
- * with provenance. Plus a shared voice profile (the owner's own past messages, outcome-labeled)
- * and the voice rules. Facts + method + constraints, no conclusions (plan §2 pr.5 / §7.5–7.6).
- *
- * The grounding contract (plan §7.5): the copywriter tags every guest-specific claim with a
- * groundedFacts key; validateDrafts checks factsUsed ⊆ groundedFacts. The thread is context for
- * avoiding repetition and matching tone — it is NOT a source of new assertable facts (extracting
- * checkable claims from free prose is undecidable; the whitelist is what keeps "only-true" enforceable).
+ * The pack-building logic lives in src/lib/growth/copywriterPack.ts (shared with the in-app
+ * copywriter, src/services/growth/copywriter.ts) so the operator prototype and production reason
+ * from IDENTICAL facts. This script just loads the brief, calls buildCopywriterPack, and writes it.
  *
  * Usage:
- *   npx tsx scripts/copywriter-pack.ts --brief /tmp/brief-autumn.json --out /tmp/cw-autumn.json
+ *   npx tsx scripts/copywriter-pack.ts --brief /tmp/brief-autumn.json --out /tmp/cw-autumn.json [--as-of YYYY-MM-DD]
  */
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 import * as fs from 'fs';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
-import { getAdminDb } from '../src/lib/firebaseAdminSafe';
-import { detectLanguage } from '../src/lib/growth/audience';
+import { buildCopywriterPack } from '../src/lib/growth/copywriterPack';
+import type { CampaignBrief } from '../src/lib/growth/contracts';
 
 const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
 const briefFile = arg('brief'); const OUT = arg('out');
-const AS_OF = new Date(`${arg('as-of', new Date().toISOString().slice(0, 10))}T00:00:00Z`);
+const asOfArg = arg('as-of');
 if (!briefFile) { console.error('required: --brief <CampaignBrief.json>'); process.exit(1); }
 
-const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
-const ymd = (d: Date) => d.toISOString().slice(0, 10);
-const days = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
-const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'winter' : m <= 5 ? 'spring' : m <= 8 ? 'summer' : 'autumn'; };
-function lastStayPhrase(last: Date | null): string | null {
-  if (!last) return null;
-  const y = last.getUTCFullYear(), nowY = AS_OF.getUTCFullYear();
-  const s = ({ winter: 'iarna', spring: 'primavara', summer: 'vara', autumn: 'toamna' } as any)[seasonOf(last)];
-  if (last.getUTCMonth() + 1 === 12 && last.getUTCDate() >= 27) return 'de Revelion';
-  return y === nowY ? `${s} aceasta` : y === nowY - 1 ? `${s} trecuta` : `in ${s} lui ${y}`;
-}
-
 async function main() {
-  const brief = JSON.parse(fs.readFileSync(briefFile, 'utf8'));
-  const wantIds: string[] = brief.audience.map((a: any) => a.guestId);
-  const careByGuest = new Map(brief.audience.map((a: any) => [a.guestId, a.careFlags || []]));
-  const framingUpdates: any[] = brief.updates || [];   // campaign news to weave in, date-targeted
-
-  const db = await getAdminDb();
-  const [gSnap, bSnap, rSnap, tSnap] = await Promise.all([
-    db.collection('guests').get(), db.collection('bookings').get(),
-    db.collection('reviews').get(), db.collection('whatsappThreads').get(),
-  ]);
-  const guestById = new Map(gSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
-  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
-  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
-  const reviewsBy = new Map<string, any[]>();
-  rSnap.docs.forEach(d => { const r: any = { id: d.id, ...d.data() }; if (!r.guestId) return; (reviewsBy.get(r.guestId) || reviewsBy.set(r.guestId, []).get(r.guestId)!).push(r); });
-
-  // ── voice profile: the owner's own substantive outbound, outcome-labeled (§7.6) ──
-  const owner = process.env.WHATSAPP_OWNER_NAME || 'Bogdan Coman';
-  const exemplars: any[] = [];
-  tSnap.docs.forEach(d => {
-    const t: any = d.data(); const g = guestById.get(d.id);
-    const stays = g ? (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean) : [];
-    (t.messages || []).forEach((m: any, i: number) => {
-      if (m.direction !== 'out' || (m.text || '').length < 260) return;
-      const after = (t.messages || []).slice(i + 1);
-      const replied = after.some((x: any) => x.direction === 'in' && (+new Date(x.ts) - +new Date(m.ts)) / 86400000 <= 14);
-      const booked = stays.some((b: any) => { const c = toD(b.createdAt); return c && +c > +new Date(m.ts) && (+c - +new Date(m.ts)) / 86400000 <= 90; });
-      exemplars.push({ text: m.text, len: (m.text || '').length, outcome: booked ? 'booked' : replied ? 'replied' : 'silent', date: String(m.ts).slice(0, 10) });
-    });
-  });
-  // a diverse, outcome-varied set (prefer booked, then replied, then some silent; cap ~10)
-  exemplars.sort((a, b) => (b.outcome === 'booked' ? 1 : 0) - (a.outcome === 'booked' ? 1 : 0) || b.len - a.len);
-  const voiceExemplars = [
-    ...exemplars.filter(e => e.outcome === 'booked').slice(0, 3),
-    ...exemplars.filter(e => e.outcome === 'replied').slice(0, 5),
-    ...exemplars.filter(e => e.outcome === 'silent').slice(0, 2),
-  ].map(e => ({ outcome: e.outcome, date: e.date, text: e.text }));
-
-  // ── per-guest packs ──
-  const guests = wantIds.map(gid => {
-    const g: any = guestById.get(gid);
-    if (!g) return { guestId: gid, error: 'guest not found' };
-    const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
-      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
-      .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
-    const lastBk: any = stayB.length ? stayB[stayB.length - 1] : null;
-    const last = lastBk ? toD(lastBk.checkInDate) : null;
-    // booking-channel history — so the copywriter presents the offer the RIGHT way per guest
-    // (a direct booker already knows they get the best price; an OTA booker needs the explicit offer).
-    const channels = stayB.map((b: any) => String(b.source || '').toLowerCase()).filter(Boolean);
-    const directCount = channels.filter((c: string) => c === 'direct').length;
-    const otaCount = channels.length - directCount;
-    const lastChannel = channels.length ? channels[channels.length - 1] : null;
-    const booksDirect = directCount > 0;
-    // campaign updates that are genuinely NEW to this guest (their last stay predates the update).
-    // This is the TRUTH gate — the copywriter still decides whether/how to mention each.
-    const applicableUpdates = framingUpdates.filter((u: any) => {
-      const eff = toD(u.effectiveDate); return eff && last && +last < +eff;
-    }).map((u: any) => ({ id: u.id, text: u.text }));
-    const rv = reviewsBy.get(gid) || [];
-    const reviewThemes = [...new Set(rv.flatMap((r: any) => { const t = r.tags; return Array.isArray(t) ? t : t && typeof t === 'object' ? Object.values(t).flat() : []; }))]
-      .filter(x => typeof x === 'string' && !/^\+\d+ more$/i.test(x));  // drop the "+N more" truncation artifact
-    const th = threads.get(gid);
-    const thread = ((th?.messages || []) as any[]).filter(m => m.ts < ymd(AS_OF)).map(m => ({ ts: m.ts, dir: m.direction, text: m.text }));
-    const totalBookings = g.totalBookings ?? stayB.length;
-    // which language to actually WRITE in — detected from the thread, because the `language` field
-    // is a blanket "ro" default across the base and does not reflect how the guest communicates.
-    const threadText = thread.map(m => m.text || '').join(' ');
-    const detected = detectLanguage(threadText);
-    const writeLanguage = detected === 'unknown' ? (g.language || 'ro') : detected;
-
-    // groundedFacts — the assertable whitelist (structured facts only; provenance attached).
-    const groundedFacts: any[] = [];
-    if (g.firstName) groundedFacts.push({ key: 'firstName', value: g.firstName, source: `guests/${gid}` });
-    if (last) groundedFacts.push({ key: 'lastStayPhrase', value: lastStayPhrase(last), source: `bookings/${lastBk.id}` });
-    if (last) groundedFacts.push({ key: 'lastStaySeason', value: seasonOf(last), source: `bookings/${lastBk.id}` });
-    if (lastBk?.numberOfGuests) groundedFacts.push({ key: 'partySize', value: lastBk.numberOfGuests, source: `bookings/${lastBk.id}` });
-    if (lastBk && (lastBk.numberOfChildren ?? 0) > 0) groundedFacts.push({ key: 'hadChildren', value: true, source: `bookings/${lastBk.id}` });
-    if (totalBookings >= 2) groundedFacts.push({ key: 'isRepeatGuest', value: totalBookings, source: `guests/${gid}` });
-    if (booksDirect) groundedFacts.push({ key: 'booksDirect', value: { directBookings: directCount, otaBookings: otaCount }, source: `bookings(guests/${gid})` });
-    reviewThemes.forEach(t => groundedFacts.push({ key: `reviewPraised:${t}`, value: t, source: `reviews/${(rv[0] || {}).id || gid}` }));
-    applicableUpdates.forEach((u: any) => groundedFacts.push({ key: `update:${u.id}`, value: u.text, source: 'campaign.updates' }));
-    // NOTE: no `issueResolved:*` facts are emitted here — the pack cannot know a problem was fixed.
-    // Those are owner-supplied (a future input); until then a complaint guest gets neutral treatment.
-
-    return {
-      guestId: gid,
-      firstName: g.firstName || null,
-      writeLanguage,                          // WRITE in this (thread-detected); the field is unreliable
-      recordLanguage: g.language || null,     // for reference only — blanket "ro", do not trust
-      threadLanguageDetected: detected,
-      careFlags: careByGuest.get(gid) || [],
-      dossier: {
-        tier: totalBookings >= 2 ? 'repeat' : 'single',
-        totalBookings,
-        lastStay: last ? ymd(last) : null,
-        lastStayPhrase: lastStayPhrase(last),
-        lastStaySeason: last ? seasonOf(last) : null,
-        partySize: lastBk?.numberOfGuests ?? null,
-        hadChildren: lastBk ? (lastBk.numberOfChildren ?? 0) > 0 : null,
-        reviewThemes,
-        bookingChannel: { lastChannel, directCount, otaCount },
-      },
-      applicableUpdates,   // campaign news the copywriter MAY mention (already date-filtered to this guest)
-      groundedFacts,
-      thread,
-      threadNote: thread.length ? `${thread.length} prior messages — read to AVOID repeating what was already said, and to match tone. Do NOT assert a new guest-specific fact from the thread that is not in groundedFacts.` : 'no prior WhatsApp history — a first contact; include the opt-out line.',
-    };
-  });
-
-  const pack = {
-    meta: { generatedFor: brief.propertyId, asOf: ymd(AS_OF), generator: 'scripts/copywriter-pack.ts', briefId: brief.opportunity?.id },
-    campaign: { occasion: brief.occasion, offer: brief.offer, updates: framingUpdates, intent: brief.intent, generalAngle: brief.generalAngle },
-    voiceProfile: {
-      note: 'Imitate this register — these are the owner\'s REAL past messages, tagged by outcome (booked/replied/silent). Copy the voice, not the content. Prefer what "booked".',
-      exemplars: voiceExemplars,
-    },
-    voiceRules: {
-      language: 'Write each message in that guest\'s writeLanguage (thread-detected: "ro" or "en"). Romanian is written WITHOUT diacritics (matches the owner). Do NOT trust recordLanguage — it is a blanket "ro" default. An English-speaking expat living here (RO phone) gets an English message.',
-      length: '300–600 characters, 3–6 short sentences',
-      noEmoji: true,
-      selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',
-      optOut: 'include a soft opt-out line only on a FIRST contact (no prior thread); otherwise rely on WhatsApp block/report',
-      grounding: 'assert ONLY facts present in that guest\'s groundedFacts; tag each claim in factsUsed with its key. No emoji. No invented stays/preferences.',
-      offerPresentation: 'The offer (campaign.offer) is set by the owner — never inflate or invent one, only phrase it. Adapt HOW you present it per guest: a guest with a `booksDirect` fact already knows they get your best price directly, so acknowledge that warmly (e.g. "si asa cum stii deja, iti pot da cea mai buna oferta direct") rather than quoting a discount as if it were news; a guest who has only booked via an OTA gets the explicit offer. For a free-night/value offer, describe the value in words, not a bare percentage. Tag `booksDirect` in factsUsed when you use that angle.',
-      updates: 'Each guest\'s `applicableUpdates` lists campaign news that is genuinely new SINCE THAT guest\'s last stay (already date-filtered — a guest who was here after a change does not see it). Decide per guest whether an update is worth mentioning and how to weave it in — do not force it into every message. You may mention ONLY updates in that guest\'s applicableUpdates, tagging factsUsed with the `update:<id>` key.',
-      sentiment: 'always positive. For a careFlag complaint: if (and only if) an issueResolved:* fact is present, you MAY add a warm PS acknowledging the fix; otherwise do NOT mention the past problem at all — write a normal forward-looking message.',
-    },
-    guests,
-  };
+  const brief = JSON.parse(fs.readFileSync(briefFile!, 'utf8')) as CampaignBrief;
+  const asOf = asOfArg ? new Date(`${asOfArg}T00:00:00Z`) : undefined;
+  const pack = await buildCopywriterPack(brief, { asOf });
 
   const json = JSON.stringify(pack, null, 2);
-  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB) · ${guests.length} guests · ${voiceExemplars.length} voice exemplars`); }
+  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB) · ${pack.guests.length} guests · ${pack.voiceProfile.exemplars.length} voice exemplars`); }
   else console.log(json);
 }
 main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/test-copywriter.ts
+++ b/scripts/test-copywriter.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env npx tsx
+/**
+ * test-copywriter — smoke-test the IN-APP copywriter (src/services/growth/copywriter.ts) end to end:
+ * build the pack → call Claude → validate → repair. Needs ANTHROPIC_API_KEY in .env.local.
+ *
+ * Usage:
+ *   npx tsx scripts/test-copywriter.ts --campaign <campaignId>     # reconstruct framing from a landed campaign
+ *   npx tsx scripts/test-copywriter.ts --brief /tmp/brief.json     # or from a brief file
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import * as fs from 'fs';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { generateDrafts } from '../src/services/growth/copywriter';
+import { getCampaign, campaignToBrief } from '../src/services/campaignService';
+import type { CampaignBrief } from '../src/lib/growth/contracts';
+
+const arg = (n: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : undefined; };
+
+async function main() {
+  if (!process.env.ANTHROPIC_API_KEY) { console.error('ANTHROPIC_API_KEY not in .env.local — add it to smoke-test locally'); process.exit(2); }
+
+  let brief: CampaignBrief;
+  const campaignId = arg('campaign');
+  const briefFile = arg('brief');
+  if (campaignId) {
+    const c = await getCampaign(campaignId);
+    if (!c) { console.error(`campaign ${campaignId} not found`); process.exit(1); }
+    brief = campaignToBrief(c);
+    console.log(`reconstructed brief from campaign ${campaignId}: ${brief.audience.length} guests · offer ${JSON.stringify(brief.offer)}`);
+  } else if (briefFile) {
+    brief = JSON.parse(fs.readFileSync(briefFile, 'utf8'));
+  } else {
+    console.error('required: --campaign <id> OR --brief <file>'); process.exit(2);
+  }
+
+  const t0 = Date.now();
+  const res = await generateDrafts(brief);
+  console.log(`\n=== generateDrafts → ok:${res.ok} · attempts:${res.attempts} · ${res.drafts.length} drafts · ${Date.now() - t0}ms ===`);
+  if (res.errors.length) console.log('errors:', res.errors);
+  if (res.warnings.length) console.log('warnings:', res.warnings);
+  res.drafts.forEach((d) => {
+    console.log(`\n--- ${d.guestId} [${d.language}] facts:${JSON.stringify(d.factsUsed)} ---`);
+    console.log(d.body);
+  });
+  process.exit(res.ok ? 0 : 1);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/admin/campaigns/_components/framing-editor.tsx
+++ b/src/app/admin/campaigns/_components/framing-editor.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+/**
+ * Gate 0 — the campaign FRAMING editor (the owner's hand on the campaign idea).
+ *
+ * The owner edits WHAT the campaign says — the occasion, the offer, the news to announce, the angle
+ * — then hits "Save & regenerate", which runs the in-app copywriter to rewrite every per-guest
+ * message from the edited framing. The copywriter adapts (voice, per-guest history, channel, which
+ * news applies); the owner shapes the substance here, once, instead of editing 14 messages.
+ */
+import { useState, useTransition } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Wand2, Plus, X, AlertCircle } from 'lucide-react';
+import { generateMessagesAction } from '../actions';
+import type { CampaignProposal, CampaignOffer, CampaignUpdate, CampaignOfferType } from '@/lib/growth/contracts';
+
+type OfferType = NonNullable<CampaignOfferType>;
+
+export function FramingEditor({
+  campaignId,
+  proposal,
+  copywriterAvailable,
+  onRegenerated,
+}: {
+  campaignId: string;
+  proposal: CampaignProposal;
+  copywriterAvailable: boolean;
+  onRegenerated: () => void;
+}) {
+  const { toast } = useToast();
+  const [busy, startGen] = useTransition();
+
+  const [point, setPoint] = useState(proposal.occasion?.point ?? '');
+  const [occasionName, setOccasionName] = useState(proposal.occasion?.name ?? '');
+  const [generalAngle, setGeneralAngle] = useState(proposal.generalAngle ?? '');
+  const [offerType, setOfferType] = useState<OfferType>((proposal.offer?.type as OfferType) ?? (proposal.offer?.discountPct != null ? 'percent' : 'none'));
+  const [discountPct, setDiscountPct] = useState(String(proposal.offer?.discountPct ?? ''));
+  const [freeNightAfter, setFreeNightAfter] = useState(String(proposal.offer?.freeNightAfter ?? ''));
+  const [amount, setAmount] = useState(String(proposal.offer?.amount ?? ''));
+  const [offerDesc, setOfferDesc] = useState(proposal.offer?.description ?? '');
+  const [updates, setUpdates] = useState<CampaignUpdate[]>(proposal.updates ?? []);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const buildOffer = (): CampaignOffer => {
+    const base = { type: offerType, description: offerDesc } as CampaignOffer;
+    if (offerType === 'percent') base.discountPct = discountPct ? Number(discountPct) : null;
+    if (offerType === 'free_night') base.freeNightAfter = freeNightAfter ? Number(freeNightAfter) : undefined;
+    if (offerType === 'fixed') base.amount = amount ? Number(amount) : undefined;
+    return base;
+  };
+
+  const setUpdate = (i: number, patch: Partial<CampaignUpdate>) =>
+    setUpdates((prev) => prev.map((u, idx) => (idx === i ? { ...u, ...patch } : u)));
+  const addUpdate = () => setUpdates((prev) => [...prev, { id: `u${prev.length + 1}`, text: '', effectiveDate: '' }]);
+  const removeUpdate = (i: number) => setUpdates((prev) => prev.filter((_, idx) => idx !== i));
+
+  const regenerate = () =>
+    startGen(async () => {
+      setErrors([]);
+      const framing = {
+        occasion: { name: occasionName || null, point },
+        offer: buildOffer(),
+        updates: updates.filter((u) => u.text.trim() && u.effectiveDate.trim()),
+        generalAngle,
+      };
+      const res = await generateMessagesAction(campaignId, framing);
+      if (res.success && res.ok) {
+        toast({ title: `Regenerated ${res.count ?? 0} messages`, description: 'Review them below, then approve to queue.' });
+        onRegenerated();
+      } else if (res.success && !res.ok) {
+        setErrors(res.errors ?? ['The copywriter output failed validation — nothing was changed.']);
+        toast({ title: 'Generation rejected', description: 'Some drafts failed the checks — messages left unchanged.', variant: 'destructive' });
+      } else {
+        toast({ title: 'Could not generate', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Campaign framing</CardTitle>
+        <CardDescription>
+          Shape the idea here — occasion, offer, and any news to announce. Hit “Save &amp; regenerate” and the
+          copywriter rewrites every message in your voice, adapting the offer and news per guest.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          <Label className="text-xs">Occasion — what &amp; why now</Label>
+          <Input value={occasionName} onChange={(e) => setOccasionName(e.target.value)} placeholder="e.g. Quiet September escape" className="mb-1" />
+          <Textarea value={point} onChange={(e) => setPoint(e.target.value)} rows={2} placeholder="One or two lines the copywriter anchors on." />
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[160px_1fr]">
+          <div className="space-y-1">
+            <Label className="text-xs">Offer</Label>
+            <select
+              value={offerType}
+              onChange={(e) => setOfferType(e.target.value as OfferType)}
+              className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+            >
+              <option value="none">No discount (first-pick)</option>
+              <option value="percent">Percent off</option>
+              <option value="free_night">Free night</option>
+              <option value="fixed">Fixed amount off</option>
+            </select>
+            {offerType === 'percent' && (
+              <Input value={discountPct} onChange={(e) => setDiscountPct(e.target.value)} placeholder="% e.g. 10" inputMode="numeric" />
+            )}
+            {offerType === 'free_night' && (
+              <Input value={freeNightAfter} onChange={(e) => setFreeNightAfter(e.target.value)} placeholder="free after N nights, e.g. 3" inputMode="numeric" />
+            )}
+            {offerType === 'fixed' && (
+              <Input value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="RON off, e.g. 200" inputMode="numeric" />
+            )}
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs">Offer wording (the copywriter may adapt it per guest)</Label>
+            <Textarea value={offerDesc} onChange={(e) => setOfferDesc(e.target.value)} rows={2} placeholder="e.g. 10% la rezervarea directa" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label className="text-xs">News to announce (only reaches guests who last stayed before each date)</Label>
+            <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={addUpdate}><Plus className="mr-1 h-3.5 w-3.5" /> Add</Button>
+          </div>
+          {updates.length === 0 && <p className="text-xs text-muted-foreground">No news — the copywriter won’t announce anything new.</p>}
+          {updates.map((u, i) => (
+            <div key={i} className="flex items-start gap-2">
+              <Textarea value={u.text} onChange={(e) => setUpdate(i, { text: e.target.value })} rows={2} placeholder="e.g. am pus un ciubar cu apa calda afara" className="flex-1 text-sm" />
+              <div className="flex flex-col gap-1">
+                <Input type="date" value={u.effectiveDate} onChange={(e) => setUpdate(i, { effectiveDate: e.target.value })} className="w-40 text-xs" />
+                <Button size="icon" variant="ghost" className="h-7 w-7 self-end" onClick={() => removeUpdate(i)} aria-label="Remove"><X className="h-4 w-4" /></Button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-1">
+          <Label className="text-xs">Angle (guidance for the copywriter — not sent to guests)</Label>
+          <Textarea value={generalAngle} onChange={(e) => setGeneralAngle(e.target.value)} rows={2} />
+        </div>
+
+        {errors.length > 0 && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+            <p className="mb-1 flex items-center gap-1 font-medium"><AlertCircle className="h-3.5 w-3.5" /> Generation rejected — messages unchanged:</p>
+            <ul className="space-y-0.5">{errors.map((e, i) => <li key={i}>• {e}</li>)}</ul>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3 border-t pt-3">
+          <Button onClick={regenerate} disabled={busy || !copywriterAvailable}>
+            {busy ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Wand2 className="mr-1 h-4 w-4" />}
+            Save &amp; regenerate messages
+          </Button>
+          {!copywriterAvailable && <span className="text-xs text-muted-foreground">Copywriter unavailable — ANTHROPIC_API_KEY not set.</span>}
+          {busy && <span className="text-xs text-muted-foreground">Writing per-guest messages…</span>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/campaigns/_components/proposal-review.tsx
+++ b/src/app/admin/campaigns/_components/proposal-review.tsx
@@ -9,7 +9,7 @@
  * approves. "Approve & queue" pushes the reviewed bodies through the gateway into the outbox — it
  * sends nothing; the owner sends manually in Gate 2. All guardrails re-run at send time.
  */
-import { useEffect, useState, useTransition } from 'react';
+import { useCallback, useEffect, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -19,6 +19,7 @@ import { useToast } from '@/hooks/use-toast';
 import { Loader2, Send, Trash2, Sparkles, Tag, CheckCircle2, Circle, AlertTriangle } from 'lucide-react';
 import { fetchProposalAction, approveProposalAction, discardDraftCampaignAction, type ProposalReviewRow } from '../actions';
 import type { CampaignProposal } from '@/lib/growth/contracts';
+import { FramingEditor } from './framing-editor';
 
 export function ProposalReview({ campaignId }: { campaignId: string }) {
   const router = useRouter();
@@ -33,22 +34,22 @@ export function ProposalReview({ campaignId }: { campaignId: string }) {
   const [rows, setRows] = useState<ProposalReviewRow[]>([]);
   const [bodies, setBodies] = useState<Record<string, string>>({});
   const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [copywriterAvailable, setCopywriterAvailable] = useState(false);
 
-  useEffect(() => {
-    let alive = true;
-    fetchProposalAction(campaignId).then((res) => {
-      if (!alive) return;
-      if (res.success && res.proposal && res.rows) {
-        setProposal(res.proposal);
-        setRows(res.rows);
-        setBodies(Object.fromEntries(res.rows.map((r) => [r.guestId, r.body])));
-      } else {
-        setError(res.error ?? 'Failed to load proposal');
-      }
-      setLoading(false);
-    });
-    return () => { alive = false; };
+  const load = useCallback(async () => {
+    const res = await fetchProposalAction(campaignId);
+    if (res.success && res.proposal && res.rows) {
+      setProposal(res.proposal);
+      setRows(res.rows);
+      setBodies(Object.fromEntries(res.rows.map((r) => [r.guestId, r.body])));
+      setCopywriterAvailable(!!res.copywriterAvailable);
+    } else {
+      setError(res.error ?? 'Failed to load proposal');
+    }
+    setLoading(false);
   }, [campaignId]);
+
+  useEffect(() => { void load(); }, [load]);
 
   const toggle = (guestId: string) =>
     setExcluded((prev) => { const next = new Set(prev); next.has(guestId) ? next.delete(guestId) : next.add(guestId); return next; });
@@ -84,7 +85,17 @@ export function ProposalReview({ campaignId }: { campaignId: string }) {
 
   return (
     <div className="space-y-6">
-      {/* What & why now */}
+      {/* Gate 0 — edit the framing, regenerate the messages */}
+      {proposal && (
+        <FramingEditor
+          campaignId={campaignId}
+          proposal={proposal}
+          copywriterAvailable={copywriterAvailable}
+          onRegenerated={() => { void load(); }}
+        />
+      )}
+
+      {/* What & why now (read-only summary of the current framing) */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -5,12 +5,14 @@ import { loggers } from '@/lib/logger';
 import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
 import type { Campaign, SegmentDefinition, MessageVariant, OutboxMessage } from '@/types';
 import { PREDEFINED_SEGMENTS, previewAudience } from '@/services/segmentService';
-import { listCampaigns, createCampaign, approveCampaign, sendCampaign, createManualCampaign, markCampaignQueued, markCampaignSent, deleteCampaign, getCampaign } from '@/services/campaignService';
+import { listCampaigns, createCampaign, approveCampaign, sendCampaign, createManualCampaign, markCampaignQueued, markCampaignSent, deleteCampaign, getCampaign, updateCampaignFraming, campaignToBrief, setCampaignDrafts } from '@/services/campaignService';
 import { buildAudience, type AudienceCandidate } from '@/services/audienceService';
 import { renderMessages, queueMessages, queueDrafts, type RenderedMessage, type SkippedRender } from '@/services/campaignMessaging';
 import { fetchOutboxForCampaign, markOutboxSent } from '@/services/outboxService';
 import { getGuestById } from '@/services/guestService';
-import type { CampaignProposal, ProposedDraft } from '@/lib/growth/contracts';
+import { generateDrafts } from '@/services/growth/copywriter';
+import { isCopywriterAvailable } from '@/lib/growth/anthropic';
+import { toProposedDrafts, type CampaignProposal, type ProposedDraft, type CampaignOffer, type CampaignUpdate } from '@/lib/growth/contracts';
 
 const logger = loggers.campaign;
 
@@ -283,7 +285,7 @@ export interface ProposalReviewRow extends ProposedDraft {
  */
 export async function fetchProposalAction(
   campaignId: string
-): Promise<{ success: boolean; proposal?: CampaignProposal; rows?: ProposalReviewRow[]; error?: string }> {
+): Promise<{ success: boolean; proposal?: CampaignProposal; rows?: ProposalReviewRow[]; copywriterAvailable?: boolean; error?: string }> {
   try {
     await requireSuperAdmin();
   } catch (error) {
@@ -304,10 +306,45 @@ export async function fetchProposalAction(
         return { ...d, name, phone: g?.normalizedPhone || g?.phone || null };
       })
     );
-    return { success: true, proposal, rows };
+    return { success: true, proposal, rows, copywriterAvailable: isCopywriterAvailable() };
   } catch (error) {
     logger.error('fetchProposalAction failed', error as Error);
     return { success: false, error: 'Failed to load proposal' };
+  }
+}
+
+/**
+ * Gate 0: save the owner's edited FRAMING and (re)generate the per-guest messages with the in-app
+ * copywriter. Persists new drafts only if they pass validation — a rejected generation returns its
+ * errors and leaves the existing drafts untouched. This is the "edit the idea → regenerate" loop.
+ */
+export async function generateMessagesAction(
+  campaignId: string,
+  framing: { occasion: { name: string | null; point: string }; offer: CampaignOffer; updates: CampaignUpdate[]; generalAngle: string }
+): Promise<{ success: boolean; ok?: boolean; count?: number; errors?: string[]; warnings?: string[]; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return handleAuthError(error);
+    throw error;
+  }
+  if (!isCopywriterAvailable()) {
+    return { success: false, error: 'The copywriter is not configured (ANTHROPIC_API_KEY missing).' };
+  }
+  try {
+    await updateCampaignFraming(campaignId, framing);
+    const campaign = await getCampaign(campaignId);
+    if (!campaign) return { success: false, error: 'Campaign not found' };
+    const brief = campaignToBrief(campaign);
+    const res = await generateDrafts(brief);
+    if (res.ok) {
+      await setCampaignDrafts(campaignId, toProposedDrafts(brief, res.drafts));
+    }
+    revalidatePath(`/admin/campaigns/${campaignId}`);
+    return { success: true, ok: res.ok, count: res.drafts.length, errors: res.errors, warnings: res.warnings };
+  } catch (error) {
+    logger.error('generateMessagesAction failed', error as Error);
+    return { success: false, error: (error as Error).message || 'Failed to generate messages' };
   }
 }
 

--- a/src/lib/growth/anthropic.ts
+++ b/src/lib/growth/anthropic.ts
@@ -1,0 +1,36 @@
+/**
+ * anthropic — lazy, gracefully-degrading Claude client for the Opportunity Engine's in-app LLM
+ * stages (the copywriter today; the planner/analyst later). Server-side ONLY — never import from a
+ * client component (the key is a RUNTIME secret).
+ *
+ * Mirrors the whatsappService pattern: if ANTHROPIC_API_KEY is absent, `getAnthropicClient()`
+ * returns null and callers degrade (surface "LLM not configured") instead of throwing at import.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.campaign;
+
+/** The default model for Opportunity-Engine generation. Opus 4.8 (per the claude-api guidance). */
+export const COPYWRITER_MODEL = 'claude-opus-4-8';
+
+let client: Anthropic | null = null;
+let triedInit = false;
+
+/** Lazily construct the client. Returns null if the key is not configured (degrade, don't crash). */
+export function getAnthropicClient(): Anthropic | null {
+  if (triedInit) return client;
+  triedInit = true;
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    logger.warn('ANTHROPIC_API_KEY not set — in-app LLM stages will be unavailable');
+    return null;
+  }
+  client = new Anthropic({ apiKey });
+  return client;
+}
+
+/** True if the copywriter can run in-app (key present). Used to gate the Gate-0 "Generate" button. */
+export function isCopywriterAvailable(): boolean {
+  return !!process.env.ANTHROPIC_API_KEY;
+}

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -41,8 +41,10 @@ export interface BriefAudienceEntry {
  * the form, `effectiveDiscountPct()` derives the economic size the margin guard checks — the
  * copywriter only ever PHRASES this (channel-aware), never inflates it.
  */
+export type CampaignOfferType = 'percent' | 'free_night' | 'fixed' | 'none';
+
 export interface CampaignOffer {
-  type?: 'percent' | 'free_night' | 'fixed' | 'none';
+  type?: CampaignOfferType;
   discountPct?: number | null;   // percent offers (also the back-compat field)
   freeNightAfter?: number;       // free_night: stay N nights, the (N+1)th is free
   amount?: number;               // fixed: absolute amount off (currency = RON)

--- a/src/lib/growth/copywriterPack.ts
+++ b/src/lib/growth/copywriterPack.ts
@@ -145,7 +145,7 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
     },
     voiceRules: {
       language: 'Write each message in that guest\'s writeLanguage (thread-detected: "ro" or "en"). Romanian is written WITHOUT diacritics (matches the owner). Do NOT trust recordLanguage — it is a blanket "ro" default. An English-speaking expat living here (RO phone) gets an English message.',
-      register: 'Pick ONE register per message and keep it consistent throughout — either tu (informal: tu/iti/te) OR voi/dumneavoastra (formal: voi/va/ati). Never mix the two in the same message. If the thread shows how the owner addressed this guest before, match it; otherwise default to the informal tu for a warm, personal feel.',
+      register: 'Pick ONE register per message and keep it consistent throughout — either tu (informal: tu/iti/te/ai) OR voi/dumneavoastra (formal: voi/va/ati). NEVER mix them in the same message (not even "ati fost… iti dau"). Choose per guest: if there is a prior thread, match how the owner addressed them there; if there is NO prior thread (a first contact), use polite voi (you do not address a stranger with tu); otherwise default to the warm informal tu.',
       length: '300–600 characters, 3–6 short sentences',
       noEmoji: true,
       selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',

--- a/src/lib/growth/copywriterPack.ts
+++ b/src/lib/growth/copywriterPack.ts
@@ -1,0 +1,159 @@
+/**
+ * copywriterPack — builds the deterministic FACT PACK the WhatsApp copywriter drafts from, for a
+ * given CampaignBrief (the framing). Shared by the CLI (scripts/copywriter-pack.ts) and the in-app
+ * copywriter (src/services/growth/copywriter.ts) so both reason from the SAME facts.
+ *
+ * For each selected guest it assembles: the full verbatim WhatsApp thread (tone + non-repetition),
+ * a dossier (incl. booking-channel history), the `applicableUpdates` (campaign news date-filtered to
+ * guests it's genuinely new for), and the `groundedFacts` whitelist — the explicit list of guest-
+ * specific facts the copywriter may assert (validateDrafts enforces factsUsed ⊆ groundedFacts).
+ * Plus the shared voice profile (owner's own past messages, outcome-labeled) and voice rules.
+ * Facts + method + constraints, no conclusions (plan §2 pr.5 / §7.5–7.6).
+ *
+ * Server-only (uses the Admin SDK).
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { detectLanguage } from '@/lib/growth/audience';
+import type { CampaignBrief } from '@/lib/growth/contracts';
+
+const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'winter' : m <= 5 ? 'spring' : m <= 8 ? 'summer' : 'autumn'; };
+function lastStayPhrase(last: Date | null, asOf: Date): string | null {
+  if (!last) return null;
+  const y = last.getUTCFullYear(), nowY = asOf.getUTCFullYear();
+  const s = ({ winter: 'iarna', spring: 'primavara', summer: 'vara', autumn: 'toamna' } as any)[seasonOf(last)];
+  if (last.getUTCMonth() + 1 === 12 && last.getUTCDate() >= 27) return 'de Revelion';
+  return y === nowY ? `${s} aceasta` : y === nowY - 1 ? `${s} trecuta` : `in ${s} lui ${y}`;
+}
+
+export interface CopywriterPack {
+  meta: { generatedFor: string; asOf: string; generator: string; briefId?: string };
+  campaign: { occasion: unknown; offer: unknown; updates: unknown[]; intent: string; generalAngle: string };
+  voiceProfile: { note: string; exemplars: Array<{ outcome: string; date: string; text: string }> };
+  voiceRules: Record<string, unknown>;
+  guests: any[];
+}
+
+/** Build the copywriter fact pack for a brief. `asOf` defaults to now (UTC midnight). */
+export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: Date; ownerName?: string }): Promise<CopywriterPack> {
+  const AS_OF = opts?.asOf ?? new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00Z`);
+  const wantIds: string[] = brief.audience.map((a) => a.guestId);
+  const careByGuest = new Map(brief.audience.map((a) => [a.guestId, a.careFlags || []]));
+  const framingUpdates: any[] = brief.updates || [];
+
+  const db = await getAdminDb();
+  const [gSnap, bSnap, rSnap, tSnap] = await Promise.all([
+    db.collection('guests').get(), db.collection('bookings').get(),
+    db.collection('reviews').get(), db.collection('whatsappThreads').get(),
+  ]);
+  const guestById = new Map(gSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
+  const reviewsBy = new Map<string, any[]>();
+  rSnap.docs.forEach(d => { const r: any = { id: d.id, ...d.data() }; if (!r.guestId) return; (reviewsBy.get(r.guestId) || reviewsBy.set(r.guestId, []).get(r.guestId)!).push(r); });
+
+  // ── voice profile: the owner's own substantive outbound, outcome-labeled (§7.6) ──
+  const exemplars: any[] = [];
+  tSnap.docs.forEach(d => {
+    const t: any = d.data(); const g = guestById.get(d.id);
+    const stays = g ? ((g as any).bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean) : [];
+    (t.messages || []).forEach((m: any, i: number) => {
+      if (m.direction !== 'out' || (m.text || '').length < 260) return;
+      const after = (t.messages || []).slice(i + 1);
+      const replied = after.some((x: any) => x.direction === 'in' && (+new Date(x.ts) - +new Date(m.ts)) / 86400000 <= 14);
+      const booked = stays.some((b: any) => { const c = toD(b.createdAt); return c && +c > +new Date(m.ts) && (+c - +new Date(m.ts)) / 86400000 <= 90; });
+      exemplars.push({ text: m.text, len: (m.text || '').length, outcome: booked ? 'booked' : replied ? 'replied' : 'silent', date: String(m.ts).slice(0, 10) });
+    });
+  });
+  exemplars.sort((a, b) => (b.outcome === 'booked' ? 1 : 0) - (a.outcome === 'booked' ? 1 : 0) || b.len - a.len);
+  const voiceExemplars = [
+    ...exemplars.filter(e => e.outcome === 'booked').slice(0, 3),
+    ...exemplars.filter(e => e.outcome === 'replied').slice(0, 5),
+    ...exemplars.filter(e => e.outcome === 'silent').slice(0, 2),
+  ].map(e => ({ outcome: e.outcome, date: e.date, text: e.text }));
+
+  // ── per-guest packs ──
+  const guests = wantIds.map(gid => {
+    const g: any = guestById.get(gid);
+    if (!g) return { guestId: gid, error: 'guest not found' };
+    const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
+      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
+      .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
+    const lastBk: any = stayB.length ? stayB[stayB.length - 1] : null;
+    const last = lastBk ? toD(lastBk.checkInDate) : null;
+    const channels = stayB.map((b: any) => String(b.source || '').toLowerCase()).filter(Boolean);
+    const directCount = channels.filter((c: string) => c === 'direct').length;
+    const otaCount = channels.length - directCount;
+    const lastChannel = channels.length ? channels[channels.length - 1] : null;
+    const booksDirect = directCount > 0;
+    const applicableUpdates = framingUpdates.filter((u: any) => {
+      const eff = toD(u.effectiveDate); return eff && last && +last < +eff;
+    }).map((u: any) => ({ id: u.id, text: u.text }));
+    const rv = reviewsBy.get(gid) || [];
+    const reviewThemes = [...new Set(rv.flatMap((r: any) => { const t = r.tags; return Array.isArray(t) ? t : t && typeof t === 'object' ? Object.values(t).flat() : []; }))]
+      .filter(x => typeof x === 'string' && !/^\+\d+ more$/i.test(x)) as string[];
+    const th = threads.get(gid);
+    const thread = ((th?.messages || []) as any[]).filter(m => m.ts < ymd(AS_OF)).map(m => ({ ts: m.ts, dir: m.direction, text: m.text }));
+    const totalBookings = g.totalBookings ?? stayB.length;
+    const threadText = thread.map(m => m.text || '').join(' ');
+    const detected = detectLanguage(threadText);
+    const writeLanguage = detected === 'unknown' ? (g.language || 'ro') : detected;
+
+    const groundedFacts: any[] = [];
+    if (g.firstName) groundedFacts.push({ key: 'firstName', value: g.firstName, source: `guests/${gid}` });
+    if (last) groundedFacts.push({ key: 'lastStayPhrase', value: lastStayPhrase(last, AS_OF), source: `bookings/${lastBk.id}` });
+    if (last) groundedFacts.push({ key: 'lastStaySeason', value: seasonOf(last), source: `bookings/${lastBk.id}` });
+    if (lastBk?.numberOfGuests) groundedFacts.push({ key: 'partySize', value: lastBk.numberOfGuests, source: `bookings/${lastBk.id}` });
+    if (lastBk && (lastBk.numberOfChildren ?? 0) > 0) groundedFacts.push({ key: 'hadChildren', value: true, source: `bookings/${lastBk.id}` });
+    if (totalBookings >= 2) groundedFacts.push({ key: 'isRepeatGuest', value: totalBookings, source: `guests/${gid}` });
+    if (booksDirect) groundedFacts.push({ key: 'booksDirect', value: { directBookings: directCount, otaBookings: otaCount }, source: `bookings(guests/${gid})` });
+    reviewThemes.forEach(t => groundedFacts.push({ key: `reviewPraised:${t}`, value: t, source: `reviews/${(rv[0] || {}).id || gid}` }));
+    applicableUpdates.forEach((u: any) => groundedFacts.push({ key: `update:${u.id}`, value: u.text, source: 'campaign.updates' }));
+
+    return {
+      guestId: gid,
+      firstName: g.firstName || null,
+      writeLanguage,
+      recordLanguage: g.language || null,
+      threadLanguageDetected: detected,
+      careFlags: careByGuest.get(gid) || [],
+      dossier: {
+        tier: totalBookings >= 2 ? 'repeat' : 'single',
+        totalBookings,
+        lastStay: last ? ymd(last) : null,
+        lastStayPhrase: lastStayPhrase(last, AS_OF),
+        lastStaySeason: last ? seasonOf(last) : null,
+        partySize: lastBk?.numberOfGuests ?? null,
+        hadChildren: lastBk ? (lastBk.numberOfChildren ?? 0) > 0 : null,
+        reviewThemes,
+        bookingChannel: { lastChannel, directCount, otaCount },
+      },
+      applicableUpdates,
+      groundedFacts,
+      thread,
+      threadNote: thread.length ? `${thread.length} prior messages — read to AVOID repeating what was already said, and to match tone. Do NOT assert a new guest-specific fact from the thread that is not in groundedFacts.` : 'no prior WhatsApp history — a first contact; include the opt-out line.',
+    };
+  });
+
+  return {
+    meta: { generatedFor: brief.propertyId, asOf: ymd(AS_OF), generator: 'src/lib/growth/copywriterPack.ts', briefId: brief.opportunity?.id },
+    campaign: { occasion: brief.occasion, offer: brief.offer, updates: framingUpdates, intent: brief.intent, generalAngle: brief.generalAngle },
+    voiceProfile: {
+      note: 'Imitate this register — these are the owner\'s REAL past messages, tagged by outcome (booked/replied/silent). Copy the voice, not the content. Prefer what "booked".',
+      exemplars: voiceExemplars,
+    },
+    voiceRules: {
+      language: 'Write each message in that guest\'s writeLanguage (thread-detected: "ro" or "en"). Romanian is written WITHOUT diacritics (matches the owner). Do NOT trust recordLanguage — it is a blanket "ro" default. An English-speaking expat living here (RO phone) gets an English message.',
+      length: '300–600 characters, 3–6 short sentences',
+      noEmoji: true,
+      selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',
+      optOut: 'include a soft opt-out line only on a FIRST contact (no prior thread); otherwise rely on WhatsApp block/report',
+      grounding: 'assert ONLY facts present in that guest\'s groundedFacts; tag each claim in factsUsed with its key. No emoji. No invented stays/preferences.',
+      offerPresentation: 'The offer (campaign.offer) is set by the owner — never inflate or invent one, only phrase it. Adapt HOW you present it per guest: a guest with a `booksDirect` fact already knows they get your best price directly, so acknowledge that warmly (e.g. "si asa cum stii deja, iti pot da cea mai buna oferta direct") rather than quoting a discount as if it were news; a guest who has only booked via an OTA gets the explicit offer. For a free-night/value offer, describe the value in words, not a bare percentage. Tag `booksDirect` in factsUsed when you use that angle.',
+      updates: 'Each guest\'s `applicableUpdates` lists campaign news that is genuinely new SINCE THAT guest\'s last stay (already date-filtered — a guest who was here after a change does not see it). Decide per guest whether an update is worth mentioning and how to weave it in — do not force it into every message. You may mention ONLY updates in that guest\'s applicableUpdates, tagging factsUsed with the `update:<id>` key.',
+      sentiment: 'always positive. For a careFlag complaint: if (and only if) an issueResolved:* fact is present, you MAY add a warm PS acknowledging the fix; otherwise do NOT mention the past problem at all — write a normal forward-looking message.',
+    },
+    guests,
+  };
+}

--- a/src/lib/growth/copywriterPack.ts
+++ b/src/lib/growth/copywriterPack.ts
@@ -145,6 +145,7 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
     },
     voiceRules: {
       language: 'Write each message in that guest\'s writeLanguage (thread-detected: "ro" or "en"). Romanian is written WITHOUT diacritics (matches the owner). Do NOT trust recordLanguage — it is a blanket "ro" default. An English-speaking expat living here (RO phone) gets an English message.',
+      register: 'Pick ONE register per message and keep it consistent throughout — either tu (informal: tu/iti/te) OR voi/dumneavoastra (formal: voi/va/ati). Never mix the two in the same message. If the thread shows how the owner addressed this guest before, match it; otherwise default to the informal tu for a warm, personal feel.',
       length: '300–600 characters, 3–6 short sentences',
       noEmoji: true,
       selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',

--- a/src/lib/growth/validateDrafts.ts
+++ b/src/lib/growth/validateDrafts.ts
@@ -33,7 +33,7 @@ export interface DraftRules {
 const DEFAULTS: Required<DraftRules> = {
   minChars: 200, maxChars: 700,
   selfIdMarkers: ['bogdan', 'comarnic', 'casuta', 'căsuța'],
-  optOutMarkers: ['stop', 'dezabon', 'nu va mai', 'nu mai doriti', 'nu mai vreti', 'spuneti-mi', 'scrieti-mi', 'nu va mai deranjez'],
+  optOutMarkers: ['stop', 'dezabon', 'nu va mai', 'nu te mai', 'nu iti mai scriu', 'nu mai doriti', 'nu mai vreti', 'spuneti-mi', 'scrieti-mi', 'nu va mai deranjez'],
 };
 const EMOJI = /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{2B00}-\u{2BFF}️]/u;
 const COMPLAINT_WORDS = /problem|scuze|imi pare rau|îmi pare rău|neplac|deranj|presiune|defect|stricat|reparat|rezolvat/i;

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -166,6 +166,55 @@ export async function createProposedCampaign(input: {
   return ref.id;
 }
 
+/** Reconstruct a CampaignBrief from a stored proposed campaign (framing + audience with angles). */
+export function campaignToBrief(
+  campaign: Campaign
+): import('@/lib/growth/contracts').CampaignBrief {
+  const p = (campaign as unknown as { proposal?: import('@/lib/growth/contracts').CampaignProposal }).proposal;
+  const drafts = (campaign as unknown as { perGuestDrafts?: import('@/lib/growth/contracts').ProposedDraft[] }).perGuestDrafts ?? [];
+  if (!p) throw new Error('campaignToBrief: campaign has no proposal (framing)');
+  return {
+    propertyId: campaign.propertyId,
+    opportunity: p.opportunity,
+    act: true,
+    intent: p.intent,
+    occasion: p.occasion,
+    offer: p.offer,
+    updates: p.updates ?? [],
+    audience: drafts.map((d) => ({ guestId: d.guestId, angle: d.angle, careFlags: d.careFlags })),
+    generalAngle: p.generalAngle,
+    rationale: p.rationale,
+  };
+}
+
+/** Persist owner edits to a draft campaign's FRAMING (the Gate-0 fields). Does not regenerate. */
+export async function updateCampaignFraming(
+  id: string,
+  framing: Partial<Pick<import('@/lib/growth/contracts').CampaignProposal, 'occasion' | 'offer' | 'updates' | 'generalAngle'>>
+): Promise<void> {
+  const db = await getAdminDb();
+  const patch: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
+  if (framing.occasion !== undefined) patch['proposal.occasion'] = framing.occasion;
+  if (framing.offer !== undefined) patch['proposal.offer'] = framing.offer;
+  if (framing.updates !== undefined) patch['proposal.updates'] = framing.updates;
+  if (framing.generalAngle !== undefined) patch['proposal.generalAngle'] = framing.generalAngle;
+  await db.collection('campaigns').doc(id).update(patch);
+  logger.info('Campaign framing updated', { campaignId: id, fields: Object.keys(framing) });
+}
+
+/** Replace the per-guest drafts on a campaign (after a copywriter (re)generation). */
+export async function setCampaignDrafts(
+  id: string,
+  drafts: import('@/lib/growth/contracts').ProposedDraft[]
+): Promise<void> {
+  const db = await getAdminDb();
+  await db.collection('campaigns').doc(id).update({
+    perGuestDrafts: drafts,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  logger.info('Campaign drafts set', { campaignId: id, count: drafts.length });
+}
+
 /** Approve a manual campaign: store the copy, record the approver, move to sending. */
 export async function markCampaignQueued(
   id: string,

--- a/src/services/growth/copywriter.ts
+++ b/src/services/growth/copywriter.ts
@@ -1,0 +1,138 @@
+/**
+ * copywriter (in-app) — turns an approved campaign FRAMING (CampaignBrief) into one grounded,
+ * voice-matched WhatsApp message per selected guest, by calling Claude with the deterministic
+ * copywriter fact pack. This is the server-side runtime of the .claude/skills/whatsapp-copywriter
+ * skill: same pack, same rules, same grounding contract — just executed in-app so the owner can
+ * hit "Generate" in Admin instead of an operator running it.
+ *
+ * Guardrails on truth + margin are enforced in CODE (validateDrafts: factsUsed ⊆ groundedFacts,
+ * no emoji, self-ID, opt-out, sentiment). The LLM owns relevance, presentation, and voice. A
+ * bounded repair loop feeds validator errors back once before giving up.
+ *
+ * Server-only. Degrades (throws a clear error) if ANTHROPIC_API_KEY is absent.
+ */
+import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import { buildCopywriterPack } from '@/lib/growth/copywriterPack';
+import { validateDrafts, type GuestForDraftValidation } from '@/lib/growth/validateDrafts';
+import type { CampaignBrief, DraftMessage } from '@/lib/growth/contracts';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.campaign;
+
+const DRAFTS_TOOL = {
+  name: 'emit_drafts',
+  description: 'Emit the final per-guest WhatsApp drafts, one object per selected guest.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      drafts: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            guestId: { type: 'string' },
+            language: { type: 'string', enum: ['ro', 'en'] },
+            body: { type: 'string', description: 'the full message, ready to send' },
+            factsUsed: { type: 'array', items: { type: 'string' }, description: 'the groundedFacts key of every guest-specific claim made' },
+            careHandled: { type: 'string', description: 'how any careFlag was handled (empty if none)' },
+          },
+          required: ['guestId', 'language', 'body', 'factsUsed'],
+        },
+      },
+    },
+    required: ['drafts'],
+  },
+};
+
+const SYSTEM = `You are the WhatsApp copywriter for a small Romanian mountain-chalet rental. You write one
+message per selected past guest, in the OWNER's voice, grounded in what is genuinely true about THAT
+guest, never a broadcast. You draft only — the owner reviews and sends by hand.
+
+THE THREE RULES
+1. Ground every guest-specific claim. You may only state a fact about a guest that appears in that
+   guest's groundedFacts. List in factsUsed the exact keys of every guest-specific claim you made.
+   Never invent stays, preferences, names, numbers, or updates. The thread is for AVOIDING repetition
+   and matching tone — not a licence to assert new facts.
+2. Write in the owner's voice (study voiceProfile.exemplars — lean toward what "booked"; copy the
+   register, not the content) and in each guest's writeLanguage. Romanian WITHOUT diacritics. Obey
+   every rule in voiceRules (length, no emoji, self-identification on line one, opt-out only on a
+   first contact = empty thread, offer presentation, updates).
+3. Positive and careful. Every message is warm and forward-looking. Follow voiceRules.sentiment for
+   any careFlag; never reference an unresolved problem.
+
+Return your work by calling the emit_drafts tool with exactly one draft per guest in the pack — no
+prose, no extra guests, none skipped.`;
+
+function packGuestsForValidation(pack: Awaited<ReturnType<typeof buildCopywriterPack>>): GuestForDraftValidation[] {
+  return pack.guests
+    .filter((g: any) => !g.error)
+    .map((g: any) => ({ guestId: g.guestId, careFlags: g.careFlags || [], groundedFacts: g.groundedFacts || [], thread: g.thread || [] }));
+}
+
+export interface GenerateDraftsResult {
+  ok: boolean;
+  drafts: DraftMessage[];
+  errors: string[];
+  warnings: string[];
+  attempts: number;
+}
+
+/**
+ * Generate per-guest drafts for a framing. Runs the LLM, validates, and on failure feeds the
+ * validator errors back for ONE bounded repair before returning (ok:false + errors) — never
+ * silently ships an ungrounded message.
+ */
+export async function generateDrafts(brief: CampaignBrief, opts?: { asOf?: Date; maxRepairs?: number }): Promise<GenerateDraftsResult> {
+  const client = getAnthropicClient();
+  if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app copywriter is unavailable');
+
+  const pack = await buildCopywriterPack(brief, { asOf: opts?.asOf });
+  const validationGuests = packGuestsForValidation(pack);
+  const maxRepairs = opts?.maxRepairs ?? 1;
+
+  // The pack (facts + voice + rules) as the user turn. Threads can be long; this is one call.
+  const packJson = JSON.stringify({ campaign: pack.campaign, voiceProfile: pack.voiceProfile, voiceRules: pack.voiceRules, guests: pack.guests });
+  const messages: Array<{ role: 'user' | 'assistant'; content: any }> = [
+    { role: 'user', content: `Here is the copywriter pack. Draft one message per guest and call emit_drafts.\n\n${packJson}` },
+  ];
+
+  let drafts: DraftMessage[] = [];
+  let lastValidation = { ok: false, errors: [] as string[], perGuest: [] as Array<{ guestId: string; errors: string[]; warnings: string[] }> };
+
+  for (let attempt = 1; attempt <= maxRepairs + 1; attempt++) {
+    const resp = await client.messages.create({
+      model: COPYWRITER_MODEL,
+      max_tokens: 8192,
+      system: SYSTEM,
+      tools: [DRAFTS_TOOL],
+      tool_choice: { type: 'tool', name: 'emit_drafts' },
+      messages,
+    });
+    const toolUse = resp.content.find((b: any) => b.type === 'tool_use') as any;
+    drafts = (toolUse?.input?.drafts ?? []) as DraftMessage[];
+
+    lastValidation = validateDrafts(validationGuests, drafts);
+    const warnings = lastValidation.perGuest.flatMap((p) => p.warnings.map((w) => `${p.guestId}: ${w}`));
+    logger.info('copywriter generateDrafts attempt', { attempt, drafts: drafts.length, ok: lastValidation.ok, errors: lastValidation.errors.length });
+
+    if (lastValidation.ok) {
+      return { ok: true, drafts, errors: [], warnings, attempts: attempt };
+    }
+    if (attempt > maxRepairs) break;
+
+    // Bounded repair: hand back the exact per-guest errors and ask to fix only those.
+    const perGuestErrs = lastValidation.perGuest.filter((p) => p.errors.length).map((p) => `- ${p.guestId}: ${p.errors.join('; ')}`).join('\n');
+    const campErrs = lastValidation.errors.length ? `Campaign-level: ${lastValidation.errors.join('; ')}\n` : '';
+    messages.push({ role: 'assistant', content: resp.content });
+    messages.push({
+      role: 'user',
+      content: `The validator rejected some drafts. Fix EXACTLY these and re-emit ALL guests via emit_drafts (a bounded repair, not a rewrite):\n${campErrs}${perGuestErrs}\n\nReminder: assert only groundedFacts keys and list them in factsUsed; no emoji; self-ID on line one; opt-out only on first contact.`,
+    });
+  }
+
+  const errors = [
+    ...lastValidation.errors,
+    ...lastValidation.perGuest.filter((p) => p.errors.length).map((p) => `${p.guestId}: ${p.errors.join('; ')}`),
+  ];
+  return { ok: false, drafts, errors, warnings: [], attempts: maxRepairs + 1 };
+}


### PR DESCRIPTION
## What

Makes the framing gate real and self-service. The owner edits the campaign idea in Admin (occasion, offer, news, angle) and hits **Save & regenerate** — the copywriter runs **in-app** (Claude, server-side) and rewrites every per-guest message from the edited framing. Previously the copywriter was operator-run off-screen; this closes the loop.

## Pipeline

```
Gate-0 (edit framing) → generateMessagesAction → in-app copywriter (Claude) → validateDrafts (+1 repair)
   → persist per-guest drafts → Gate-1 review → Gate-2 send
```

## Files

- `@anthropic-ai/sdk`; `src/lib/growth/anthropic.ts` (lazy client, degrades if no key)
- `src/lib/growth/copywriterPack.ts` — pack-building extracted from the CLI into a shared server lib (booking-channel, date-targeted updates, grounding, voice); the CLI now calls it (no drift)
- `src/services/growth/copywriter.ts` — `generateDrafts(brief)`: buildPack → Claude (forced `emit_drafts` tool) → validateDrafts → bounded repair; never ships an ungrounded message
- `campaignService`: `campaignToBrief` / `updateCampaignFraming` / `setCampaignDrafts`
- admin actions: `generateMessagesAction`; `fetchProposalAction` reports `copywriterAvailable`
- `framing-editor.tsx` (Gate-0) + mounted in `proposal-review.tsx`
- `apphosting.yaml`: `ANTHROPIC_API_KEY` runtime secret
- `scripts/test-copywriter.ts` smoke test
- validator: recognise tu-form opt-outs; copywriter voiceRules: register consistency (voi for first-contacts, else tu)

## Test

`npm run build` passes. Smoke-tested end-to-end against the live Sep campaign with a real Claude call: **ok on attempt 1, 14/14 valid**, channel-aware offer + date-targeted news confirmed, opt-out + register fixes verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)