### PR TITLE
fix: WhatsApp export replaces the scrape (was double-storing)

### DIFF
--- a/scripts/import-whatsapp-export.ts
+++ b/scripts/import-whatsapp-export.ts
@@ -81,8 +81,9 @@ async function importOne(file: string, guestByPhone: Map<string, { id: string; n
   console.log(`\n${guest.name} [${guest.id}]  ← ${label}`);
   console.log(`  parsed: ${msgs.length} msgs (${textMsgs.length} text, ${msgs.length - textMsgs.length} media) · ${outCount} owner-sent · ${msgs[0]?.ts.slice(0,10)}→${msgs[msgs.length-1]?.ts.slice(0,10)}`);
   if (DRY) { console.log('  (dry-run — not written)'); return; }
-  const res = await upsertThreadMessages({ guestId: guest.id, phone: guest.phone, messages: msgs });
-  console.log(`  merged → +${res.added} new, ${res.total} total in vault`);
+  // The official export is the COMPLETE, clean history → REPLACE the (partial, artifact-laden) scrape.
+  const res = await upsertThreadMessages({ guestId: guest.id, phone: guest.phone, messages: msgs, replace: true });
+  console.log(`  replaced → ${res.total} messages in vault (was scrape/partial)`);
 }
 
 async function main() {

--- a/src/services/whatsappThreadService.ts
+++ b/src/services/whatsappThreadService.ts
@@ -28,13 +28,17 @@ export async function upsertThreadMessages(input: {
   guestId: string;
   phone: string;
   messages: WhatsAppMessage[];
+  replace?: boolean;   // true = this batch IS the complete, authoritative history (official phone
+                       // export) — overwrite, don't merge. The browser scrape uses minute-precision
+                       // timestamps + text artifacts that would NOT dedupe against a clean export,
+                       // so merging the two double-stores every shared message. Replace avoids that.
 }): Promise<{ added: number; total: number }> {
   const db = await getAdminDb();
   const ref = db.collection('whatsappThreads').doc(input.guestId);
   const snap = await ref.get();
-  const existing = snap.exists ? ((snap.data() as WhatsAppThread).messages ?? []) : [];
+  const existing = (!input.replace && snap.exists) ? ((snap.data() as WhatsAppThread).messages ?? []) : [];
 
-  const merged = mergeMessages(existing, input.messages);
+  const merged = mergeMessages(existing, input.messages);   // dedups within the batch + sorts
   const added = merged.length - existing.length;
   const lastMessageTs = merged.length ? merged[merged.length - 1].ts : undefined;
   const now = FieldValue.serverTimestamp();


### PR DESCRIPTION
Merging an official export with the desktop scrape double-stored every shared message — scrape timestamps are minute-precision (11:54:00) with text artifacts ("78 kB…"), the export has real seconds + clean text, so fingerprints never matched (Stefan: 9+12=21 with 8 dupes).

The phone export is the complete, clean history → REPLACE the partial scrape, not merge. Added `replace` to `upsertThreadMessages`; importer passes it. Re-verified: Razvan 99 clean, Stefan 12 clean, 0 cross-source dupes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)