### PR TITLE
fix: regenerate showed the error boundary on success (redundant revalidatePath)

### DIFF
--- a/src/app/admin/campaigns/_components/framing-editor.tsx
+++ b/src/app/admin/campaigns/_components/framing-editor.tsx
@@ -62,21 +62,26 @@ export function FramingEditor({
   const regenerate = () =>
     startGen(async () => {
       setErrors([]);
-      const framing = {
-        occasion: { name: occasionName || null, point },
-        offer: buildOffer(),
-        updates: updates.filter((u) => u.text.trim() && u.effectiveDate.trim()),
-        generalAngle,
-      };
-      const res = await generateMessagesAction(campaignId, framing);
-      if (res.success && res.ok) {
-        toast({ title: `Regenerated ${res.count ?? 0} messages`, description: 'Review them below, then approve to queue.' });
-        onRegenerated();
-      } else if (res.success && !res.ok) {
-        setErrors(res.errors ?? ['The copywriter output failed validation — nothing was changed.']);
-        toast({ title: 'Generation rejected', description: 'Some drafts failed the checks — messages left unchanged.', variant: 'destructive' });
-      } else {
-        toast({ title: 'Could not generate', description: res.error, variant: 'destructive' });
+      try {
+        const framing = {
+          occasion: { name: occasionName || null, point },
+          offer: buildOffer(),
+          updates: updates.filter((u) => u.text.trim() && u.effectiveDate.trim()),
+          generalAngle,
+        };
+        const res = await generateMessagesAction(campaignId, framing);
+        if (res.success && res.ok) {
+          toast({ title: `Regenerated ${res.count ?? 0} messages`, description: 'Review them below, then approve to queue.' });
+          onRegenerated();
+        } else if (res.success && !res.ok) {
+          setErrors(res.errors ?? ['The copywriter output failed validation — nothing was changed.']);
+          toast({ title: 'Generation rejected', description: 'Some drafts failed the checks — messages left unchanged.', variant: 'destructive' });
+        } else {
+          toast({ title: 'Could not generate', description: res.error, variant: 'destructive' });
+        }
+      } catch (e) {
+        // Never let a rejection bubble to the root error boundary — show it inline.
+        toast({ title: 'Could not generate', description: (e as Error)?.message || 'Unexpected error', variant: 'destructive' });
       }
     });
 

--- a/src/app/admin/campaigns/actions.ts
+++ b/src/app/admin/campaigns/actions.ts
@@ -340,7 +340,9 @@ export async function generateMessagesAction(
     if (res.ok) {
       await setCampaignDrafts(campaignId, toProposedDrafts(brief, res.drafts));
     }
-    revalidatePath(`/admin/campaigns/${campaignId}`);
+    // NOTE: no revalidatePath here — the client refetches via fetchProposalAction (load()).
+    // Revalidating the route mid-transition forced a redundant RSC re-render that surfaced as
+    // the root error boundary on success; the client-side refetch is the single refresh path.
     return { success: true, ok: res.ok, count: res.drafts.length, errors: res.errors, warnings: res.warnings };
   } catch (error) {
     logger.error('generateMessagesAction failed', error as Error);


### PR DESCRIPTION
## Symptom
"Save & regenerate" ran ~30s (the Claude call), then redirected to the root error page ("Something went wrong"), even though the messages were regenerated and saved.

## Root cause
`generateMessagesAction` fully succeeded (prod logs: framing updated → generateDrafts → "Campaign drafts set", no ERROR logged). The `revalidatePath(...)` I put inside the action forced an RSC re-render of the route mid-transition; a raw render error there prints to stderr (not the structured stdout logger, hence no captured ERROR) and surfaces as `src/app/error.tsx` on the client. It was also redundant — the client refetches via `fetchProposalAction` (`load()`).

## Fix
- Remove `revalidatePath` from `generateMessagesAction`; the client-side `load()` is the single refresh path for the regenerate loop (framing stays `draft`, no route-level change needed).
- Harden `FramingEditor.regenerate` with try/catch so any rejection shows a toast, never the root boundary.

No data was lost — drafts saved throughout; a reload shows them. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)