### PR TITLE
feat: warm-up cron + additive first-timers on gap-fill

### DIFF
--- a/.claude/skills/whatsapp-planner/SKILL.md
+++ b/.claude/skills/whatsapp-planner/SKILL.md
@@ -31,11 +31,19 @@ Read the pack. Produce the plan in the format below. Nothing else is required.
 
 ## THE TWO RULES
 
-1. **You narrow; you never widen.** You may only select guests from `audience.eligible`. Never
-   invent a `guestId`, never reach into `audience.ineligible`, never exceed `constraints.runCap`.
+1. **You narrow; you never widen.** Your WARM selection may only come from `audience.eligible`. Never
+   invent a `guestId`, never reach into `audience.ineligible`, never let your warm picks exceed
+   `constraints.runCap`.
 2. **Reason from the pack's facts; the pack gives no answers.** It deliberately provides raw
    dossier inputs, not a ranking — the selection *is* your reasoning. Don't ask for a "score" that
    isn't there; weigh the raw inputs yourself and show your reasoning.
+
+**Additive first-timers (on top, not from the cap).** `audience.additiveFirstTimers` are never-contacted
+guests who fit this window. You MAY append the ones the window *genuinely* suits, each with
+`additive: true` — they are added ON TOP of your warm selection and do **not** count against the run cap
+(so they never displace a warm guest). Only select additive ids from `audience.additiveFirstTimers`, and
+only real fits (a first cold WhatsApp is a bigger ask — be selective). Give each a first-contact angle;
+the copywriter self-identifies and adds an opt-out automatically.
 
 ## How to think
 

--- a/scripts/planner-pack.ts
+++ b/scripts/planner-pack.ts
@@ -170,7 +170,13 @@ async function main() {
     });
   }
 
-  const eligible = dossiers.filter(d => d.eligible);
+  const eligibleAll = dossiers.filter(d => d.eligible);
+  // WARM audience = contacted-before or repeat (tier != unknown) — the run cap applies to these.
+  // ADDITIVE first-timers = never-contacted (tier 'unknown') who are recent enough to still remember
+  // (<=600d since stay) — appended ON TOP of the warm selection, NOT counted against the run cap.
+  // (unknown + cold >600d are left out of the gap-fill entirely; they belong to the cold-reintro warm-up.)
+  const eligible = eligibleAll.filter(d => d.tier !== 'unknown');
+  const additiveFirstTimers = eligibleAll.filter(d => d.tier === 'unknown' && d.daysSinceLastStay != null && d.daysSinceLastStay <= 600);
 
   // live return-season-transition matrix over Romania-based repeat guests (the fit signal: a guest
   // whose last-stay season → target season is a common transition is a good fit, NOT "same season").
@@ -215,14 +221,17 @@ async function main() {
     audience: {
       romaniaBasedReachable: dossiers.length,
       eligibleCount: eligible.length,
-      ineligibleCount: dossiers.length - eligible.length,
+      additiveFirstTimerCount: additiveFirstTimers.length,
+      ineligibleCount: dossiers.length - eligibleAll.length,
       eligible,
+      additiveFirstTimers,   // append the FITTING ones with additive:true — ON TOP, they don't use the run cap
+      additiveNote: 'additiveFirstTimers are never-contacted guests who fit this window (recent enough to remember). You MAY append the ones the window genuinely suits with `additive:true` — they are ADDED ON TOP of your warm selection and do NOT count against the run cap. Give each a first-contact angle; the copywriter self-IDs + adds an opt-out automatically. Do not force them in; pick only real fits.',
       ineligible: dossiers.filter(d => !d.eligible).map(d => ({ guestId: d.guestId, tier: d.tier, reasons: d.ineligibleReasons })),
     },
   };
 
   const json = JSON.stringify(pack, null, 2);
-  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB) · ${eligible.length} eligible of ${dossiers.length} RO`); }
+  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB) · ${eligible.length} warm eligible + ${additiveFirstTimers.length} additive first-timers of ${dossiers.length} RO`); }
   else console.log(json);
 }
 main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/warmup-pack.ts
+++ b/scripts/warmup-pack.ts
@@ -1,120 +1,30 @@
 #!/usr/bin/env npx tsx
 /**
- * warmup-pack — audience selector for the no-ask "share" campaigns (plan: keep-in-touch + cold re-intro).
+ * warmup-pack — CLI wrapper: emits the CampaignBrief for a no-ask "share" warm-up campaign.
+ * Audience logic lives in src/lib/growth/warmupAudience.ts (shared with the in-app cron).
  *
- * Unlike planner-pack (window/gap-driven, carries an offer), this is RELATIONSHIP-driven and carries
- * NO offer: intent = 'share'. It keeps the past-guest relationship warm so it doesn't go cold. Two
- * segments:
- *   --segment keepintouch : recently-stayed, still-warm guests we HAVEN'T reached in a while (or ever)
- *                           — the recurring ~6-8wk touch that stops warm guests sliding into the cold pile.
- *   --segment coldreintro : the long-lapsed (2y+) pile — a gentle "just saying hi", self-ID + when they
- *                           stayed + an easy opt-out. Occasional, small batches (cold = ban-riskier).
- *
- * Emits a CampaignBrief (intent 'share', offer {type:'none'}) → feeds copywriter-pack → copywriter.
- * The copywriter calibrates warmth from each guest's relationship state (first-contact/lapsed/silent).
- *
- * Usage:
  *   npx tsx scripts/warmup-pack.ts --segment keepintouch --property prahova-mountain-chalet --out /tmp/warm.json
- *   npx tsx scripts/warmup-pack.ts --segment coldreintro --property prahova-mountain-chalet --out /tmp/cold.json
+ *   npx tsx scripts/warmup-pack.ts --segment coldreintro --out /tmp/cold.json [--cap 15] [--as-of YYYY-MM-DD]
  */
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 import * as fs from 'fs';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
-import { getAdminDb } from '../src/lib/firebaseAdminSafe';
-import { isRomaniaBased } from '../src/lib/growth/audience';
-import type { CampaignBrief } from '../src/lib/growth/contracts';
+import { buildWarmupBrief, type WarmupSegment } from '../src/lib/growth/warmupAudience';
 
 const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
-const SEGMENT = (arg('segment', 'keepintouch') as 'keepintouch' | 'coldreintro');
-const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
-const OUT = arg('out');
-const AS_OF = new Date(`${arg('as-of', new Date().toISOString().slice(0, 10))}T00:00:00Z`);
-const RUN_CAP = Number(arg('cap', SEGMENT === 'coldreintro' ? '15' : '25'));
-
-const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
-const ymd = (d: Date) => d.toISOString().slice(0, 10);
-const days = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
-const norm = (p: string) => (p || '').replace(/[^0-9]/g, '');
-const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'iarna' : m <= 5 ? 'primavara' : m <= 8 ? 'vara' : 'toamna'; };
-const complaintRe = /problem|scuze|imi pare rau|îmi pare rău|neplac|deranj|presiune|defect|stricat/i;
-
-// Segment windows (days since last stay) + the "recently contacted" floor that excludes anyone we
-// touched too recently to warm up again.
-const WINDOWS = {
-  keepintouch: { minSinceStay: 45, maxSinceStay: 400, recentOutboundFloor: 60 },
-  coldreintro: { minSinceStay: 500, maxSinceStay: Infinity, recentOutboundFloor: 180 },
-};
 
 async function main() {
-  const db = await getAdminDb();
-  const [gSnap, bSnap, tSnap, sSnap] = await Promise.all([
-    db.collection('guests').get(), db.collection('bookings').get(),
-    db.collection('whatsappThreads').get(), db.collection('suppressionList').get(),
-  ]);
-  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
-  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
-  const suppressed = new Set(sSnap.docs.map(d => norm((d.data() as any).normalizedPhone || '').slice(-9)).filter(Boolean));
-  const win = WINDOWS[SEGMENT];
-
-  const guests = gSnap.docs.map(d => ({ id: d.id, ...(d.data() as any) })).filter(g => (g.propertyIds || []).includes(PROPERTY));
-  const picked: any[] = [];
-  for (const g of guests) {
-    if (!g.normalizedPhone || g.unsubscribed) continue;                                  // reachable + not opted out
-    if (suppressed.has(norm(g.normalizedPhone).slice(-9))) continue;                       // do-not-contact
-    const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
-      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
-      .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
-    if (!isRomaniaBased({ normalizedPhone: g.normalizedPhone, phone: g.phone, country: g.country, stays: stayB.length })) continue;
-    const activeFuture = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
-      .some((b: any) => { const e = toD(b.checkOutDate) ?? toD(b.checkInDate); return e && b.status !== 'cancelled' && +e >= +AS_OF; });
-    if (activeFuture) continue;                                                            // don't warm-up someone already booked
-
-    const last = stayB.length ? toD(stayB[stayB.length - 1].checkInDate) : null;
-    if (!last) continue;
-    const sinceStay = days(last, AS_OF);
-    if (sinceStay < win.minSinceStay || sinceStay > win.maxSinceStay) continue;            // segment recency window
-
-    const th = threads.get(g.id);
-    const msgs = (th?.messages || []) as any[];
-    const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
-    const daysSinceOut = lastOut ? days(new Date(`${lastOut}T00:00:00Z`), AS_OF) : null;
-    if (daysSinceOut !== null && daysSinceOut < win.recentOutboundFloor) continue;         // touched too recently — leave them
-
-    const careFlags = msgs.some(m => m.direction === 'in' && complaintRe.test(m.text || '')) ? ['complaint-in-thread'] : [];
-    picked.push({
-      guestId: g.id,
-      firstName: g.firstName || null,
-      sinceStay,
-      hasThread: msgs.length > 0,
-      angle: SEGMENT === 'coldreintro'
-        ? `Stayed ${seasonOf(last)} ${last.getUTCFullYear()} (~${Math.round(sinceStay / 30)}mo ago), never really kept in touch — a gentle "just saying hi" + who I am + an easy opt-out.`
-        : `Stayed ~${Math.round(sinceStay / 30)}mo ago, ${msgs.length ? 'quiet since' : 'never messaged on WhatsApp'} — a light keep-in-touch so the relationship stays warm.`,
-      careFlags,
-    });
-  }
-  // Warm end first (most recent stay = warmest / highest odds); cap for hand-sending.
-  picked.sort((a, b) => a.sinceStay - b.sinceStay);
-  const audience = picked.slice(0, RUN_CAP);
-
-  const point = SEGMENT === 'coldreintro'
-    ? 'A gentle re-introduction to guests who stayed a while ago and were never really kept in touch with — just a warm hello: who you are, when they stayed, no ask, and an easy way to opt out. Pure good mood.'
-    : 'A no-ask keep-in-touch to recently-stayed guests you have not spoken to in a while — a light, warm hello that keeps the relationship alive for when they want to come back. No offer, no request.';
-  const brief: CampaignBrief = {
-    propertyId: PROPERTY,
-    opportunity: { id: `warmup-${SEGMENT}-${ymd(AS_OF)}`, propertyId: PROPERTY, source: 'named_period', window: { start: ymd(AS_OF), end: ymd(AS_OF), nights: 0 }, daysOut: 0, instrument: 'whatsapp', rationale: `warm-up/${SEGMENT}` },
-    act: audience.length > 0,
-    intent: 'share',
-    occasion: { name: null, point },
-    offer: { type: 'none', description: '' },
-    updates: [],
-    audience: audience.map(a => ({ guestId: a.guestId, angle: a.angle, careFlags: a.careFlags })),
-    generalAngle: 'A genuine, low-pressure hello — NO offer, NO booking ask. Keep it short and warm. Self-identify, and for anyone not spoken to in a long time, gently remind them who you are and roughly when they stayed. Always include an easy opt-out. The goal is only to keep the door open, not to sell.',
-    rationale: `Warm-up campaign (${SEGMENT}): ${audience.length} of ${picked.length} eligible, capped at ${RUN_CAP}. Relationship-driven, no offer. Keeps warm guests from going cold / re-opens the door with long-lapsed ones.`,
-  };
-
+  const segment = (arg('segment', 'keepintouch') as WarmupSegment);
+  const propertyId = arg('property', 'prahova-mountain-chalet');
+  const capArg = arg('cap'); const asOfArg = arg('as-of'); const OUT = arg('out');
+  const { brief, eligibleCount } = await buildWarmupBrief(segment, {
+    propertyId,
+    asOf: asOfArg ? new Date(`${asOfArg}T00:00:00Z`) : undefined,
+    cap: capArg ? Number(capArg) : undefined,
+  });
   const json = JSON.stringify(brief, null, 2);
-  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} · segment=${SEGMENT} · ${audience.length}/${picked.length} eligible (cap ${RUN_CAP})`); }
+  if (OUT) { fs.writeFileSync(OUT, json); console.error(`wrote ${OUT} · segment=${segment} · ${brief.audience.length}/${eligibleCount} eligible`); }
   else console.log(json);
 }
 main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });

--- a/src/app/admin/campaigns/_components/proposal-review.tsx
+++ b/src/app/admin/campaigns/_components/proposal-review.tsx
@@ -148,6 +148,9 @@ export function ProposalReview({ campaignId }: { campaignId: string }) {
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="font-medium">{r.name}</span>
                       <Badge variant="outline" className="uppercase text-[10px]">{r.language}</Badge>
+                      {r.additive && (
+                        <Badge variant="outline" className="border-blue-300 text-[10px] text-blue-700">first-timer · added on top</Badge>
+                      )}
                       {(r.careFlags ?? []).map((f) => (
                         <Badge key={f} variant="outline" className="border-amber-300 text-[10px] text-amber-700">
                           <AlertTriangle className="mr-1 h-3 w-3" />{f}

--- a/src/app/api/cron/whatsapp-warmup/route.ts
+++ b/src/app/api/cron/whatsapp-warmup/route.ts
@@ -1,0 +1,31 @@
+/**
+ * whatsapp-warmup cron — generates the recurring no-ask "keep-in-touch" campaign and lands it as a
+ * DRAFT in /admin/campaigns for the owner to review and send by hand. Never sends anything.
+ *
+ * Intended cadence: every ~6–8 weeks via Cloud Scheduler (GET). It self-skips if nobody newly
+ * qualifies or a previous keep-in-touch draft is still pending review, so a slow cadence is safe.
+ * Only the recurring keepintouch segment runs here; coldreintro stays operator-triggered (occasional).
+ *
+ * Auth: Cloud Scheduler header (X-Appengine-Cron) or a Bearer token — same gate as the other crons.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { generateWarmupCampaign } from '@/services/growth/warmupCampaign';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.campaign;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  const cronHeader = request.headers.get('X-Appengine-Cron');
+  if (!cronHeader && !authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const result = await generateWarmupCampaign('keepintouch');
+    logger.info('whatsapp-warmup cron ran', result);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    logger.error('whatsapp-warmup cron failed', error as Error);
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -33,6 +33,8 @@ export interface BriefAudienceEntry {
   guestId: string;
   angle: string;                 // why this guest, in one line (due? fit? relationship?)
   careFlags?: string[];          // e.g. ['complaint-in-thread'] — the copywriter must handle gently
+  additive?: boolean;            // true = a first-timer appended ON TOP of the warm audience (does NOT
+                                 // count against the run cap; a first WhatsApp contact for a fitting guest)
 }
 
 /**
@@ -119,6 +121,7 @@ export interface ProposedDraft {
   guestId: string;
   angle: string;              // from the brief — why this guest (shown at Gate 1)
   careFlags?: string[];       // carried from the brief for the reviewer's context
+  additive?: boolean;         // a first-timer added on top of the warm audience (badged at Gate 1)
   language: LanguageCode;
   body: string;               // the copywriter's per-guest message
   factsUsed: string[];        // grounding contract (already validated)
@@ -163,6 +166,7 @@ export function toProposedDrafts(
       guestId: a.guestId,
       angle: a.angle,
       careFlags: a.careFlags,
+      additive: a.additive,
       language: d.language,
       body: d.body,
       factsUsed: d.factsUsed,

--- a/src/lib/growth/validatePlan.ts
+++ b/src/lib/growth/validatePlan.ts
@@ -23,8 +23,9 @@ export interface PlannerPackForValidation {
   constraints: { runCap: number };
   offer: { maxDiscountPct: number | null };
   audience: {
-    eligible: Array<{ guestId: string }>;
+    eligible: Array<{ guestId: string }>;              // the WARM audience — the run cap applies here
     ineligible?: Array<{ guestId: string }>;
+    additiveFirstTimers?: Array<{ guestId: string }>;  // first-timers that may be appended ON TOP (no cap)
   };
 }
 
@@ -49,7 +50,11 @@ export function validatePlan(
 
   const eligible = new Set(pack.audience.eligible.map((g) => g.guestId));
   const ineligible = new Set((pack.audience.ineligible ?? []).map((g) => g.guestId));
+  const additiveSet = new Set((pack.audience.additiveFirstTimers ?? []).map((g) => g.guestId));
   const ids = brief.audience.map((a) => a.guestId);
+  // WARM picks count against the run cap; ADDITIVE first-timers are appended on top (no cap).
+  const warmIds = brief.audience.filter((a) => !a.additive).map((a) => a.guestId);
+  const additiveIds = brief.audience.filter((a) => a.additive).map((a) => a.guestId);
   const cap = pack.constraints.runCap;
 
   // A plan that declined to act is valid iff it selected nobody.
@@ -60,22 +65,24 @@ export function validatePlan(
     return { ok: errors.length === 0, errors, warnings, stats: { selected: ids.length, eligible: eligible.size, runCap: cap } };
   }
 
-  // 1. Narrows-never-widens: every selected id must be in the eligible set.
-  const notEligible = ids.filter((id) => !eligible.has(id));
+  // 1. Narrows-never-widens. Warm picks must be in the eligible (warm) set; additive picks must be in
+  //    the additive-first-timer set. Neither may reach outside its set.
+  const notEligible = warmIds.filter((id) => !eligible.has(id));
   if (notEligible.length) {
-    // Distinguish "reached into the ineligible set" from "invented an id" — different failure modes.
     const fromIneligible = notEligible.filter((id) => ineligible.has(id));
     const invented = notEligible.filter((id) => !ineligible.has(id));
     if (fromIneligible.length) errors.push(`selected ${fromIneligible.length} INELIGIBLE guest(s): ${fromIneligible.join(', ')}`);
     if (invented.length) errors.push(`selected ${invented.length} UNKNOWN guest id(s) not in the pack: ${invented.join(', ')}`);
   }
+  const additiveNotAllowed = additiveIds.filter((id) => !additiveSet.has(id));
+  if (additiveNotAllowed.length) errors.push(`marked ${additiveNotAllowed.length} guest(s) additive that are not in the additive-first-timer set: ${additiveNotAllowed.join(', ')}`);
 
-  // 2. No duplicates.
+  // 2. No duplicates (across warm + additive).
   const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
   if (dupes.length) errors.push(`duplicate guest id(s): ${[...new Set(dupes)].join(', ')}`);
 
-  // 3. Run cap.
-  if (ids.length > cap) errors.push(`selected ${ids.length} > run cap ${cap}`);
+  // 3. Run cap — WARM picks only; additive first-timers are on top and do not count.
+  if (warmIds.length > cap) errors.push(`selected ${warmIds.length} warm > run cap ${cap} (additive first-timers don't count, but warm picks do)`);
 
   // 4. Empty acting plan.
   if (ids.length === 0) errors.push('act:true but no guests selected');

--- a/src/lib/growth/warmupAudience.ts
+++ b/src/lib/growth/warmupAudience.ts
@@ -1,0 +1,100 @@
+/**
+ * warmupAudience — builds the CampaignBrief for a no-ask "share" warm-up campaign. Shared by the CLI
+ * (scripts/warmup-pack.ts) and the in-app cron (src/services/growth/warmupCampaign.ts) so both select
+ * the same way. Relationship-driven (no window, no offer); intent = 'share'.
+ *
+ *   keepintouch : recently-stayed, still-warm, not-recently-touched → the recurring light hello
+ *   coldreintro : the long-lapsed (2y+) pile → a gentle "just saying hi" (self-ID + when-stayed + opt-out)
+ *
+ * Server-only (Admin SDK).
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { isRomaniaBased } from '@/lib/growth/audience';
+import type { CampaignBrief } from '@/lib/growth/contracts';
+
+export type WarmupSegment = 'keepintouch' | 'coldreintro';
+
+const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const days = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
+const norm = (p: string) => (p || '').replace(/[^0-9]/g, '');
+const seasonOf = (d: Date) => { const m = d.getUTCMonth() + 1; return m === 12 || m <= 2 ? 'iarna' : m <= 5 ? 'primavara' : m <= 8 ? 'vara' : 'toamna'; };
+const complaintRe = /problem|scuze|imi pare rau|îmi pare rău|neplac|deranj|presiune|defect|stricat/i;
+
+const WINDOWS: Record<WarmupSegment, { minSinceStay: number; maxSinceStay: number; recentOutboundFloor: number; defaultCap: number }> = {
+  keepintouch: { minSinceStay: 45, maxSinceStay: 400, recentOutboundFloor: 60, defaultCap: 25 },
+  coldreintro: { minSinceStay: 500, maxSinceStay: Infinity, recentOutboundFloor: 180, defaultCap: 15 },
+};
+
+export interface WarmupResult { brief: CampaignBrief; eligibleCount: number; }
+
+/** Build a warm-up CampaignBrief for a segment. `asOf` defaults to now; `cap` defaults per segment. */
+export async function buildWarmupBrief(segment: WarmupSegment, opts?: { propertyId?: string; asOf?: Date; cap?: number }): Promise<WarmupResult> {
+  const propertyId = opts?.propertyId ?? 'prahova-mountain-chalet';
+  const AS_OF = opts?.asOf ?? new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00Z`);
+  const win = WINDOWS[segment];
+  const cap = opts?.cap ?? win.defaultCap;
+
+  const db = await getAdminDb();
+  const [gSnap, bSnap, tSnap, sSnap] = await Promise.all([
+    db.collection('guests').get(), db.collection('bookings').get(),
+    db.collection('whatsappThreads').get(), db.collection('suppressionList').get(),
+  ]);
+  const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
+  const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
+  const suppressed = new Set(sSnap.docs.map(d => norm((d.data() as any).normalizedPhone || '').slice(-9)).filter(Boolean));
+
+  const guests = gSnap.docs.map(d => ({ id: d.id, ...(d.data() as any) })).filter(g => (g.propertyIds || []).includes(propertyId));
+  const picked: any[] = [];
+  for (const g of guests) {
+    if (!g.normalizedPhone || g.unsubscribed) continue;
+    if (suppressed.has(norm(g.normalizedPhone).slice(-9))) continue;
+    const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
+      .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
+      .sort((a: any, b: any) => +toD(a.checkInDate)! - +toD(b.checkInDate)!);
+    if (!isRomaniaBased({ normalizedPhone: g.normalizedPhone, phone: g.phone, country: g.country, stays: stayB.length })) continue;
+    const activeFuture = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
+      .some((b: any) => { const e = toD(b.checkOutDate) ?? toD(b.checkInDate); return e && b.status !== 'cancelled' && +e >= +AS_OF; });
+    if (activeFuture) continue;
+
+    const last = stayB.length ? toD(stayB[stayB.length - 1].checkInDate) : null;
+    if (!last) continue;
+    const sinceStay = days(last, AS_OF);
+    if (sinceStay < win.minSinceStay || sinceStay > win.maxSinceStay) continue;
+
+    const th = threads.get(g.id);
+    const msgs = (th?.messages || []) as any[];
+    const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
+    const daysSinceOut = lastOut ? days(new Date(`${lastOut}T00:00:00Z`), AS_OF) : null;
+    if (daysSinceOut !== null && daysSinceOut < win.recentOutboundFloor) continue;
+
+    const careFlags = msgs.some(m => m.direction === 'in' && complaintRe.test(m.text || '')) ? ['complaint-in-thread'] : [];
+    picked.push({
+      guestId: g.id, sinceStay,
+      angle: segment === 'coldreintro'
+        ? `Stayed ${seasonOf(last)} ${last.getUTCFullYear()} (~${Math.round(sinceStay / 30)}mo ago), never really kept in touch — a gentle "just saying hi" + who I am + an easy opt-out.`
+        : `Stayed ~${Math.round(sinceStay / 30)}mo ago, ${msgs.length ? 'quiet since' : 'never messaged on WhatsApp'} — a light keep-in-touch so the relationship stays warm.`,
+      careFlags,
+    });
+  }
+  picked.sort((a, b) => a.sinceStay - b.sinceStay);   // warmest (most recent stay) first
+  const audience = picked.slice(0, cap);
+
+  const point = segment === 'coldreintro'
+    ? 'A gentle re-introduction to guests who stayed a while ago and were never really kept in touch with — just a warm hello: who you are, when they stayed, no ask, and an easy way to opt out. Pure good mood.'
+    : 'A no-ask keep-in-touch to recently-stayed guests you have not spoken to in a while — a light, warm hello that keeps the relationship alive for when they want to come back. No offer, no request.';
+
+  const brief: CampaignBrief = {
+    propertyId,
+    opportunity: { id: `warmup-${segment}-${ymd(AS_OF)}`, propertyId, source: 'named_period', window: { start: ymd(AS_OF), end: ymd(AS_OF), nights: 0 }, daysOut: 0, instrument: 'whatsapp', rationale: `warm-up/${segment}` },
+    act: audience.length > 0,
+    intent: 'share',
+    occasion: { name: null, point },
+    offer: { type: 'none', description: '' },
+    updates: [],
+    audience: audience.map(a => ({ guestId: a.guestId, angle: a.angle, careFlags: a.careFlags })),
+    generalAngle: 'A genuine, low-pressure hello — NO offer, NO booking ask. Keep it short and warm. Self-identify, and for anyone not spoken to in a long time, gently remind them who you are and roughly when they stayed. Always include an easy opt-out. The goal is only to keep the door open, not to sell.',
+    rationale: `Warm-up (${segment}): ${audience.length} of ${picked.length} eligible, cap ${cap}.`,
+  };
+  return { brief, eligibleCount: picked.length };
+}

--- a/src/services/growth/warmupCampaign.ts
+++ b/src/services/growth/warmupCampaign.ts
@@ -1,0 +1,61 @@
+/**
+ * warmupCampaign — generate a no-ask "share" warm-up campaign in-app and LAND it as a draft.
+ *
+ * This is what the cron runs (keep-in-touch, recurring) and what an admin action could call on
+ * demand: buildWarmupBrief → copywriter (generateDrafts) → createProposedCampaign (status:'draft').
+ * It NEVER sends — the owner reviews at Gate 1 and sends by hand, same as every campaign.
+ *
+ * Server-only. Degrades cleanly (returns a reason) if the copywriter is unavailable or nobody qualifies.
+ */
+import { buildWarmupBrief, type WarmupSegment } from '@/lib/growth/warmupAudience';
+import { generateDrafts } from '@/services/growth/copywriter';
+import { createProposedCampaign, listCampaigns } from '@/services/campaignService';
+import { isCopywriterAvailable } from '@/lib/growth/anthropic';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.campaign;
+
+export interface WarmupRunResult {
+  status: 'landed' | 'skipped';
+  reason?: string;
+  campaignId?: string;
+  count?: number;
+  errors?: string[];
+}
+
+const NAME: Record<WarmupSegment, string> = {
+  keepintouch: 'Keep-in-touch',
+  coldreintro: 'Cold re-intro',
+};
+
+/**
+ * Generate + land one warm-up campaign. Skips (no-op) if the copywriter is off, nobody qualifies,
+ * a previous warm-up draft of this segment is still pending review, or generation fails validation.
+ */
+export async function generateWarmupCampaign(segment: WarmupSegment, opts?: { propertyId?: string }): Promise<WarmupRunResult> {
+  if (!isCopywriterAvailable()) return { status: 'skipped', reason: 'copywriter-unavailable' };
+  const propertyId = opts?.propertyId ?? 'prahova-mountain-chalet';
+
+  // Don't pile up: if a warm-up draft of this segment is already waiting for review, skip this run.
+  const existing = (await listCampaigns(propertyId)).find(
+    (c) => c.status === 'draft' && typeof c.name === 'string' && c.name.startsWith(`${NAME[segment]} —`)
+  );
+  if (existing) return { status: 'skipped', reason: 'pending-draft-exists', campaignId: existing.id };
+
+  const { brief, eligibleCount } = await buildWarmupBrief(segment, { propertyId });
+  if (!brief.act || brief.audience.length === 0) {
+    logger.info('warmup: nobody eligible', { segment, eligibleCount });
+    return { status: 'skipped', reason: 'no-eligible-audience' };
+  }
+
+  const res = await generateDrafts(brief);
+  if (!res.ok) {
+    logger.warn('warmup: generation failed validation — not landed', { segment, errors: res.errors });
+    return { status: 'skipped', reason: 'generation-invalid', errors: res.errors };
+  }
+
+  const name = `${NAME[segment]} — ${new Date().toISOString().slice(0, 10)} (${res.drafts.length})`;
+  const campaignId = await createProposedCampaign({ name, brief, drafts: res.drafts });
+  logger.info('warmup campaign landed', { segment, campaignId, count: res.drafts.length });
+  return { status: 'landed', campaignId, count: res.drafts.length };
+}


### PR DESCRIPTION
**Build 1 — recurring keep-in-touch cron:** `warmupAudience` server lib (shared with the CLI), `generateWarmupCampaign` (build → copywriter → land a DRAFT, self-skips safely, never sends), `/api/cron/whatsapp-warmup` (Scheduler-auth, ~6-8wk). Needs a Cloud Scheduler job. coldreintro stays operator-run.

**Build 2 — additive first-timers ("on top, not a quota"):** planner `eligible` = warm only; recent never-contacted → `additiveFirstTimers` (cold >600d drop to cold-reintro). `additive` flag on the brief/draft; `validatePlan` counts the run cap on warm only and validates additive against its set. Verified: 20 warm (=cap) + additive on top PASSES; additive-without-flag and 21-warm correctly reject. Gate-1 badges them.

Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)