### PR TITLE
fix: repeat-guest from real completed stays, not inflated totalBookings

### DIFF
--- a/scripts/planner-pack.ts
+++ b/scripts/planner-pack.ts
@@ -118,7 +118,7 @@ async function main() {
     const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
     const daysSinceOut = lastOut ? days(new Date(`${lastOut}T00:00:00Z`), AS_OF) : null;
 
-    const totalBookings = g.totalBookings ?? stays.length;
+    const totalBookings = stayB.length;   // REAL completed stays — g.totalBookings is unreliable (inflated; counts cancelled)
     const tier = totalBookings >= 2 ? 'repeat' : inbound >= 3 ? 'engaged' : inbound >= 1 ? 'responsive' : outbound >= 1 ? 'silent' : 'unknown';
 
     // coarse complaint signal (the copywriter does the real sentiment read over the full thread)

--- a/src/lib/growth/copywriterPack.ts
+++ b/src/lib/growth/copywriterPack.ts
@@ -105,7 +105,7 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
       .filter(x => typeof x === 'string' && !/^\+\d+ more$/i.test(x)) as string[];
     const th = threads.get(gid);
     const thread = ((th?.messages || []) as any[]).filter(m => m.ts < ymd(AS_OF)).map(m => ({ ts: m.ts, dir: m.direction, text: m.text }));
-    const totalBookings = g.totalBookings ?? stayB.length;
+    const totalBookings = stayB.length;   // REAL completed (non-cancelled, past) stays — g.totalBookings is unreliable (inflated; e.g. Roy Levi shows 2 with one cancelled booking), so never claim "repeat" from it
     const threadText = thread.map(m => m.text || '').join(' ');
     const detected = detectLanguage(threadText);
     const writeLanguage = detected === 'unknown' ? (g.language || 'ro') : detected;


### PR DESCRIPTION
Owner spotted an Israeli guest (Roy Levi, cancelled-only booking) flagged as a repeat. `guest.totalBookings` is unreliable (shows 2, he has 1 cancelled → 0 completed stays). The planner gates on real stays (so it already excluded him), but `isRepeatGuest` (a grounded claim) and the tier used the inflated field — risking a false "returning guest" greeting.

Fix: derive repeat/tier from `stayB.length` (non-cancelled, past stays) in both packs. Conservative — under-claims rather than over-claims. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)