### PR TITLE
fix: foreign phone overrides unreliable country=RO in reactivation audience

### DIFF
--- a/src/lib/growth/audience.ts
+++ b/src/lib/growth/audience.ts
@@ -34,12 +34,22 @@ export interface RomaniaBasedInput {
   stays?: number;   // non-cancelled stays (for the repeat-returner extension)
 }
 
-/** Is this guest reachable domestically for reactivation ("lives in Romania", or a proven repeat)? */
+/**
+ * Is this guest reachable domestically for reactivation ("lives in Romania", or a proven repeat)?
+ *
+ * `country` is UNRELIABLE (defaulted to RO across the base, like `language`), so a foreign phone —
+ * a much stronger signal of where someone actually lives — OVERRIDES country=RO. Owner's rule
+ * (2026-07-24): "George lives in the USA, you can see by the phone number." Several RO-diaspora
+ * guests (name Romanian, phone +33/+1/+34/+49/+31) carry country=RO but cannot pop over for a
+ * dated window — they are ads/OTA targets, not WhatsApp reactivation. A proven repeat returner
+ * (2+ stays) still qualifies regardless of location (Artem ×3, Bianca ×2).
+ */
 export function isRomaniaBased(g: RomaniaBasedInput): boolean {
-  if (hasRomanianPhone(g.normalizedPhone) || hasRomanianPhone(g.phone)) return true;
-  if (['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase())) return true;
-  if ((g.stays ?? 0) >= 2) return true;   // repeat returner — worth it regardless of location
-  return false;
+  if ((g.stays ?? 0) >= 2) return true;                 // proven repeat returner — worth it wherever they live
+  const phone = g.normalizedPhone || g.phone;
+  if (hasRomanianPhone(phone)) return true;             // RO phone = strongest "based here" signal
+  if (phone && !hasRomanianPhone(phone)) return false;  // a FOREIGN phone overrides an unreliable country=RO
+  return ['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase()); // no phone → fall back to country
 }
 
 /** Coarse thread-language sniff for the copywriter: which language to actually write in. */


### PR DESCRIPTION
Owner flagged a US-based guest (US phone) in the WhatsApp reactivation audience — he qualified via `country=RO`, which is a blanket-RO default (unreliable, like `language`). 6 RO-diaspora guests (foreign phone, country=RO, single stay) were wrongly included; they're ads/OTA targets, not reactivation.

Reordered `isRomaniaBased`: a foreign phone now overrides `country=RO`; repeat returners (2+ stays) still qualify regardless of location. Verified: all 6 diaspora now excluded, repeat foreign returners kept.

Separately (data, owner request): suppressed Melhem + George (suppressionList + unsubscribed:true) — negative reviews/conduct; George US-based.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)