### PR TITLE
feat: copywriter continues the conversation (relationship-aware) + repair-loop fix

### DIFF
--- a/src/lib/growth/copywriterPack.ts
+++ b/src/lib/growth/copywriterPack.ts
@@ -18,6 +18,7 @@ import type { CampaignBrief } from '@/lib/growth/contracts';
 
 const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
 const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const days = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
 const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'winter' : m <= 5 ? 'spring' : m <= 8 ? 'summer' : 'autumn'; };
 function lastStayPhrase(last: Date | null, asOf: Date): string | null {
   if (!last) return null;
@@ -100,6 +101,18 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
     const detected = detectLanguage(threadText);
     const writeLanguage = detected === 'unknown' ? (g.language || 'ro') : detected;
 
+    // Relationship state — so the copywriter continues the conversation instead of cold-opening,
+    // and decides self-ID / opt-out from the REAL history (facts; the LLM judges from these).
+    const inboundCount = thread.filter(m => m.dir === 'in').length;
+    const lastExchange = thread.length ? String(thread[thread.length - 1].ts).slice(0, 10) : null;
+    const daysSinceLastExchange = lastExchange ? days(new Date(`${lastExchange}T00:00:00Z`), AS_OF) : null;
+    const relationshipState =
+      thread.length === 0 ? 'first-contact'                       // never messaged
+      : inboundCount === 0 ? 'silent'                              // messaged before, never replied
+      : (daysSinceLastExchange ?? 999) <= 120 ? 'active'          // replied + spoke recently
+      : 'lapsed';                                                 // replied before, but long ago
+    const relationship = { state: relationshipState, totalMessages: thread.length, replies: inboundCount, lastExchange, daysSinceLastExchange };
+
     const groundedFacts: any[] = [];
     if (g.firstName) groundedFacts.push({ key: 'firstName', value: g.firstName, source: `guests/${gid}` });
     if (g.partnerName) groundedFacts.push({ key: 'partnerName', value: g.partnerName, source: `guests/${gid}` });
@@ -119,6 +132,7 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
       recordLanguage: g.language || null,
       threadLanguageDetected: detected,
       careFlags: careByGuest.get(gid) || [],
+      relationship,
       dossier: {
         tier: totalBookings >= 2 ? 'repeat' : 'single',
         totalBookings,
@@ -149,12 +163,13 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
       register: 'Pick ONE register per message and keep it consistent throughout — either tu (informal: tu/iti/te/ai) OR voi/dumneavoastra (formal: voi/va/ati). NEVER mix them in the same message (not even "ati fost… iti dau"). Choose per guest: if there is a prior thread, match how the owner addressed them there; if there is NO prior thread (a first contact), use polite voi (you do not address a stranger with tu); otherwise default to the warm informal tu.',
       length: '300–600 characters, 3–6 short sentences',
       noEmoji: true,
-      selfIdRequired: 'open by identifying the sender (e.g. "Bogdan sunt, de la casuta din Comarnic")',
+      continuity: 'These are ONGOING relationships, not cold sends. READ the guest\'s `thread` and `relationship` and continue it naturally — pick up where you left off, and where it fits, nod to the last exchange. NEVER re-say something the thread shows you already told them (see `updates`). Use `relationship.state`: "active" (replied, spoke ≤120d ago) → continue warmly, do NOT re-introduce yourself; "lapsed" (replied before, long ago) → a light reconnect ("a trecut ceva vreme"); "silent" (messaged, never replied) → a fresh, low-pressure note; "first-contact" (no thread) → introduce yourself.',
+      selfId: 'Identify yourself ("Bogdan sunt, de la casuta din Comarnic") ONLY when it helps — a first-contact, a "lapsed"/"silent" state, or a long gap. For an "active" recent thread they know who you are; opening with a re-introduction reads as a form letter — just continue. (Self-ID must still appear somewhere for a first/cold contact — the validator checks it there.)',
       partnerGreeting: 'If a `partnerName` grounded fact is present, the WhatsApp number belongs to that partner (who booked under the guest firstName) — greet BOTH warmly, e.g. "Buna Razvan si Loredana!", and tag `partnerName` in factsUsed. If there is no partnerName, greet only by firstName.',
-      optOut: 'include a soft opt-out line only on a FIRST contact (no prior thread); otherwise rely on WhatsApp block/report',
+      optOut: 'Give a graceful, low-pressure way out to a FIRST contact AND to a "silent" guest (messaged before, never replied) — e.g. "daca preferi sa nu-ti mai scriu, spune-mi". An "active"/"lapsed" guest who has replied does NOT need one — it would be odd. Use judgment from `relationship.state`.',
       grounding: 'assert ONLY facts present in that guest\'s groundedFacts; tag each claim in factsUsed with its key. No emoji. No invented stays/preferences.',
       offerPresentation: 'The offer (campaign.offer) is set by the owner — never inflate or invent one, only phrase it. Adapt HOW you present it per guest: a guest with a `booksDirect` fact already knows they get your best price directly, so acknowledge that warmly (e.g. "si asa cum stii deja, iti pot da cea mai buna oferta direct") rather than quoting a discount as if it were news; a guest who has only booked via an OTA gets the explicit offer. For a free-night/value offer, describe the value in words, not a bare percentage. Tag `booksDirect` in factsUsed when you use that angle.',
-      updates: 'Each guest\'s `applicableUpdates` lists campaign news that is genuinely new SINCE THAT guest\'s last stay (already date-filtered — a guest who was here after a change does not see it). Decide per guest whether an update is worth mentioning and how to weave it in — do not force it into every message. You may mention ONLY updates in that guest\'s applicableUpdates, tagging factsUsed with the `update:<id>` key.',
+      updates: 'Each guest\'s `applicableUpdates` lists campaign news new SINCE THAT guest\'s last stay (date-filtered). BUT before mentioning one, CHECK the thread: if you already told this guest about it in a previous message, do NOT re-announce it as "noutate" — either build on it ("cum ti-am zis, avem acum…") or leave it out; mention only the part that is genuinely new to them. Decide per guest whether it is worth raising at all — do not force it into every message. You may mention ONLY updates in that guest\'s applicableUpdates, tagging factsUsed with the `update:<id>` key.',
       sentiment: 'always positive. For a careFlag complaint: if (and only if) an issueResolved:* fact is present, you MAY add a warm PS acknowledging the fix; otherwise do NOT mention the past problem at all — write a normal forward-looking message.',
     },
     guests,

--- a/src/lib/growth/validateDrafts.ts
+++ b/src/lib/growth/validateDrafts.ts
@@ -79,11 +79,16 @@ export function validateDrafts(
     }
 
     // 2. voice
+    const firstContact = (g.thread || []).length === 0;
     if (EMOJI.test(body)) errors.push('contains emoji (forbidden)');
-    if (!r.selfIdMarkers.some((m) => loose(body).includes(loose(m)))) errors.push('no self-identification (open by saying who is writing)');
+    // Self-ID: a first/cold contact MUST say who is writing (a stranger needs it); when continuing an
+    // active thread, re-introducing reads as a form letter — so it is only a soft nudge there.
+    if (!r.selfIdMarkers.some((m) => loose(body).includes(loose(m)))) {
+      if (firstContact) errors.push('no self-identification (a first contact must say who is writing)');
+      else warnings.push('no self-identification (fine when continuing an active thread)');
+    }
     if (body.length < r.minChars) errors.push(`too short (${body.length} < ${r.minChars})`);
     else if (body.length > r.maxChars) warnings.push(`long (${body.length} > ${r.maxChars})`);
-    const firstContact = (g.thread || []).length === 0;
     if (firstContact && !r.optOutMarkers.some((m) => loose(body).includes(loose(m)))) warnings.push('first contact but no opt-out line found');
 
     return { guestId: d.guestId, errors, warnings };

--- a/src/services/growth/copywriter.ts
+++ b/src/services/growth/copywriter.ts
@@ -48,17 +48,23 @@ const SYSTEM = `You are the WhatsApp copywriter for a small Romanian mountain-ch
 message per selected past guest, in the OWNER's voice, grounded in what is genuinely true about THAT
 guest, never a broadcast. You draft only — the owner reviews and sends by hand.
 
-THE THREE RULES
-1. Ground every guest-specific claim. You may only state a fact about a guest that appears in that
-   guest's groundedFacts. List in factsUsed the exact keys of every guest-specific claim you made.
-   Never invent stays, preferences, names, numbers, or updates. The thread is for AVOIDING repetition
-   and matching tone — not a licence to assert new facts.
-2. Write in the owner's voice (study voiceProfile.exemplars — lean toward what "booked"; copy the
-   register, not the content) and in each guest's writeLanguage. Romanian WITHOUT diacritics. Obey
-   every rule in voiceRules (length, no emoji, self-identification on line one, opt-out only on a
-   first contact = empty thread, offer presentation, updates).
-3. Positive and careful. Every message is warm and forward-looking. Follow voiceRules.sentiment for
+THE RULES
+1. CONTINUE THE RELATIONSHIP — do not cold-open. Each guest has a thread (verbatim history) and a
+   relationship state. Read them and write the NEXT message in an ongoing conversation: pick up the
+   thread, never re-introduce yourself to someone you spoke with recently, and NEVER re-announce
+   something the thread shows you already told them. Follow voiceRules.continuity / selfId / updates.
+2. Ground every guest-specific claim. You may only state a fact about a guest that appears in that
+   guest's groundedFacts; list the exact keys in factsUsed. Never invent stays, preferences, names,
+   numbers, or updates. The thread is context for continuity and tone — not a source of new claims.
+3. Write in the owner's voice (study voiceProfile.exemplars — lean toward what "booked"; copy the
+   register, not the content) and in each guest's writeLanguage, WITHOUT diacritics. Obey voiceRules
+   (length, no emoji, register consistency, self-ID/opt-out/offer/updates as they apply per relationship).
+4. Positive and careful. Every message is warm and forward-looking. Follow voiceRules.sentiment for
    any careFlag; never reference an unresolved problem.
+
+You are trusted to make the judgment calls the rules frame — whether to self-ID, whether to raise an
+update, whether to offer an opt-out, how much to reference the last exchange — from each guest's real
+history. Be the thoughtful host writing to someone you know, not a mail-merge.
 
 Return your work by calling the emit_drafts tool with exactly one draft per guest in the pack — no
 prose, no extra guests, none skipped.`;
@@ -110,6 +116,7 @@ export async function generateDrafts(brief: CampaignBrief, opts?: { asOf?: Date;
     });
     const toolUse = resp.content.find((b: any) => b.type === 'tool_use') as any;
     drafts = (toolUse?.input?.drafts ?? []) as DraftMessage[];
+    const toolUseId = toolUse?.id as string | undefined;
 
     lastValidation = validateDrafts(validationGuests, drafts);
     const warnings = lastValidation.perGuest.flatMap((p) => p.warnings.map((w) => `${p.guestId}: ${w}`));
@@ -120,13 +127,18 @@ export async function generateDrafts(brief: CampaignBrief, opts?: { asOf?: Date;
     }
     if (attempt > maxRepairs) break;
 
-    // Bounded repair: hand back the exact per-guest errors and ask to fix only those.
+    // Bounded repair: hand back the exact per-guest errors and ask to fix only those. Because the
+    // assistant turn contains a tool_use, the API REQUIRES the next turn to carry a matching
+    // tool_result — so the error feedback rides in the tool_result block, not a plain user message.
     const perGuestErrs = lastValidation.perGuest.filter((p) => p.errors.length).map((p) => `- ${p.guestId}: ${p.errors.join('; ')}`).join('\n');
     const campErrs = lastValidation.errors.length ? `Campaign-level: ${lastValidation.errors.join('; ')}\n` : '';
+    const repairText = `The validator rejected some drafts. Fix EXACTLY these and re-emit ALL guests via emit_drafts (a bounded repair, not a rewrite):\n${campErrs}${perGuestErrs}\n\nReminder: assert only groundedFacts keys and list them in factsUsed; no emoji; a first/cold contact must self-identify; give first-contact and silent guests an opt-out.`;
     messages.push({ role: 'assistant', content: resp.content });
     messages.push({
       role: 'user',
-      content: `The validator rejected some drafts. Fix EXACTLY these and re-emit ALL guests via emit_drafts (a bounded repair, not a rewrite):\n${campErrs}${perGuestErrs}\n\nReminder: assert only groundedFacts keys and list them in factsUsed; no emoji; self-ID on line one; opt-out only on first contact.`,
+      content: toolUseId
+        ? [{ type: 'tool_result', tool_use_id: toolUseId, content: repairText }]
+        : repairText,
     });
   }
 


### PR DESCRIPTION
Owner feedback: messages read like cold first-sends mid-conversation and re-announced news already told to the guest; silent guests got no opt-out. The thread was always in the pack — the prompt was the issue.

- `relationship` state per guest (active/lapsed/silent/first-contact) as facts
- voiceRules reframed to continuity-first: continue the thread, self-ID only when it helps, don't re-announce what's already been said, opt-out for first-contact AND silent
- validateDrafts: self-ID hard-required only for first contacts (soft warning otherwise) so natural continuations pass
- FIX latent repair-loop bug: tool_use must be followed by a tool_result (was a plain message → 400)

Smoke-tested against the live campaign: ok attempt 1, active threads continue naturally (reference prior exchanges), fire not re-announced to those already told, partner greeting + opt-out all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)