### PR TITLE
fix: toProposedDrafts undefined fields broke the landing write (regression)

### DIFF
--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -162,15 +162,17 @@ export function toProposedDrafts(
   for (const a of brief.audience) {
     const d = draftFor.get(a.guestId);
     if (!d) continue;
+    // Default every optional field — Firestore's Admin SDK rejects `undefined` on write, and these
+    // are persisted verbatim by createProposedCampaign/setCampaignDrafts.
     rows.push({
       guestId: a.guestId,
-      angle: a.angle,
-      careFlags: a.careFlags,
-      additive: a.additive,
+      angle: a.angle ?? '',
+      careFlags: a.careFlags ?? [],
+      additive: a.additive ?? false,
       language: d.language,
       body: d.body,
-      factsUsed: d.factsUsed,
-      careHandled: d.careHandled,
+      factsUsed: d.factsUsed ?? [],
+      careHandled: d.careHandled ?? '',
     });
   }
   return rows;


### PR DESCRIPTION
End-to-end testing the warm-up cron caught it: `createProposedCampaign` threw "Cannot use undefined as a Firestore value". `toProposedDrafts` emitted `careFlags/additive/careHandled` as undefined when unset; the `additive` field from #186 made this hit **every** landing — including the in-app regenerate (`setCampaignDrafts`). A deployed regression.

Fix: default all optional fields. Re-verified end-to-end: warm-up cron lands cleanly, additive:true still carries, no undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)