### PR TITLE
fix: keep diaspora in reactivation, classify residency (corrects #177)

### DIFF
--- a/scripts/planner-pack.ts
+++ b/scripts/planner-pack.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 import { getAdminDb } from '../src/lib/firebaseAdminSafe';
-import { isRomaniaBased } from '../src/lib/growth/audience';
+import { isRomaniaBased, classifyResidency } from '../src/lib/growth/audience';
 
 const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
 const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
@@ -152,6 +152,7 @@ async function main() {
       eligible: reasons.length === 0,
       ineligibleReasons: reasons,
       tier,
+      residency: classifyResidency({ normalizedPhone: g.normalizedPhone, phone: g.phone, country: g.country, stays: stayB.length }),
       totalBookings,
       lastStay: last ? ymd(last) : null,
       daysSinceLastStay: last ? days(last, AS_OF) : null,
@@ -207,6 +208,7 @@ async function main() {
       note: 'Choose WHO (a subset of eligible), the occasion/angle, and the offer. This pack gives raw dossier inputs, NOT a ranking — the selection is your reasoning. Weigh: is the guest DUE (days-since-stay against the return clock)? Does the window FIT them (see below), and does the OCCASION suit them (a school break is a kids window; a quiet weekend suits adults-only)? Prefer people the window actually suits over the merely warm. Do not exceed the run cap. Give a per-guest reason and say what you rejected.',
       returnClock: { medianDays: 147, p25: 76, p75: 278, note: 'days-since-last-stay near/after this range = due' },
       fitInputs: 'Per dossier: lastStaySeason (match via returnSeasonTransitionsToThisTarget below, NOT "same season"), lastHadChildren (vs whether this is a family window), typicalNights (vs the gap\'s nights), reviewThemes (vs the occasion — e.g. "Peaceful"/"Private" suit a quiet escape).',
+      residency: 'domestic = lives in RO (any window, incl. short-notice local gaps). diaspora = Romanian living abroad — they travel home for MAJOR holidays/vacations (Christmas, Easter, summer, 1 Dec / national days); target them ONLY when this window is such an occasion, NOT for a short-notice local mid-week gap (they will not fly in for a random Tuesday). foreign = a proven repeat returner kept for loyalty; judge case by case. Weigh residency against this window\'s occasion.',
       returnSeasonTransitionsToThisTarget: transitionsToTarget,
       returnSeasonTransitionsNote: `how often a guest whose last stay was in season X returned in ${targetSeason} (X->${targetSeason}). A guest whose lastStaySeason is a strong source here fits this window even though it is a different season.`,
     },

--- a/src/lib/growth/audience.ts
+++ b/src/lib/growth/audience.ts
@@ -35,21 +35,38 @@ export interface RomaniaBasedInput {
 }
 
 /**
- * Is this guest reachable domestically for reactivation ("lives in Romania", or a proven repeat)?
+ * Is this guest a Romanian-affinity reactivation target (domestic OR diaspora OR proven repeat)?
  *
- * `country` is UNRELIABLE (defaulted to RO across the base, like `language`), so a foreign phone —
- * a much stronger signal of where someone actually lives — OVERRIDES country=RO. Owner's rule
- * (2026-07-24): "George lives in the USA, you can see by the phone number." Several RO-diaspora
- * guests (name Romanian, phone +33/+1/+34/+49/+31) carry country=RO but cannot pop over for a
- * dated window — they are ads/OTA targets, not WhatsApp reactivation. A proven repeat returner
- * (2+ stays) still qualifies regardless of location (Artem ×3, Bianca ×2).
+ * `country` IS meaningful (it varies across ~30 countries, NOT a blanket-RO default — corrected
+ * 2026-07-24). Combined with the phone it cleanly separates three groups:
+ *   - domestic  : Romanian phone (+40)                → lives here; good for any window.
+ *   - diaspora  : country=RO but a FOREIGN phone      → Romanian living abroad; visits RO for major
+ *                 holidays (Christmas/Easter/summer/national days). Owner's rule (2026-07-24): do NOT
+ *                 exclude them — they travel home and are a real seasonal target; just target the
+ *                 right occasions (not a short-notice local gap). Use classifyResidency() + the
+ *                 planner's occasion reasoning to decide when.
+ *   - foreign   : country≠RO                          → a tourist; ads/OTA, NOT WhatsApp reactivation.
+ * A proven repeat returner (2+ stays) qualifies regardless of origin (Artem ×3, Bianca ×2).
+ * (Individuals we never want to contact are handled separately via suppressionList / unsubscribed.)
  */
 export function isRomaniaBased(g: RomaniaBasedInput): boolean {
-  if ((g.stays ?? 0) >= 2) return true;                 // proven repeat returner — worth it wherever they live
-  const phone = g.normalizedPhone || g.phone;
-  if (hasRomanianPhone(phone)) return true;             // RO phone = strongest "based here" signal
-  if (phone && !hasRomanianPhone(phone)) return false;  // a FOREIGN phone overrides an unreliable country=RO
-  return ['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase()); // no phone → fall back to country
+  if ((g.stays ?? 0) >= 2) return true;                                          // proven repeat returner
+  if (hasRomanianPhone(g.normalizedPhone) || hasRomanianPhone(g.phone)) return true; // domestic
+  if (['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase())) return true; // Romanian (diaspora if foreign phone)
+  return false;                                                                  // foreign tourist — not a reactivation target
+}
+
+export type Residency = 'domestic' | 'diaspora' | 'foreign';
+
+/**
+ * Classify where a reactivation target lives, so the planner can match them to the right occasion:
+ * domestic → any window; diaspora → major-holiday/vacation windows they travel home for; foreign →
+ * only present here as a proven repeat returner (kept for loyalty, judge case by case).
+ */
+export function classifyResidency(g: RomaniaBasedInput): Residency {
+  if (hasRomanianPhone(g.normalizedPhone) || hasRomanianPhone(g.phone)) return 'domestic';
+  if (['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase())) return 'diaspora';
+  return 'foreign';
 }
 
 /** Coarse thread-language sniff for the copywriter: which language to actually write in. */


### PR DESCRIPTION
Owner correction: diaspora (Romanians abroad) travel home for major holidays and ARE a valid seasonal target — don't exclude them. #177 excluded them on a false premise.

Data disproved that premise: `country` is meaningful (varies across ~30 countries); among foreign-phone guests only 8 are country=RO (diaspora), the rest carry their real country. So country+phone separates domestic / diaspora / foreign cleanly.

- `isRomaniaBased` restored (country=RO → in; foreign tourists out; repeat returners in)
- new `classifyResidency()` → domestic/diaspora/foreign
- planner-pack dossier carries `residency` + method guidance: target diaspora only for major-holiday windows they travel home for, not short-notice local gaps (LLM weighs residency × occasion)

George remains suppressed (own reasons). Verified: 5 diaspora back in, GB tourist out. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)