### PR TITLE
Promotion system phase 1: architecture + brand/acquisition sensors + ad planner

### DIFF
--- a/.claude/skills/situation-analyst/SKILL.md
+++ b/.claude/skills/situation-analyst/SKILL.md
@@ -59,6 +59,17 @@ Two method rules that follow from data provenance in general:
 - **Respect n.** Check `yearsOfData` / `n` on any field before drawing a conclusion.
   State the n. Do not assert a trend from a single month or a handful of observations.
 
+## `currentSignals` — live brand & acquisition state
+
+`pack.currentSignals` carries LIVE Facebook **page** + **ad-account** health, read from Meta
+at pack-build. It is *current state* — it has no history and does **not** correspond to `--as-of`
+(`dataQuality.currentSignals.isAsOfReproducible: false`), and it is **withheld on a backtest**
+(`available: false`). So: never put a `currentSignals` number into a trend or a like-for-like
+comparison. Use it only to answer "how do the page and ad account stand *right now*", and surface
+each block's `warnings` as flags — several are **owner/brand actions or prerequisites**, not guest
+campaigns (see the instruments below). If `available` is false, say the signal was unavailable and
+move on; do not infer all-is-well from its absence.
+
 ## How to think
 
 Work in this order. Do not jump to step 3.
@@ -110,6 +121,12 @@ does not tell you which to use for any given situation.
   `audience.segments` and the occasion each week.
 - **Ads** (Meta, built separately) — reaches strangers; scales with budget. Hand over
   as a dated, sized proposal.
+- **Brand / page fixes** (from `currentSignals`, owner actions — not guest campaigns) — some
+  health flags are prerequisites or one-off fixes, not something to route to a campaign: a page
+  `websiteIsOtaLink` (the page sends clicks to an OTA → leaks direct-booking margin), a `dormant`
+  page, `no-account-spend-limit` (must be set before any ad spend), an unpublished page. Raise
+  these as FLAGS with the **owner** as the actor. (The organic-posting instrument — keeping the
+  page alive — is being built; for now, flag a dormant page, don't propose posting to it.)
 - **Price change** — the largest lever; never a message. (Check `dataQuality.pricing`
   for whether in-system pricing is even the live rate before reasoning about it.)
 - **Minimum-stay change** — see `inventory` for the current min-stay and any gaps it

--- a/docs/growth-ad-engine-plan.md
+++ b/docs/growth-ad-engine-plan.md
@@ -238,3 +238,33 @@ Don't build 2b/2c before 2a proves photos → bookings.
 - Which external provider(s) for relight vs people-compositing (quality-led; A/B vs Advantage+).
 - Video: split the existing tour/drone master into short-clip variants now, or wait for more footage.
 - Exact catalog-snapshot/versioning + agent-API auth mechanism (part of the §7 brain seam).
+
+---
+
+## 15. Current state (26 Jul 2026) — what actually shipped and where it sits
+
+The **execution engine is built and proven at zero spend; it has never run live.** Verified against code + live account (see `docs/meta-ads-infrastructure-2026.md` §11):
+- **Enabled but dry-run:** `GROWTH_ADS_ENABLED="true"` in `apphosting.yaml` (switch 1 ON → `/admin/ads` composes drafts + dry-run activates). `GROWTH_ADS_MODE=live` deliberately absent → **zero spend possible.**
+- **Config wired:** Prahova `analytics.{metaAdAccountId,metaPageId,metaTokenRef,metaInstagramActorId,metaPixelId}` all present; `META_ADS_TOKENS` secret live; pixel firing.
+- **2 leftover draft `adCampaigns`** from July machinery validation — confirmed PAUSED/inert in Meta, stale end-times, harmless.
+- **Never activated:** no campaign approved, none carries `spendCapMinor`, the only `adAuditLog` entry is one `dry-run`.
+- **Open gaps:** (a) **no reconciliation cron** — insights/effective-status refresh is manual (`refreshAdInsightsAction` only); (b) **no `/api/growth/ad-proposals`** brain seam; (c) 🔴 account `spend_cap = 0` (owner must set it before live).
+
+## 16. The ads INTELLIGENCE build — the missing brain (mirrors the WhatsApp arm)
+
+The engine is a safe *console where a human does 100% of the thinking*. The WhatsApp arm proves the intelligent shape end-to-end (`analyst → planner → copywriter → Gate-1 review → send`); the ads arm reuses it. See `docs/promotion-system-architecture.md` §4.2 for the cross-channel framing. Concretely:
+
+- **16.1 Generalize the Opportunity contract** — `contracts.ts` `Opportunity.instrument` is the literal `'whatsapp'` today; widen to `'whatsapp' | 'ads' | 'page'` so the analyst can route an opportunity to ads and a planner can consume it.
+- **16.2 Ad planner** (twin of `.claude/skills/whatsapp-planner` + `planner-pack.ts`): an ad-planner-pack (geo/interest candidates, budget ceiling `MAX_DAILY_BUDGET_MINOR`, opportunity nights/value, past-ad performance, page-best content) → LLM sizes targeting + budget + angle + creative brief → an ad-brief validator (spend-cap math via `validateApprovalCap`, geo sanity — "narrows-never-widens" against the candidate set) → a **PAUSED `adCampaigns` draft** via the existing `composeAndCreateAd`.
+- **16.3 Ad creative/copy intelligence** (twin of `copywriter.ts`): grounded in real gallery photos + best-performing past ad copy + the page's best posts; writes primary-text/headline/CTA + picks photos; validated for truth (no invented amenities) and the **public brand voice** (distinct from the private WhatsApp voice — architecture §5.1). Feeds the composer.
+- **16.4 The hand-off** — `POST /api/growth/ad-proposals` (the §7 brain seam), mirroring `land-campaign.ts → /admin/campaigns`: lands a proposal as a PAUSED draft in `/admin/ads`.
+- **16.5 Admin symmetry** — reshape `/admin/ads` from a blank compose form into the campaigns-workspace pattern: **framing → "Generate ad" → Gate-1 review → guarded activate.**
+- **16.6 Reconciliation cron** — the durability backstop the plan always intended (§13 C2/M2): a cron that syncs `effective_status` + insights and flags any non-paused campaign not in the approved set. Build before ongoing (vs one-shot) ads.
+
+## 17. Go-live runbook (when the brain is trusted — a deliberate act, not a default)
+
+1. **Owner Meta preflight:** set an **account-level spend limit** in Ads Manager (`spend_cap` is 0); confirm the app is Live and the pixel is firing.
+2. **Compose one fresh ad** in `/admin/ads` (the 2 existing drafts are stale) — real gallery photos, city + radius, ~5 RON/day, a near future end-date.
+3. **Dry-run validation:** with `GROWTH_ADS_MODE` unset, Approve → Activate returns `dry-run` (proves the whole pipeline, zero spend).
+4. **Flip `GROWTH_ADS_MODE=live`** (deploy) → Approve → Activate the one small ad → measure via Pixel/CAPI + `utm_campaign=<adCampaignId>` ROAS join → Pause. That is the proven first loop.
+5. Emergency stop = the Pause button + the account spend limit — **never** the env switch (that's a deploy).

--- a/docs/meta-ads-infrastructure-2026.md
+++ b/docs/meta-ads-infrastructure-2026.md
@@ -249,3 +249,42 @@ All verified live PAUSED + deleted, zero spend. This is the contract for the ric
 **GOTCHA:** a Dynamic-Creative ad fails on a normal ad set — err 100/**1885998** "Cannot Create Dynamic Creative ad In Non-Dynamic Creative Ad Set". The AD SET must be created with **`is_dynamic_creative:true`**. Single-image `object_story_spec` creatives stay on normal (non-dynamic) ad sets. So the composer picks the path by asset count: 1 image → object_story_spec/normal adset; 2+ images or copy variants → asset_feed_spec + `is_dynamic_creative:true` adset.
 
 **§9f addendum (asset_feed_spec duplicate values):** Meta rejects DUPLICATE values within an `asset_feed_spec` array — err 100/**1815809** "Duplicate of ad asset values are not allowed / enter a unique headline for each field". Two copy variants sharing one headline → duplicate `titles[]` → rejected. Fix: dedup each array by value (`campaignBuilder.createCreative`). A single shared title + multiple distinct bodies is valid. Found via the Brain-simulated real-campaign compose (4 photos + 2 variants sharing a headline).
+
+---
+
+## 11. Live account + PAGE + token audit — read-only Graph v25 (26 Jul 2026)
+
+Verified directly against the live account with the `META_ADS_TOKENS` system-user token (GET-only, zero spend, no writes). This section is ground truth for what the token can see/do *today* and what needs owner provisioning. Re-verify before relying (beta).
+
+### 11.1 Token capabilities (matrix)
+System user **"rentalspot"** (id `122096486619395064`), app **"Rentalspot"** (`1020612017421319`), BM Comarnic. **Non-expiring** (`expires_at:0`). Scopes: `pages_show_list, ads_management, ads_read, business_management, pages_read_engagement, pages_manage_ads, public_profile`. The system user is on the Comarnic page (`me/accounts` returns a derivable **Page access token**) with tasks **`ANALYZE, ADVERTISE`** only.
+
+| Capability | Today? | Needs |
+|---|---|---|
+| Manage ads (create/activate/pause/insights), read ad account | ✅ | — |
+| Read pixel; read page **public profile**; read page **aggregate insights** | ✅ | ANALYZE task + derived page token |
+| Read page **post content / feed** | ❌ | `pages_read_user_content` |
+| **Publish** organic posts | ❌ | `pages_manage_posts` + `CREATE_CONTENT` page task |
+| Read/reply comments & DMs | ❌ | `pages_read_user_content` / `pages_messaging` + `MODERATE` |
+| Any **Instagram** (read/post) | ❌ | `instagram_basic` / `instagram_manage_insights` / `instagram_content_publish` |
+
+v25 page-insight metrics are a **shrunken set** — valid: `page_post_engagements, page_daily_follows_unique, page_follows, page_views_total, page_total_actions`. Deprecated/removed: `page_impressions`, `page_fans`, `page_fans_country`, `page_fans_gender_age`. `/published_posts` and `/feed` both require `pages_read_user_content` (a page token alone is not enough).
+
+### 11.2 Provisioning checklist (owner) — do in ONE batch when building the page arm
+1. Business Settings → Users → **System Users → "rentalspot"** → Assigned assets → the Comarnic page → add task **Create content** (+ Moderate if comment/DM handling wanted).
+2. Ensure the **Instagram** account (`17841435421272996`) is added to the business and assigned to the system user.
+3. **Regenerate the system-user token** including the new scopes (`pages_read_user_content`, `pages_manage_posts`, `instagram_basic`, `instagram_manage_insights`, `instagram_content_publish` as needed) on top of the existing ads scopes.
+4. **Advanced Access:** these page/IG scopes typically need Advanced Access (App Dashboard → App Review → Permissions and Features) — usually a toggle for own business-owned assets, but confirm; some may prompt the standard review.
+5. Paste the new token into the `META_ADS_TOKENS` secret (same JSON map, key `prahova-mountain-chalet`) — ads keep working (same identity), page/IG unlock.
+
+### 11.3 Page state (the "keep-alive" opportunity, quantified)
+"Comarnic Mountain Chalet" (@ComarnicChalet, id `107610677616243`): **552 followers, `talking_about_count:0` (DORMANT), 0 ratings, published, not verified.** ⚠️ Page `website` field = `airbnb.com/rooms/43265214` — **leaks direct-booking margin; change to `prahova-chalet.ro`** (Page settings, no token change).
+
+### 11.4 Ad account state + history
+`act_543311232953437` "Bogdan-Comarnic": ACTIVE, RON, CET, VISA funding, `min_daily_budget` 463 bani. 🔴 **`spend_cap = "0"` — NO account-level spending limit set** (set one in Ads Manager before any live spend — the platform backstop; the env switch is a deploy, not the emergency stop). `web_custom_audience_tos` accepted; customer-file ToS NOT.
+- **Lifetime (2023→now):** ~412 RON spend, 90.6k impressions, 6,062 clicks, **CTR 6.69% / CPC 0.068 RON**, reach 41.9k. ~11 campaigns, **ALL PAUSED**, all `LINK_CLICKS`/`TRAFFIC`/`MESSAGES` pointed at **OTA URLs** — **ZERO conversion-optimized history** → the pixel has no purchase learning; `OUTCOME_SALES` campaigns start COLD. Nothing ran in the last 90 days. (Strong CTR = good creative/audience instincts to reuse.)
+- **Pixel** "Prahova Chalet Web" (`1010060168431159`): **last fired 2026-07-24, alive** — measurement half ready.
+- The **2 leftover `adCampaigns` drafts** (`PC2fnhq3…`, `mfgGzG…`) confirmed **PAUSED/effective PAUSED** in Meta, inert, past/near stop_times — harmless July machinery-validation leftovers.
+
+### 11.5 apphosting.yaml flag state (26 Jul)
+`GROWTH_ADS_ENABLED="true"` (switch 1 ON → console composes + dry-run activates, zero spend); `GROWTH_ADS_MODE` ABSENT (→ dry-run). Never driven to live spend; no campaign approved / carries a spend cap; only audit entry is one `dry-run`. Reconciliation cron NOT built (insights refresh is manual-only).

--- a/docs/promotion-system-architecture.md
+++ b/docs/promotion-system-architecture.md
@@ -1,0 +1,168 @@
+# Promotion System Architecture — the RentalSpot Growth Brain
+
+**Author:** Opus 4.8, from a full investigation of the codebase + a live read-only audit of the Meta account/page · 26 July 2026
+**Status:** Agreed architecture — the umbrella that unifies WhatsApp reactivation, Meta ads, and the Facebook page under one intelligence layer. This is the durable source of truth; it **references, never re-copies** the detailed plans below.
+
+**Companion documents (read for depth on each area):**
+- `docs/meta-ads-infrastructure-2026.md` — verified external Meta facts + live-account contract spikes + the 26 Jul live audit (§11). *committed.*
+- `docs/growth-ad-engine-plan.md` — the ads execution engine + the ads-intelligence build phases. *committed.*
+- `plans/engagement-system.md` — the Opportunity Engine / WhatsApp arm, in full detail. *local-only (gitignored).*
+- `plans/growth-engine.md` — the original locked decisions (Core/Brain planes, the seam). *local-only.*
+- `docs/business/growth-engine-roadmap.md` — the business rationale. *local-only.*
+
+**Memory pointers:** `growth-engine-core`, `engagement-system`, `meta-ads-page-live-state`.
+
+---
+
+## 0. The one idea, and the one sequencing decision
+
+**One detector, many responses.** A property has *one* situation each week — the gaps, the pace, the RevPAR trend, the dormant page. That situation is diagnosed *once* by a shared analyst, which then routes each opportunity to the instrument that fits: a WhatsApp message to warm past guests, a Meta ad to strangers, an organic page post, a price change — or, explicitly, *nothing*.
+
+**Build the intelligence before running the spend.** The execution machinery on every channel is already built and guarded. What is missing is the *brain* that decides and composes. We build that first; live ad spend is a deliberate act taken only once the brain is trusted, not a default.
+
+**The principle that governs every LLM stage:** *feed the model facts + method + constraints, never conclusions.* Guardrails constrain only **truth and margin**; relevance, presentation, voice, and per-target adaptation are the model's job. (Plan §2 principles 1 & 5.)
+
+---
+
+## 1. The business problem this serves
+
+Measured in `plans/engagement-system.md` §0 (2026-07-22): a three-year decline, RevPAR −40% in 2026, driven by an **acquisition** collapse (new-guest bookings 39→34→18) as foreign waves faded and OTA rate rises cut ranking. The recovery target is ~65 more nights this year. The instruments split by who delivers them:
+
+- **OTA rate/ranking recovery** — the largest single block (owner + OTA action).
+- **Meta ads — ~30–75 nights** — rebuild acquisition; reach strangers. *The lever this architecture most enables.*
+- **WhatsApp reactivation — ~15–25 nights/yr** — the best-*margin* nights (direct ADR 719 vs Airbnb 588 + commission saved), but a scalpel, not an engine: ~130 warm RO guests, finite goodwill.
+- **Calendar hygiene** — immediate, unblock bookability.
+
+Acquisition is the constraint, and acquisition is ads + a live brand page. That is why finalizing the ads/page intelligence is aligned with the real revenue problem, not a side quest.
+
+---
+
+## 2. The architecture — one brain, many arms
+
+```
+  SENSORS ─────────────────────────────► ANALYST ──► ROUTER ──►  ARM (per instrument)
+  (deterministic facts, no conclusions)   (LLM over    (audience-
+                                           the facts)   math)
+  ┌─ inventory / pace / calendar ─┐                          ┌─ WhatsApp: planner → copywriter → wa.me   [BUILT]
+  ├─ audience segments / dueNow ──┤                          ├─ Ads: ad planner → creative/copy → activate [TO BUILD]
+  ├─ acquisition / market  [new] ─┤                          ├─ Page: post planner → composer → publish   [TO BUILD]
+  └─ Facebook page health  [new] ─┘                          └─ price / min-stay / OTA / do-nothing (human)
+```
+
+The **spine** (sensors → analyst → router) is shared and channel-agnostic. Each **arm** is a per-instrument planner → generator → guarded execution gateway. The WhatsApp arm is the fully-built reference implementation; the ads and page arms reuse its exact shape.
+
+| Layer | Shared? | Status |
+|---|---|---|
+| Sensors (`situation-pack.ts`) | shared | Built (inventory/pace/audience); **new: acquisition + page-health sensors** |
+| Analyst (`situation-analyst` skill) | shared | Built — LLM over facts; **already routes to ads** as a menu item |
+| Router / instrument choice | shared | Built into the analyst's reasoning (a menu, not a rules table) |
+| Opportunity contract (`contracts.ts`) | shared | Built — **but `instrument` is WhatsApp-only today; generalize to `whatsapp\|ads\|page`** |
+| WhatsApp planner + copywriter + validators | arm | **Built, live in prod** |
+| Ads planner + creative/copy intelligence | arm | **Missing** (execution console exists; no brain) |
+| Page post planner + composer | arm | **Missing** (+ needs token scopes) |
+| Execution gateways (message / ads / page) | arm | Message + ads gateways built; page gateway new |
+
+---
+
+## 3. The shared brain
+
+### 3.1 Sensors — what the system watches (`scripts/situation-pack.ts`)
+Pure functions over Firestore + the clock. Today: `performance` (occupancy/ADR/RevPAR, like-for-like YTD), month baselines, channel/origin mix, `inventory` (gaps, **orphan nights**, unsellable-under-min-stay, named periods), `audience` (segments, `dueNow`, return clock), `dataQuality` (provenance + caveats). **To add:**
+- **Acquisition/market sensor** — past ad performance (from the ad account: CTR/CPC/spend history), pixel pool size, seasonal demand signals. Tells the analyst whether an acquisition play is warranted and what has worked.
+- **Facebook page-health sensor** — is the page alive (last post date, engagement trend), profile correctness (e.g. the website-link-to-Airbnb leak), audience. A dormant page is itself a flagged opportunity.
+
+### 3.2 The analyst — an LLM over the facts (`.claude/skills/situation-analyst`)
+Not a rules engine. It reads the pack and produces a **Situation Report** (headline → flags ranked by money at risk → opportunities with instrument + why → an explicit NORMAL section → questions → confidence). It **never computes** (every number is cited from the pack) and **never sends or spends**. Crucially, its instrument list is *"a menu, not a mapping"* — it already includes **Ads** (*"reaches strangers; scales with budget; hand over as a dated, sized proposal"*). So detection and the WhatsApp-vs-ads decision already live in this one shared reasoner. **This is why we extend it, never fork a second ads analyst** — a fork would duplicate the identical sensors and diagnosis and could disagree with itself.
+
+### 3.3 The Opportunity — the one shape everything shares (`src/lib/growth/contracts.ts`)
+`Opportunity` = `{ id, propertyId, source, window{start,end,nights}, daysOut, occasion?, valueAtRisk?, instrument, rationale }`. **Today `instrument` is the literal `'whatsapp'`** — the typed pipeline is WhatsApp-only by construction. **The core generalization this architecture requires: `instrument: 'whatsapp' | 'ads' | 'page'`** (or a discriminated union), so the analyst can route an opportunity to ads or the page and a matching planner can consume it — exactly as the WhatsApp planner consumes a whatsapp-routed one.
+
+### 3.4 Routing — audience-math-driven, "both" allowed
+The split is already encoded: the analyst's standing constraint (*"WhatsApp targets Romanian guests; foreign demand is an ads or OTA matter"*) plus `src/lib/growth/audience.ts` (`isRomaniaBased` / `classifyResidency` → **domestic / diaspora / foreign**). For a detected gap the router reasons: the **warm RO/diaspora/repeat** slice → WhatsApp; the **residual/strangers/foreign** slice → ads; a **silent brand page** → an organic post. *Often the answer is several arms for the same gap, to different people* — that is the cohesion, and only one shared analyst keeps it coherent.
+
+---
+
+## 4. The channel arms
+
+### 4.1 WhatsApp — the reference implementation (BUILT, live in prod)
+`analyst → planner (`whatsapp-planner` skill + `planner-pack.ts`) → copywriter (`copywriter.ts`, Opus, in-app) → land (`createProposedCampaign`) → /admin/campaigns Gate-1 review → outbox → Gate-2 wa.me`. Guardrails: `validatePlan` (narrows-never-widens · run cap · offer ceiling) and `validateDrafts` (grounding · voice · self-ID · opt-out · sentiment). Ban-safe: the server never touches WhatsApp; the owner one-taps `wa.me`. This arm is the template the other two copy.
+
+### 4.2 Ads — execution built, intelligence missing (THE main build)
+**Built** (`src/services/growth/metaAds/*`, `adComposer`, `adExecutionGateway`, `/admin/ads`): the whole PAUSED create→approve→activate→pause→insights chain, two-switch spend gate, ownership asserts, spend-cap math, audit log — see `docs/growth-ad-engine-plan.md`. **Missing** — the *brain*, which is the twin of the WhatsApp arm:
+- **Ad planner** (twin of `whatsapp-planner`): an ad-planner-pack (geo/interest candidates, budget ceiling `MAX_DAILY_BUDGET_MINOR`, the opportunity's nights/value, past-ad performance, page-best content) → LLM sizes targeting + budget + angle + creative brief → an ad-brief validator (spend-cap math, geo sanity) → a **PAUSED `adCampaigns` draft** landed into `/admin/ads` for Gate-1 review. `narrows-never-widens` becomes "narrows targeting/budget against candidates"; the offer-ceiling guard becomes the spend-cap guard.
+- **Ad creative/copy intelligence** (twin of the copywriter): grounded in real gallery photos + best-performing past ad copy + the page's best posts; writes ad primary-text/headline/CTA and picks photos; validated for truth (no invented amenities) and the **public brand voice** (see §5.1). Feeds the existing composer.
+- **The hand-off**: `POST /api/growth/ad-proposals` — the analyst→ads seam that lands a proposal into the console (mirrors `land-campaign.ts` → `/admin/campaigns`).
+- **Admin symmetry**: reshape `/admin/ads` from a blank compose form into the campaigns-workspace pattern — **framing → "Generate ad" → Gate-1 review → guarded activate**.
+
+### 4.3 The Facebook page — sensor AND instrument (NEW; needs a token grant)
+The page (`ComarnicChalet`, 552 followers) is a real, **dormant** asset the system should both understand and keep alive.
+- **As a sensor** (§3.1): page health, post performance, audience — a corpus for voice + what-to-promote, and a flag when it goes quiet.
+- **As an instrument**: an organic-post planner + composer → **draft → owner approves → publish**, under the same gate discipline as ads/WhatsApp. Never auto-post; content guardrail = truth + real assets + the owner's brand voice.
+- **Provisioning boundary** (from the 26 Jul live audit): reading the page *profile + aggregate insights* works today; reading *post content* + Instagram + *posting* needs added token scopes (`pages_read_user_content`, `pages_manage_posts`, `instagram_*`) + a `CREATE_CONTENT` page task. See `docs/meta-ads-infrastructure-2026.md` §11 and the provisioning checklist there.
+- **Immediate free win** (no token change): the page's `website` field points at `airbnb.com/rooms/43265214` — change it to `prahova-chalet.ro` to stop leaking direct-booking margin.
+
+### 4.4 Non-campaign instruments (the analyst must be able to propose these)
+Price change, minimum-stay change, length-of-stay discount, OTA action, and **do nothing (with a reason)**. A system that never says "this is normal" can't be trusted when it says "this isn't."
+
+---
+
+## 5. The shared patterns — what makes it cohesive
+
+### 5.1 Corpus voice-learning — one voice, per-surface register
+The copywriter learns the owner's voice from a **real, outcome-labeled corpus**, not a description (`copywriterPack.ts`: the owner's own outbound, tagged booked/replied/silent, ranked toward what booked). The same method extends across channels **with a different corpus per surface**:
+- **WhatsApp** → the private, warm 1:1 register (*tu/voi*, self-ID) from WhatsApp threads.
+- **Ads + page** → a **public brand voice**, learned from the best-performing past ad copy + the page's best posts. Same method (learn from real, outcome-weighted content; ground every claim; validate) — different corpus, so each channel sounds right for its context while all stay unmistakably the owner. *Things to promote* likewise draw on which page posts/photos and which ad angles actually resonated (the account's historical CTR was 6.7% — the instincts worked).
+
+### 5.2 Grounding + validators — truth and margin in code
+Every LLM stage declares the facts it used; a pure validator checks them against a whitelist and rejects anything ungrounded (`validateDrafts`: `factsUsed ⊆ groundedFacts`; `validatePlan`: eligible-set + cap + offer ceiling). A bounded repair loop feeds errors back once. The LLM owns intelligence; code owns truth + margin.
+
+### 5.3 Two-gate review + guarded execution
+Every channel: create/compose is safe by default and nothing goes live without a human gate. WhatsApp: Gate-1 review → Gate-2 wa.me. Ads: PAUSED-by-default + `GROWTH_ADS_ENABLED` + `GROWTH_ADS_MODE=live` two-switch + operator approve → activate. Page: draft → approve → publish. **Emergency stop is the Pause/limit, never the env switch (a deploy).**
+
+### 5.4 Facts + method + constraints, never conclusions
+The governing principle for every pack and prompt (§0). Validate via the strip test: remove any planted conclusion, re-run cold; what survives is real reasoning.
+
+---
+
+## 6. Locked design decisions (26 Jul 2026)
+
+1. **One shared analyst — extend, never fork.** Confirmed in code: the analyst already routes to ads over a menu; the RO/stranger split predicate exists.
+2. **Ad planner + creative intelligence run in-app** (like the copywriter's "Generate"), landing PAUSED drafts into `/admin/ads`.
+3. **Facebook page = sensor + instrument.** Read now (profile + aggregate health); posts/IG/publishing after a one-time token grant.
+4. **Creative: real photos first** (asset_feed_spec crops); external generation (people/relight) is a later phase.
+5. **Admin symmetry:** `/admin/ads` becomes framing → generate → Gate-1 review → guarded activate.
+6. **One public brand voice** for ads + page, distinct from the private WhatsApp voice; same corpus-learning method.
+
+---
+
+## 7. Build order (value-first, lowest-risk first)
+
+1. **Page understanding + the two free fixes** — ingest readable page data (profile + aggregate insights) + the ad-history sensor; surface "page dormant" and fix the Airbnb link. No provisioning.
+2. **Generalize the Opportunity contract** (`instrument: 'whatsapp' | 'ads' | 'page'`) + make the analyst's ads/page routing emit typed opportunities.
+3. **Ad planner** — routed opportunity → PAUSED ad draft into the console (twin of the WhatsApp planner).
+4. **Ad creative/copy intelligence** — grounded in photos + best past-ad copy + page best posts; the `/admin/ads` framing→generate→review redesign.
+5. **Organic page instrument** (after the token grant) — draft → approve → publish.
+6. **Reconciliation cron + go-live** — the durability backstop (see ads plan), set the account spend limit, then run the first real ad as a deliberate act.
+
+Do not build a later step before an earlier one proves out. Each arm reuses the WhatsApp arm's shape, so none is a from-scratch build.
+
+---
+
+## 8. Provisioning & backstops (owner actions, not code)
+
+- **Token scopes for the page** — add `pages_read_user_content`, `pages_manage_posts`, `instagram_*` + a `CREATE_CONTENT` page task; regenerate the system-user token into the `META_ADS_TOKENS` secret. Needed only for reading posts + Instagram + posting; do it in one batch. Detail: `docs/meta-ads-infrastructure-2026.md` §11.
+- **Account spend limit** — Meta `spend_cap` is currently `0`; set an account-level limit in Ads Manager before any live spend. This is the platform backstop that survives our bugs/dead tokens.
+- **Page website link** — change from the Airbnb URL to `prahova-chalet.ro`.
+
+---
+
+## Appendix — which document owns what (no duplication)
+
+| Concern | Home |
+|---|---|
+| Whole-system architecture, the brain, the arms, shared patterns, decisions, build order | **this file** |
+| Verified external Meta facts, API contracts, live-account + page + token audit | `docs/meta-ads-infrastructure-2026.md` |
+| Ads execution engine + ads-intelligence build phases + go-live runbook | `docs/growth-ad-engine-plan.md` |
+| WhatsApp arm in full (opportunity engine, planner, copywriter, gates) | `plans/engagement-system.md` *(local)* |
+| Original locked decisions (Core/Brain planes, the seam) | `plans/growth-engine.md` *(local)* |
+| Business rationale / roadmap | `docs/business/growth-engine-roadmap.md` *(local)* |

--- a/scripts/ad-plan.ts
+++ b/scripts/ad-plan.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env npx tsx
+/**
+ * ad-plan — run the in-app ad planner (generateAdPlan) against a real window and print the resulting
+ * AdBrief + validation. Prototyping/verification only; it PLANS, it never creates or activates
+ * anything on Meta. Tokens (ANTHROPIC_API_KEY + META_ADS_TOKENS) are pulled from Secret Manager.
+ *
+ * Usage:
+ *   npx tsx scripts/ad-plan.ts --start 2026-09-06 --end 2026-09-17 --value 6372 [--occasion "..."] [--property slug]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+const secret = (name: string) =>
+  execSync(`gcloud secrets versions access latest --secret=${name} --project=rentalspot-fzwom`, { encoding: 'utf8' }).trim();
+process.env.META_ADS_TOKENS = secret('META_ADS_TOKENS');
+process.env.ANTHROPIC_API_KEY = secret('ANTHROPIC_API_KEY');
+
+import { generateAdPlan } from '@/services/growth/adPlanner';
+import type { AdOpportunity } from '@/lib/growth/contracts';
+
+const arg = (n: string, d?: string): string | undefined => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? process.argv[i + 1] : d;
+};
+
+const start = arg('start');
+const end = arg('end');
+if (!start || !end) {
+  console.error('required: --start YYYY-MM-DD --end YYYY-MM-DD [--value RON] [--occasion "..."] [--property slug]');
+  process.exit(2);
+}
+const property = arg('property', 'prahova-mountain-chalet')!;
+const value = arg('value');
+const occasionName = arg('occasion');
+
+const nights = Math.round((Date.parse(end) - Date.parse(start)) / 86400000);
+const daysOut = Math.max(0, Math.round((Date.parse(start) - Date.now()) / 86400000));
+
+const opportunity: AdOpportunity = {
+  id: `adhoc-${start}-${end}`,
+  propertyId: property,
+  source: 'gap',
+  window: { start, end, nights },
+  daysOut,
+  occasion: occasionName ? { name: occasionName, type: 'ad-hoc', startDate: start, endDate: end } : null,
+  valueAtRisk: value ? Number(value) : null,
+  instrument: 'ads',
+  rationale: 'ad-hoc plan (CLI)',
+};
+
+const ron = (minor: number) => `${(minor / 100).toFixed(2)} RON`;
+
+(async () => {
+  const t0 = Date.now();
+  const res = await generateAdPlan(opportunity);
+  const secs = Math.round((Date.now() - t0) / 1000);
+  console.log(`\n=== ad plan for ${property} ${start}→${end} (${nights}n, ${daysOut}d out) — ${res.ok ? 'VALID' : 'REJECTED'} in ${res.attempts} attempt(s), ${secs}s ===\n`);
+  const b = res.brief;
+  if (b) {
+    console.log(`act: ${b.act}`);
+    console.log(`objective: ${b.objective}`);
+    console.log(`cities: ${b.targeting.cities.map((c) => `${c.name}(${c.key}) r${c.radius}km`).join(', ') || '(none)'}`);
+    console.log(`daily budget: ${ron(b.dailyBudgetMinor)}  ·  end: ${b.endTime}`);
+    console.log(`\ncreativeBrief:\n  ${b.creativeBrief}`);
+    console.log(`\nrationale:\n  ${b.rationale}`);
+  }
+  if (res.warnings.length) console.log(`\n⚠ warnings: ${res.warnings.join(' · ')}`);
+  if (!res.ok) console.log(`\n✖ errors: ${res.errors.join(' · ')}`);
+  process.exit(res.ok ? 0 : 1);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ad-planner-pack.ts
+++ b/scripts/ad-planner-pack.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env npx tsx
+/**
+ * ad-planner-pack — build + print the deterministic ad-planner fact pack for a window, to prototype
+ * and verify the pack (the in-app ad planner calls buildAdPlannerPack with the SAME logic). Read-only,
+ * zero spend; the money-scoped ads token is pulled from Secret Manager at runtime, never on argv.
+ *
+ * Usage:
+ *   npx tsx scripts/ad-planner-pack.ts --start 2026-09-06 --end 2026-09-17 --value 6372 [--occasion "..."] [--property ...] [--out pack.json]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import * as fs from 'fs';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+process.env.META_ADS_TOKENS = execSync(
+  'gcloud secrets versions access latest --secret=META_ADS_TOKENS --project=rentalspot-fzwom',
+  { encoding: 'utf8' }
+).trim();
+
+import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
+import type { AdOpportunity } from '@/lib/growth/contracts';
+
+const arg = (n: string, d?: string): string | undefined => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? process.argv[i + 1] : d;
+};
+
+const start = arg('start');
+const end = arg('end');
+if (!start || !end) {
+  console.error('required: --start YYYY-MM-DD --end YYYY-MM-DD [--value RON] [--occasion "..."] [--property slug] [--out file]');
+  process.exit(2);
+}
+const property = arg('property', 'prahova-mountain-chalet')!;
+const value = arg('value');
+const occasionName = arg('occasion');
+const OUT = arg('out');
+
+const nights = Math.round((Date.parse(end) - Date.parse(start)) / 86400000);
+const daysOut = Math.max(0, Math.round((Date.parse(start) - Date.now()) / 86400000));
+
+const opportunity: AdOpportunity = {
+  id: `adhoc-${start}-${end}`,
+  propertyId: property,
+  source: 'gap',
+  window: { start, end, nights },
+  daysOut,
+  occasion: occasionName ? { name: occasionName, type: 'ad-hoc', startDate: start, endDate: end } : null,
+  valueAtRisk: value ? Number(value) : null,
+  instrument: 'ads',
+  rationale: 'ad-hoc pack build (CLI)',
+};
+
+(async () => {
+  const pack = await buildAdPlannerPack(opportunity);
+  const json = JSON.stringify(pack, null, 2);
+  if (OUT) {
+    fs.writeFileSync(OUT, json);
+    console.error(`wrote ${OUT} (${Math.round(json.length / 1024)} KB)`);
+  } else {
+    console.log(json);
+  }
+  process.exit(0);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/growth-page-audit.ts
+++ b/scripts/growth-page-audit.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env npx tsx
+/**
+ * growth-page-audit — print the read-only Facebook PAGE + ad-account ACQUISITION
+ * health for a property (promotion-system-architecture.md §3.1 sensors). GET-only,
+ * zero spend, no writes. The money-scoped ads token is pulled from Secret Manager
+ * at runtime (never on argv), same pattern as scripts/growth-validate-ad-chain.ts.
+ *
+ * Usage: npx tsx scripts/growth-page-audit.ts [propertySlug]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+process.env.META_ADS_TOKENS = execSync(
+  'gcloud secrets versions access latest --secret=META_ADS_TOKENS --project=rentalspot-fzwom',
+  { encoding: 'utf8' }
+).trim();
+
+import { getPageHealth, getAdAccountHealth } from '@/services/growth/metaAds/brandHealth';
+
+const P = process.argv[2] || 'prahova-mountain-chalet';
+const ron = (minor: number) => `${(minor / 100).toFixed(2)} RON`;
+
+(async () => {
+  console.log(`=== Brand & acquisition audit — ${P} (read-only) ===\n`);
+
+  const page = await getPageHealth(P);
+  if (!page.ok) {
+    console.log(`PAGE: ✖ ${page.error}`);
+  } else {
+    const d = page.data;
+    console.log(`PAGE: ${d.name} (@${d.username}) — ${d.followers} followers · ${d.category}`);
+    console.log(`  published: ${d.isPublished} · talking_about: ${d.talkingAboutCount} · dormant: ${d.dormant}`);
+    console.log(`  website: ${d.websiteUrl ?? '—'}${d.websiteIsOtaLink ? '  ⚠️ OTA link — leaks direct margin' : ''}`);
+    console.log(`  insights(28d, ${d.canReadInsights ? 'readable' : 'UNREADABLE'}): ${JSON.stringify(d.insights28d)}`);
+    if (d.warnings.length) console.log(`  ⚠ ${d.warnings.join('\n  ⚠ ')}`);
+  }
+
+  const acct = await getAdAccountHealth(P);
+  if (!acct.ok) {
+    console.log(`\nAD ACCOUNT: ✖ ${acct.error}`);
+  } else {
+    const d = acct.data;
+    console.log(`\nAD ACCOUNT: ${d.name} (${d.adAccountId}) — ${d.currency} · active: ${d.accountStatusActive}`);
+    console.log(`  spend limit: ${d.hasSpendLimit ? ron(d.spendCapMinor) : 'NONE SET  🔴 (set one before live spend)'}`);
+    console.log(`  lifetime spent: ${ron(d.amountSpentMinor)} · funding: ${d.funding ?? '—'}`);
+    console.log(
+      `  lifetime perf: spend ${d.lifetime.spend} · ${d.lifetime.impressions} impr · ${d.lifetime.clicks} clicks · CTR ${d.lifetime.ctr}% · CPC ${d.lifetime.cpc}`
+    );
+    console.log(`  campaigns: ${d.campaignCount} (${d.activeCampaignCount} active) · conversion history: ${d.hasConversionHistory}`);
+    if (d.warnings.length) console.log(`  ⚠ ${d.warnings.join('\n  ⚠ ')}`);
+  }
+
+  process.exit(0);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/situation-pack.ts
+++ b/scripts/situation-pack.ts
@@ -18,7 +18,9 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import * as fs from 'fs';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { execSync } from 'child_process';
 import { getAdminDb } from '../src/lib/firebaseAdminSafe';
+import { getPageHealth, getAdAccountHealth } from '@/services/growth/metaAds/brandHealth';
 
 const arg = (n: string, d?: string) => {
   const i = process.argv.indexOf(`--${n}`);
@@ -101,6 +103,15 @@ async function main() {
       'history (we cannot observe whether domestic demand would rise to fill vacated foreign dates).',
     amountsNote: 'booking.pricing.total is NET-TO-OWNER — the amount that actually landed in the owner\'s account (owner-confirmed). OTA figures are post-commission (Booking.com / Airbnb pay out net); direct figures are the full amount the guest paid the owner by phone. Therefore ADR and RevPAR are true take-home, and cross-channel ADR is directly comparable as-is — do NOT subtract commission again, it is already out. Caveat: a direct-vs-OTA ADR gap reflects BOTH saved commission AND booking mix (which stays land on which channel), not commission alone.',
     sampleSize: { totalBookings: live.length, completedAsOf: completed.length, cancelled: allBookings.length - live.length },
+    currentSignals: {
+      isAsOfReproducible: false,
+      note:
+        'pack.currentSignals holds LIVE Facebook page + ad-account state read from Meta at pack-build ' +
+        'time. It has NO history and does NOT correspond to --as-of, so it is WITHHELD on a historical ' +
+        'backtest. Use it only for "current brand/acquisition health" (is the page alive, is the website ' +
+        'link correct, is an account spend limit set, is there conversion history) — never as a dated ' +
+        'fact inside a trend or a like-for-like comparison.',
+    },
   };
 
   // ---------- night ledger (stay-date based — fully reliable) ----------
@@ -607,9 +618,52 @@ async function main() {
       return { date: day, recipients: gset.size, repliedWithin14d: replied, replyRatePct: round(replied / gset.size * 100), stayedWithin120d: booked };
     });
 
+  // ---------- current brand + acquisition signals (LIVE Meta state — NOT as-of reproducible) ----------
+  // Fetched DIRECTLY from Meta at pack-build (promotion-system-architecture.md §3.1). Unlike every
+  // other block, this is CURRENT state with no history and no as-of, so it is WITHHELD on a historical
+  // backtest — the same discipline `inventory` uses — and flagged in dataQuality.currentSignals so the
+  // analyst never treats it as a dated fact. Best-effort: any failure (no token in this environment,
+  // a Graph hiccup) degrades to available:false; it never breaks the pack build.
+  let currentSignals: unknown;
+  if (isHistorical) {
+    currentSignals = {
+      available: false,
+      withheldReason:
+        `Generated with --as-of ${ymd(AS_OF)} (a backtest). Facebook page + ad-account health is CURRENT ` +
+        `state only (no history, no as-of), so it is withheld to avoid mixing today's brand state into a ` +
+        `historical view. Do not reason about the page or ad account from this pack.`,
+    };
+  } else {
+    // resolveAdContext reads the ads token from META_ADS_TOKENS. Load it best-effort from Secret
+    // Manager if this environment doesn't already carry it (mirrors scripts/growth-page-audit.ts);
+    // if gcloud/creds are absent the reads below simply return available:false.
+    if (!process.env.META_ADS_TOKENS) {
+      try {
+        process.env.META_ADS_TOKENS = execSync(
+          'gcloud secrets versions access latest --secret=META_ADS_TOKENS --project=rentalspot-fzwom',
+          { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+        ).trim();
+      } catch {
+        /* no creds in this environment → currentSignals degrades to available:false */
+      }
+    }
+    const [pageRes, acctRes] = await Promise.all([getPageHealth(PROPERTY), getAdAccountHealth(PROPERTY)]);
+    currentSignals = {
+      available: pageRes.ok || acctRes.ok,
+      note:
+        'LIVE current Facebook/Meta state at pack-build time — NOT as-of-reproducible and NOT part of the ' +
+        'historical series. Treat as "how things stand right now". Each block\'s `warnings` are actionable ' +
+        'flags (dormant page, OTA website link, no account spend limit, no conversion history). ' +
+        'available:false means the ads token was not reachable from this environment, not that all is well.',
+      page: pageRes.ok ? pageRes.data : { available: false, error: pageRes.error },
+      adAccount: acctRes.ok ? acctRes.data : { available: false, error: acctRes.error },
+    };
+  }
+
   const pack = {
     meta: { generatedFor: PROPERTY, asOf: ymd(AS_OF), generator: 'scripts/situation-pack.ts' },
     dataQuality,
+    currentSignals,
     performance,
     channels: bySrcYear,
     origin: byOriginYear,

--- a/src/lib/growth/__tests__/validateAdPlan.test.ts
+++ b/src/lib/growth/__tests__/validateAdPlan.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+
+import { validateAdPlan, type AdPlannerPackForValidation } from '../validateAdPlan';
+import type { AdBrief } from '../contracts';
+
+const NOW = Date.parse('2026-07-26T00:00:00Z');
+
+const PACK: AdPlannerPackForValidation = {
+  constraints: { maxDailyBudgetMinor: 20000, maxTotalSpendMinor: 50000 }, // 200 RON/day, 500 RON envelope
+  targeting: { candidateCityKeys: ['1910415', '1925836', '1913456'] },    // Bucuresti, Ploiesti, Constanta
+};
+
+/** A valid brief: 30 RON/day for 10 days = 300 RON ≤ 500 RON envelope, one candidate city. */
+const OK: Pick<AdBrief, 'act' | 'objective' | 'targeting' | 'dailyBudgetMinor' | 'endTime'> = {
+  act: true,
+  objective: 'sales',
+  targeting: { cities: [{ key: '1910415', name: 'Bucuresti', radius: 25 }] },
+  dailyBudgetMinor: 3000,
+  endTime: '2026-08-05T00:00:00Z', // NOW + 10 days
+};
+
+const run = (brief: Partial<typeof OK>) => validateAdPlan(PACK, { ...OK, ...brief } as typeof OK, NOW);
+
+describe('validateAdPlan — happy path', () => {
+  it('accepts a well-formed, in-budget, in-geo plan and reports stats', () => {
+    const res = run({});
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(res.stats).toEqual({ dailyBudgetMinor: 3000, cities: 1, daysToEnd: 10, projectedTotalMinor: 30000 });
+  });
+});
+
+describe('validateAdPlan — act:false (decline)', () => {
+  it('is valid when it targets nobody', () => {
+    const res = validateAdPlan(PACK, { ...OK, act: false, targeting: { cities: [] } }, NOW);
+    expect(res.ok).toBe(true);
+  });
+  it('rejects a declined plan that still carries targeting', () => {
+    const res = validateAdPlan(PACK, { ...OK, act: false }, NOW);
+    expect(res.ok).toBe(false);
+    expect(res.errors[0]).toMatch(/act:false but 1 city/);
+  });
+});
+
+describe('validateAdPlan — budget ceiling', () => {
+  it('rejects a daily budget above the ceiling', () => {
+    const res = run({ dailyBudgetMinor: 25000 });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('exceeds the ceiling'))).toBe(true);
+  });
+  it.each([0, -100, Number.NaN])('rejects a non-positive daily budget (%p)', (v) => {
+    const res = run({ dailyBudgetMinor: v as number });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('invalid daily budget'))).toBe(true);
+  });
+});
+
+describe('validateAdPlan — end time', () => {
+  it('rejects an end time in the past', () => {
+    const res = run({ endTime: '2026-07-20T00:00:00Z' }); // before NOW
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('not in the future'))).toBe(true);
+  });
+  it('rejects an unparseable end time', () => {
+    const res = run({ endTime: 'next tuesday' });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('invalid end time'))).toBe(true);
+  });
+});
+
+describe('validateAdPlan — geo (narrows-never-widens)', () => {
+  it('rejects a plan with no cities', () => {
+    const res = run({ targeting: { cities: [] } });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('no city targeting'))).toBe(true);
+  });
+  it('rejects a city key not in the pack candidates', () => {
+    const res = run({ targeting: { cities: [{ key: '9999999', name: 'Nowhere', radius: 25 }] } });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('not in the pack') && e.includes('9999999'))).toBe(true);
+  });
+  it.each([0, 100])('rejects an out-of-range radius (%p km)', (r) => {
+    const res = run({ targeting: { cities: [{ key: '1910415', name: 'Bucuresti', radius: r }] } });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('radius'))).toBe(true);
+  });
+});
+
+describe('validateAdPlan — objective', () => {
+  it('rejects an unsupported objective', () => {
+    const res = validateAdPlan(PACK, { ...OK, objective: 'awareness' as never }, NOW);
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('unsupported objective'))).toBe(true);
+  });
+});
+
+describe('validateAdPlan — spend envelope', () => {
+  it('rejects a plan whose projected total exceeds the envelope', () => {
+    // 6000/day × 10 days = 60000 > 50000 envelope
+    const res = run({ dailyBudgetMinor: 6000 });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('exceeds the plan envelope'))).toBe(true);
+    expect(res.stats.projectedTotalMinor).toBe(60000);
+  });
+  it('warns (does not block) when the pack sets no envelope', () => {
+    const noEnvelope: AdPlannerPackForValidation = { ...PACK, constraints: { ...PACK.constraints, maxTotalSpendMinor: null } };
+    const res = validateAdPlan(noEnvelope, OK, NOW);
+    expect(res.ok).toBe(true);
+    expect(res.warnings.some((w) => w.includes('no maxTotalSpendMinor'))).toBe(true);
+  });
+});

--- a/src/lib/growth/adPlannerPack.ts
+++ b/src/lib/growth/adPlannerPack.ts
@@ -1,0 +1,182 @@
+/**
+ * adPlannerPack — the deterministic FACT PACK the ad planner reasons over for one ads-routed
+ * opportunity (promotion-system-architecture.md §4.2). The acquisition twin of `copywriterPack` /
+ * the WhatsApp `planner-pack`: it assembles CANDIDATES + CONSTRAINTS (never conclusions, plan §2
+ * pr.5), and the planner narrows them into an `AdBrief` that `validateAdPlan` then gates.
+ *
+ * What it provides:
+ *   - the `AdOpportunity` (echoed — window, nights, value, occasion);
+ *   - `constraints`: the daily-budget ceiling + a spend ENVELOPE derived from the revenue at risk
+ *     (the ad-side analog of the WhatsApp offer inequality — never plan to spend more than the
+ *     nights at risk are worth);
+ *   - `targeting.candidateCities`: RO feeder-market cities resolved to Meta `adgeolocation` keys
+ *     (the geo the planner may pick from — narrows-never-widens; `validateAdPlan` enforces it);
+ *   - `account`: past-ad performance + health flags (from `brandHealth`) to size budget/expectation;
+ *   - `assets`: the property's gallery photos (for the planner's creative BRIEF — step 4 picks the
+ *     actual images);
+ *   - `landing`: the canonical direct-booking URL (the ROAS-attributed destination).
+ *
+ * Server-only (Admin SDK + read-only Meta GETs). Never throws on a Meta hiccup — the affected block
+ * degrades to `{available:false}` and the pack still builds.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { getBaseUrl } from '@/lib/structured-data';
+import { serverTranslateContent } from '@/lib/server-language-utils';
+import { getMaxDailyBudgetMinor } from '@/config/growth-ads';
+import { searchCities } from '@/services/growth/metaAds/geo';
+import { getAdAccountHealth, getPageHealth } from '@/services/growth/metaAds/brandHealth';
+import type { AdOpportunity } from '@/lib/growth/contracts';
+import type { CityMatch } from '@/services/growth/metaAds/geo';
+import type { PropertyImage } from '@/types';
+
+/**
+ * RO feeder markets for a Prahova-valley chalet — the candidate geo the planner picks from. Names
+ * are resolved to Meta keys at build time (cities MUST target by key, §9f). Ordered roughly by
+ * historical relevance (Bucharest = the main source; Ploiești/Brașov are the valley's near cities).
+ * Multi-property note: this list is Prahova-specific; a future property carries its own feeder set.
+ */
+const RO_FEEDER_CITIES = [
+  // NB: the capital resolves to the WHOLE city only under the English name "Bucharest" (key
+  // 1910415, §9f-verified); "Bucuresti"/"București" return only individual sectors.
+  'Bucharest', 'Ploiesti', 'Brasov', 'Constanta', 'Pitesti',
+  'Targoviste', 'Buzau', 'Galati', 'Braila', 'Ramnicu Valcea',
+];
+
+/** Absolute ceiling on a single plan's spend envelope, bani — 500 RON (Meta's campaign spend-cap floor). */
+const ABSOLUTE_MAX_TOTAL_MINOR = 50000;
+
+/** Diacritic-insensitive lowercase, so "Bucuresti" matches "București". */
+const norm = (s: string) => s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '');
+
+/**
+ * Pick the best city match for a feeder-city query. Prefers the WHOLE city: an exact (diacritic-
+ * insensitive) name match first, then any non-sector result, then the top match. Without this, a
+ * bare "Bucuresti" search resolves to "București Sectorul 1" — targeting one sector, not the city.
+ */
+function pickBestCity(query: string, matches: CityMatch[]): CityMatch | undefined {
+  if (!matches.length) return undefined;
+  const q = norm(query);
+  return matches.find((m) => norm(m.name) === q) ?? matches.find((m) => !/sector/i.test(m.name)) ?? matches[0];
+}
+
+export interface AdPlannerPack {
+  meta: { generatedFor: string; asOf: string; generator: string; opportunityId: string };
+  opportunity: AdOpportunity;
+  constraints: {
+    maxDailyBudgetMinor: number;
+    /** Spend envelope for this plan, bani = min(revenue-at-risk, absolute cap). Null if value unknown → planner sizes conservatively. */
+    maxTotalSpendMinor: number | null;
+    note: string;
+  };
+  targeting: {
+    candidateCities: CityMatch[];
+    candidateCityKeys: string[];
+    note: string;
+  };
+  account:
+    | {
+        available: true;
+        hasSpendLimit: boolean;
+        hasConversionHistory: boolean;
+        lifetime: { spend: number; impressions: number; clicks: number; ctr: number; cpc: number };
+        warnings: string[];
+        note: string;
+      }
+    | { available: false; error: string };
+  page: { available: true; dormant: boolean; followers: number; warnings: string[] } | { available: false; error: string };
+  assets: Array<{ storagePath: string; alt: string; tags: string[] }>;
+  landing: { baseUrl: string; note: string };
+  method: string[];
+}
+
+/** Build the ad-planner fact pack for one ads-routed opportunity. `asOf` defaults to now (UTC date). */
+export async function buildAdPlannerPack(
+  opportunity: AdOpportunity,
+  opts?: { asOf?: Date }
+): Promise<AdPlannerPack> {
+  const asOf = opts?.asOf ?? new Date();
+  const propertyId = opportunity.propertyId;
+
+  // Health blocks + candidate-city resolution + property doc, in parallel (all read-only, all degrade).
+  const [accountRes, pageRes, cityResults, propSnap] = await Promise.all([
+    getAdAccountHealth(propertyId),
+    getPageHealth(propertyId),
+    Promise.all(RO_FEEDER_CITIES.map((name) => searchCities(propertyId, name, { limit: 3 }))),
+    getAdminDb().then((db) => db.collection('properties').doc(propertyId).get()),
+  ]);
+
+  // Candidate cities — the best match per name, deduped by key (a resolution failure just drops that
+  // city). "Best" prefers the WHOLE city over a sub-unit: a bare "Bucuresti" search returns
+  // "București Sectorul 1" first, which would target one sector instead of the whole city.
+  const candidateCities: CityMatch[] = [];
+  const seenKeys = new Set<string>();
+  for (let i = 0; i < cityResults.length; i++) {
+    const r = cityResults[i];
+    if (!r.ok) continue;
+    const m = pickBestCity(RO_FEEDER_CITIES[i], r.data);
+    if (m && !seenKeys.has(m.key)) {
+      seenKeys.add(m.key);
+      candidateCities.push(m);
+    }
+  }
+
+  // Spend envelope: never plan to outspend the revenue at risk (valueAtRisk is RON → bani).
+  const valueAtRiskMinor =
+    opportunity.valueAtRisk != null && opportunity.valueAtRisk > 0 ? Math.round(opportunity.valueAtRisk * 100) : null;
+  const maxTotalSpendMinor = valueAtRiskMinor != null ? Math.min(valueAtRiskMinor, ABSOLUTE_MAX_TOTAL_MINOR) : ABSOLUTE_MAX_TOTAL_MINOR;
+
+  // Gallery assets owned by this property (for the creative brief — step 4 picks the actual photos).
+  const propData = propSnap.exists ? (propSnap.data() as { images?: PropertyImage[]; customDomain?: string | null }) : undefined;
+  const ownPrefix = `properties/${propertyId}/`;
+  const assets = (propData?.images ?? [])
+    .filter((img): img is PropertyImage & { storagePath: string } => Boolean(img.storagePath && img.storagePath.startsWith(ownPrefix)))
+    .map((img) => ({ storagePath: img.storagePath, alt: serverTranslateContent(img.alt, 'en'), tags: img.tags ?? [] }));
+
+  const account: AdPlannerPack['account'] = accountRes.ok
+    ? {
+        available: true,
+        hasSpendLimit: accountRes.data.hasSpendLimit,
+        hasConversionHistory: accountRes.data.hasConversionHistory,
+        lifetime: {
+          spend: accountRes.data.lifetime.spend,
+          impressions: accountRes.data.lifetime.impressions,
+          clicks: accountRes.data.lifetime.clicks,
+          ctr: accountRes.data.lifetime.ctr,
+          cpc: accountRes.data.lifetime.cpc,
+        },
+        warnings: accountRes.data.warnings,
+        note: 'Past-ad performance (lifetime). A high CTR/low CPC = the account\'s creative/audience instincts have worked; but hasConversionHistory:false means a conversion (OUTCOME_SALES) campaign starts cold — no pixel-purchase learning yet, so early results are noisy. `no-account-spend-limit` is an owner prerequisite before live spend, NOT a planning input.',
+      }
+    : { available: false, error: accountRes.error };
+
+  const page: AdPlannerPack['page'] = pageRes.ok
+    ? { available: true, dormant: pageRes.data.dormant, followers: pageRes.data.followers, warnings: pageRes.data.warnings }
+    : { available: false, error: pageRes.error };
+
+  return {
+    meta: { generatedFor: propertyId, asOf: asOf.toISOString().slice(0, 10), generator: 'src/lib/growth/adPlannerPack.ts', opportunityId: opportunity.id },
+    opportunity,
+    constraints: {
+      maxDailyBudgetMinor: getMaxDailyBudgetMinor(),
+      maxTotalSpendMinor,
+      note: `Budgets are in BANI (minor units). Keep dailyBudgetMinor ≤ maxDailyBudgetMinor, and dailyBudget × days-to-endTime ≤ maxTotalSpendMinor (the revenue-at-risk envelope). For a first, unproven acquisition test, size CONSERVATIVELY (a small daily budget + a bounded end date) — the point is to learn whether ads convert, not to spend the envelope.`,
+    },
+    targeting: {
+      candidateCities,
+      candidateCityKeys: candidateCities.map((c) => c.key),
+      note: 'Pick a SUBSET of these cities (with a per-city radius in km). Advantage+ Audience owns demographics (§9f) — there is NO age/gender/interest control; GEO + the copy angle qualify the audience. Favor the feeder markets that fit the occasion and the property (a mountain weekend sells to nearby cities + Bucharest).',
+    },
+    account,
+    page,
+    assets,
+    landing: {
+      baseUrl: getBaseUrl(propData?.customDomain),
+      note: 'The direct-booking site — the ROAS-attributed destination. The composer stamps utm_campaign=<adCampaignId> on it (step 4); the planner just confirms the destination is the direct site, never an OTA URL.',
+    },
+    method: [
+      'You PLAN: pick geo (subset of candidateCities + radius), a daily budget + a bounded end time (within the envelope), and write a creativeBrief (the angle + which asset themes to favor + tone). You do NOT write final ad copy or choose exact photos — that is the creative intelligence (step 4).',
+      'Ground every choice in the pack: the opportunity (window/nights/occasion), account performance (CTR/CPC to size reach), the candidate cities, the assets available. Do not invent a city key, a budget above the ceiling, or an asset not listed.',
+      'If the opportunity is weak (no occasion, tiny value, or the account is blocked), set act:false and say why — a forced ad burns real money, unlike a WhatsApp message.',
+    ],
+  };
+}

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -9,7 +9,7 @@
  *
  * Pure types + a couple of pure guards — no Firestore, no network.
  */
-import type { LanguageCode } from '@/types';
+import type { AdObjective, CityTarget, LanguageCode } from '@/types';
 
 // ── analyst → router → per-instrument planner ────────────────────────────────
 /**
@@ -119,6 +119,35 @@ export function effectiveDiscountPct(offer: CampaignOffer | undefined | null): n
     case 'fixed': return null;
     default: return offer.discountPct ?? null;
   }
+}
+
+// ── ad planner → ad creative intelligence / validateAdPlan ───────────────────
+/**
+ * The ad planner's typed output — the reviewable BRIEF for a Meta acquisition push
+ * (promotion-system-architecture.md §4.2, the twin of `CampaignBrief`). The planner
+ * decides WHERE (geo), HOW MUCH (budget), HOW LONG (end time), and the ANGLE; it does
+ * NOT write copy or pick photos — that is the creative intelligence (step 4), which
+ * turns this brief into a PAUSED Meta ad via `adComposer.composeAndCreateAd`.
+ *
+ * `targeting.cities` and `objective` reuse the NEUTRAL `@/types` shapes so a validated
+ * brief threads straight into `ComposeAndCreateAdInput` without remapping. No age/gender/
+ * interests: the composer's baked `advantage_audience:1` OWNS demographics (§9f) — geo +
+ * copy qualify the audience. `validateAdPlan` is the money/margin gate (budget ceiling,
+ * future end time, geo present, cities ⊆ the pack's candidates — narrows-never-widens).
+ */
+export interface AdBrief {
+  propertyId: string;
+  opportunity: AdOpportunity;   // the ads arm only ever plans an ads-routed opportunity
+  act: boolean;                 // false = decline; a declined plan carries no targeting
+  objective: AdObjective;       // 2a: 'sales' (→ Meta OUTCOME_SALES)
+  targeting: {
+    /** Selected city targets — a SUBSET of the pack's candidate cities (validateAdPlan enforces). */
+    cities: CityTarget[];
+  };
+  dailyBudgetMinor: number;     // bani — ≤ MAX_DAILY_BUDGET_MINOR (validated)
+  endTime: string;              // ISO 8601 — bounds the run + the spend-cap math
+  creativeBrief: string;        // the brief the creative intelligence particularises: what to say/show, tone, which photo themes
+  rationale: string;            // why this geo / budget / timing
 }
 
 // ── copywriter → grounding validator / outbox ────────────────────────────────

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -11,8 +11,17 @@
  */
 import type { LanguageCode } from '@/types';
 
-// ── analyst → planner ────────────────────────────────────────────────────────
-/** One routed opportunity the analyst decided WhatsApp should act on (plan §3.1). */
+// ── analyst → router → per-instrument planner ────────────────────────────────
+/**
+ * The instrument the analyst routed an opportunity to (promotion-system-architecture.md §3.3/§3.4).
+ * ONE shared detector, MANY responses: a warm past-guest message (`whatsapp`), a paid acquisition
+ * push to strangers (`ads`), or an organic brand post (`page`). Each instrument has its own planner
+ * downstream — this field says which one owns a given opportunity. The analyst emits the general
+ * `Opportunity`; the router/planners narrow (see the subtypes below).
+ */
+export type OpportunityInstrument = 'whatsapp' | 'ads' | 'page';
+
+/** One sized/dated/priced opportunity the analyst routed to an instrument (plan §3.1). */
 export interface Opportunity {
   id: string;
   propertyId: string;
@@ -21,9 +30,20 @@ export interface Opportunity {
   daysOut: number;
   occasion?: { name: string; type: string; startDate: string; endDate: string; source?: string | null } | null;
   valueAtRisk?: number | null;                              // nights × baseline ADR, if known
-  instrument: 'whatsapp';                                   // the analyst routed it here
+  instrument: OpportunityInstrument;                        // which instrument the analyst routed it to
   rationale?: string;
 }
+
+/**
+ * Instrument-narrowed opportunity subtypes. Each arm's planner consumes ONLY its own kind — the
+ * WhatsApp planner/copywriter path takes a `WhatsAppOpportunity`, the ad planner (being built) an
+ * `AdOpportunity`, the page planner a `PageOpportunity`. Narrowing here makes a mis-routed
+ * opportunity a COMPILE error, not a runtime surprise, while the analyst still emits the general
+ * `Opportunity`.
+ */
+export type WhatsAppOpportunity = Opportunity & { instrument: 'whatsapp' };
+export type AdOpportunity = Opportunity & { instrument: 'ads' };
+export type PageOpportunity = Opportunity & { instrument: 'page' };
 
 // ── planner → copywriter / validator / createManualCampaign ──────────────────
 export type CampaignIntent = 'gap_fill' | 'share';
@@ -68,7 +88,7 @@ export interface CampaignUpdate {
 /** The planner's typed output — the draft FRAMING the human gate edits before the copywriter runs (§7.4). */
 export interface CampaignBrief {
   propertyId: string;
-  opportunity: Opportunity;
+  opportunity: WhatsAppOpportunity;   // the WhatsApp arm only ever plans a whatsapp-routed opportunity
   act: boolean;                  // false = decline; audience must then be empty
   intent: CampaignIntent;
   occasion: { name: string | null; point: string };   // the "what & why now"
@@ -136,7 +156,7 @@ export interface CampaignProposal {
   updates?: CampaignUpdate[];
   generalAngle: string;
   rationale: string;
-  opportunity: Opportunity;
+  opportunity: WhatsAppOpportunity;
 }
 
 // ── pure guards / joins ──────────────────────────────────────────────────────

--- a/src/lib/growth/validateAdPlan.ts
+++ b/src/lib/growth/validateAdPlan.ts
@@ -1,0 +1,127 @@
+/**
+ * validateAdPlan — the deterministic gate between the ad planner (an LLM) and the ad creative
+ * intelligence / console. The AD twin of `validatePlan`: it enforces plan §2 principle 1 ("the
+ * LLM narrows, never widens") for the acquisition arm, in CODE. Where `validatePlan` guards a guest
+ * list + an offer ceiling, this guards the MONEY + GEO of an `AdBrief`:
+ *
+ *   1. Narrows-never-widens — every selected city.key must be in the pack's candidate set. The
+ *      planner may only pick geo the pack offered; it cannot invent an ad-geolocation key.
+ *   2. Budget ceiling — dailyBudgetMinor within (0, maxDailyBudgetMinor]. This mirrors
+ *      `adComposer.validateDailyBudget`'s server-side ceiling (B2) at the plan stage, before any
+ *      Meta call, so a runaway budget is rejected as a plan, not caught downstream.
+ *   3. Spend envelope — a bounded run: dailyBudgetMinor × days-to-end must not exceed the pack's
+ *      maxTotalSpendMinor (the plan's budget envelope). The real per-campaign spend cap is set later
+ *      at approval (`adExecutionGateway` + `validateApprovalCap`); this is the earlier, plan-level
+ *      backstop so an over-budget plan never reaches the creative stage.
+ *   4. Sane targeting — a future end time, at least one city, and each radius within Meta's range.
+ *
+ * Pure — no Firestore, no network, no Meta — so it is exhaustively unit-testable and safe to import
+ * from both the eventual in-app ad planner and any CLI harness. The `adExecutionGateway` still
+ * re-checks the money gates at activation regardless; this is the campaign-level backstop that stops
+ * a bad PLAN from ever being composed into a PAUSED ad.
+ */
+import type { AdBrief } from './contracts';
+
+/** Meta city-radius bounds (kilometers) — the neutral layer targets in km (§9f). */
+const MIN_RADIUS_KM = 1;
+const MAX_RADIUS_KM = 80; // Meta's ~50-mile city-radius ceiling
+
+/** The subset of the ad-planner pack this validator needs. */
+export interface AdPlannerPackForValidation {
+  constraints: {
+    /** Hard daily ceiling, bani — mirrors `MAX_DAILY_BUDGET_MINOR`. */
+    maxDailyBudgetMinor: number;
+    /** Optional overall spend envelope for this plan, bani. Null ⇒ no envelope in the pack (warn, don't block). */
+    maxTotalSpendMinor: number | null;
+  };
+  targeting: {
+    /** The ad-geolocation city keys the planner may pick from (narrows-never-widens). */
+    candidateCityKeys: string[];
+  };
+}
+
+export interface AdPlanValidationResult {
+  ok: boolean;
+  errors: string[];   // hard failures — reject the whole plan (feed back to the planner; bounded repair)
+  warnings: string[]; // worth surfacing at review but not blocking
+  stats: { dailyBudgetMinor: number; cities: number; daysToEnd: number | null; projectedTotalMinor: number | null };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Validate an ad-planner `AdBrief` against its pack. Errors are written repair-prompt-ready: on
+ * failure, feed them back to the planner (bounded to 1–2 retries), then escalate to the human.
+ * Never silently drop the offending targeting and proceed — that hides a reasoning defect.
+ *
+ * `now` is injectable for deterministic tests; it defaults to the wall clock (same discipline as
+ * `adComposer.validateApprovalCap`, which reads `Date.now()`).
+ */
+export function validateAdPlan(
+  pack: AdPlannerPackForValidation,
+  brief: Pick<AdBrief, 'act' | 'objective' | 'targeting' | 'dailyBudgetMinor' | 'endTime'>,
+  now: number = Date.now()
+): AdPlanValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const cities = brief.targeting?.cities ?? [];
+  const nothing = (daysToEnd: number | null, projected: number | null): AdPlanValidationResult => ({
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    stats: { dailyBudgetMinor: brief.dailyBudgetMinor, cities: cities.length, daysToEnd, projectedTotalMinor: projected },
+  });
+
+  // A plan that declined to act is valid iff it targeted nobody (mirrors validatePlan's act:false rule).
+  if (!brief.act) {
+    if (cities.length > 0) errors.push(`act:false but ${cities.length} city target(s) selected — a declined plan must target nobody`);
+    return nothing(null, null);
+  }
+
+  // 1. Objective (2a supports only 'sales').
+  if (brief.objective !== 'sales') errors.push(`unsupported objective "${brief.objective}" — only 'sales' is verified`);
+
+  // 2. Budget ceiling.
+  const daily = brief.dailyBudgetMinor;
+  if (!Number.isFinite(daily) || daily <= 0) {
+    errors.push(`invalid daily budget ${daily} — must be a positive number of bani`);
+  } else if (daily > pack.constraints.maxDailyBudgetMinor) {
+    errors.push(`daily budget ${daily} exceeds the ceiling ${pack.constraints.maxDailyBudgetMinor} (bani)`);
+  }
+
+  // 3. End time — must parse and be in the future.
+  const endMs = Date.parse(brief.endTime);
+  let daysToEnd: number | null = null;
+  if (Number.isNaN(endMs)) {
+    errors.push(`invalid end time "${brief.endTime}" — must be ISO 8601`);
+  } else {
+    daysToEnd = Math.ceil((endMs - now) / DAY_MS);
+    if (daysToEnd <= 0) errors.push('end time is not in the future — a bounded run needs a future end date');
+  }
+
+  // 4. Geo — at least one city, all from the candidate set, each with a sane radius.
+  if (cities.length === 0) {
+    errors.push('no city targeting — an ad set needs at least one geo target');
+  } else {
+    const candidates = new Set(pack.targeting.candidateCityKeys);
+    const offList = cities.filter((c) => !candidates.has(c.key)).map((c) => c.key);
+    if (offList.length) errors.push(`selected ${offList.length} city key(s) not in the pack's candidates: ${offList.join(', ')}`);
+    const badRadius = cities.filter((c) => !Number.isFinite(c.radius) || c.radius < MIN_RADIUS_KM || c.radius > MAX_RADIUS_KM);
+    if (badRadius.length) {
+      errors.push(`${badRadius.length} city radius/radii out of range [${MIN_RADIUS_KM}, ${MAX_RADIUS_KM}] km: ${badRadius.map((c) => `${c.key}:${c.radius}`).join(', ')}`);
+    }
+  }
+
+  // 5. Spend envelope — dailyBudget × days must fit the plan's total budget (when the pack sets one).
+  let projected: number | null = null;
+  if (Number.isFinite(daily) && daily > 0 && daysToEnd && daysToEnd > 0) {
+    projected = daily * daysToEnd;
+    if (pack.constraints.maxTotalSpendMinor == null) {
+      warnings.push(`projected total ~${projected} bani over ${daysToEnd} day(s), but the pack sets no maxTotalSpendMinor envelope — confirm the total manually`);
+    } else if (projected > pack.constraints.maxTotalSpendMinor) {
+      errors.push(`projected total ${projected} bani (${daily}/day × ${daysToEnd}d) exceeds the plan envelope ${pack.constraints.maxTotalSpendMinor}`);
+    }
+  }
+
+  return nothing(daysToEnd, projected);
+}

--- a/src/services/growth/adPlanner.ts
+++ b/src/services/growth/adPlanner.ts
@@ -1,0 +1,193 @@
+/**
+ * adPlanner (in-app) — turns ONE analyst-routed ads opportunity into a reviewable ad PLAN
+ * (`AdBrief`), by calling Claude with the deterministic `adPlannerPack`. The acquisition twin of
+ * `copywriter.ts`: same shape (build pack → forced tool call → validate → one bounded repair), but
+ * it plans a paid push (geo + budget + timing + a creative brief) instead of writing a per-guest
+ * message. It PLANS — it does not write final ad copy or choose exact photos (that is the creative
+ * intelligence, step 4), and it does not create or activate anything on Meta.
+ *
+ * Guardrails on MONEY + geo are enforced in CODE (`validateAdPlan`: budget ceiling, spend envelope,
+ * cities ⊆ candidates, future end time). The LLM owns the judgement (which cities, how much, the
+ * angle, and whether to act at all). It never ships an over-budget or off-geo plan.
+ *
+ * Server-only. Degrades (throws a clear error) if ANTHROPIC_API_KEY is absent.
+ */
+import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
+import { validateAdPlan, type AdPlannerPackForValidation } from '@/lib/growth/validateAdPlan';
+import type { AdBrief, AdOpportunity } from '@/lib/growth/contracts';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+const AD_BRIEF_TOOL = {
+  name: 'emit_ad_brief',
+  description: 'Emit the ad plan: whether to act, the geo targeting, the budget, the end time, and the creative brief.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      act: { type: 'boolean', description: 'true = run this push; false = decline (weak opportunity) — then cities must be empty' },
+      objective: { type: 'string', enum: ['sales'], description: "always 'sales' (2a's only verified objective)" },
+      cities: {
+        type: 'array',
+        description: 'a SUBSET of the pack\'s targeting.candidateCities — never invent a key. Each: the exact key + name from the pack, plus a radius in km (1-80).',
+        items: {
+          type: 'object',
+          properties: {
+            key: { type: 'string', description: 'the exact candidateCities[].key from the pack' },
+            name: { type: 'string' },
+            radius: { type: 'number', description: 'kilometers, 1-80' },
+          },
+          required: ['key', 'name', 'radius'],
+        },
+      },
+      dailyBudgetMinor: { type: 'number', description: 'bani (minor units). Must be ≤ constraints.maxDailyBudgetMinor, AND dailyBudgetMinor × runDays ≤ constraints.maxTotalSpendMinor.' },
+      runDays: { type: 'number', description: 'the run length in DAYS from today (a small integer, e.g. 5-21). The code converts this to the end date — do NOT compute dates yourself. dailyBudgetMinor × runDays must stay within maxTotalSpendMinor.' },
+      creativeBrief: { type: 'string', description: 'the angle + which gallery asset THEMES to favor + tone. NOT final ad copy and NOT specific chosen photos — a brief for the creative stage.' },
+      rationale: { type: 'string', description: 'why this geo / budget / timing (or, if act:false, why decline).' },
+    },
+    required: ['act', 'objective', 'cities', 'dailyBudgetMinor', 'runDays', 'creativeBrief', 'rationale'],
+  },
+};
+
+const SYSTEM = `You are the ad planner for a small Romanian mountain-chalet rental. The analyst has
+routed ONE opportunity to Meta ads — paid acquisition, reaching STRANGERS (not past guests; that is
+the WhatsApp arm). Your job: decide WHERE (a subset of the candidate cities + a per-city radius),
+HOW MUCH (a daily budget within the envelope), HOW LONG (a bounded end date), and write a
+creativeBrief (the angle + which asset themes to favor + tone). You PLAN only — you do NOT write the
+final ad copy or choose exact photos (the creative stage does that), and nothing you emit spends
+money until a human approves and activates it.
+
+THE RULES
+1. NARROW, NEVER WIDEN. Pick cities ONLY from the pack's targeting.candidateCities, using their exact
+   keys — never invent a geo key. Keep dailyBudgetMinor ≤ constraints.maxDailyBudgetMinor, and
+   dailyBudgetMinor × runDays ≤ constraints.maxTotalSpendMinor (the revenue-at-risk envelope). You
+   pick runDays (a small integer, the run length in days from TODAY) — the code turns it into the end
+   date, so you never do date arithmetic; just keep dailyBudgetMinor × runDays within the envelope.
+2. SIZE CONSERVATIVELY. This account has NO conversion history (account.hasConversionHistory) — an
+   OUTCOME_SALES campaign starts cold and early results are noisy. This is a LEARNING test, not a
+   spend-the-envelope exercise: prefer a small daily budget and a bounded end date. Past CTR/CPC
+   (account.lifetime) tell you the account's reach is cheap; you do not need a large budget to learn.
+3. GEO + ANGLE QUALIFY THE AUDIENCE. There is no age/gender/interest control (Advantage+ Audience
+   owns demographics). Choose feeder cities that fit the property and the occasion (a mountain
+   weekend sells to the valley's near cities + Bucharest), and let the creativeBrief's angle do the
+   rest. Favor gallery asset THEMES that match the occasion (from the pack's assets — reference
+   themes/tags, do not pick exact files).
+4. GROUND EVERY CHOICE in the pack (the opportunity, account performance, candidate cities, assets,
+   landing). Do not assert a fact the pack does not contain.
+5. OR DECLINE. If the opportunity is weak — no occasion, tiny value, or the account is blocked — set
+   act:false and say why in the rationale, with cities empty. A forced ad spends real money, unlike
+   a WhatsApp message; declining is a valid, valuable output.
+
+Return your plan by calling emit_ad_brief. Nothing else.`;
+
+export interface GenerateAdPlanResult {
+  ok: boolean;
+  brief: AdBrief | null;
+  errors: string[];
+  warnings: string[];
+  attempts: number;
+}
+
+interface EmitAdBriefInput {
+  act: boolean;
+  objective: 'sales';
+  cities: Array<{ key: string; name: string; radius: number }>;
+  dailyBudgetMinor: number;
+  runDays: number;
+  creativeBrief: string;
+  rationale: string;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Generate an ad plan for one ads-routed opportunity. Builds the pack, runs the LLM, validates, and
+ * on failure feeds the validator errors back for ONE bounded repair before returning
+ * (ok:false + errors) — never ships an over-budget or off-geo plan.
+ */
+export async function generateAdPlan(
+  opportunity: AdOpportunity,
+  opts?: { asOf?: Date; maxRepairs?: number }
+): Promise<GenerateAdPlanResult> {
+  const client = getAnthropicClient();
+  if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app ad planner is unavailable');
+
+  const pack = await buildAdPlannerPack(opportunity, { asOf: opts?.asOf });
+  const validationPack: AdPlannerPackForValidation = {
+    constraints: { maxDailyBudgetMinor: pack.constraints.maxDailyBudgetMinor, maxTotalSpendMinor: pack.constraints.maxTotalSpendMinor },
+    targeting: { candidateCityKeys: pack.targeting.candidateCityKeys },
+  };
+  const maxRepairs = opts?.maxRepairs ?? 1;
+
+  const packJson = JSON.stringify({
+    opportunity: pack.opportunity,
+    constraints: pack.constraints,
+    targeting: pack.targeting,
+    account: pack.account,
+    page: pack.page,
+    assets: pack.assets,
+    landing: pack.landing,
+    method: pack.method,
+  });
+  const messages: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
+    { role: 'user', content: `Here is the ad-planner pack. Produce ONE ad plan and call emit_ad_brief.\n\n${packJson}` },
+  ];
+
+  let brief: AdBrief | null = null;
+  let lastValidation = { ok: false, errors: [] as string[], warnings: [] as string[] };
+
+  for (let attempt = 1; attempt <= maxRepairs + 1; attempt++) {
+    const resp = await client.messages.create({
+      model: COPYWRITER_MODEL, // Opus 4.8 — same model as the copywriter (no `thinking` param: incompatible with forced tool_choice)
+      max_tokens: 4096,
+      system: SYSTEM,
+      tools: [AD_BRIEF_TOOL],
+      tool_choice: { type: 'tool', name: 'emit_ad_brief' },
+      messages: messages as never,
+    });
+    const toolUse = resp.content.find((b: { type: string }) => b.type === 'tool_use') as { id?: string; input?: EmitAdBriefInput } | undefined;
+    const input = toolUse?.input;
+    const toolUseId = toolUse?.id;
+
+    // The model emits runDays (a small integer it can reason about); the CODE computes endTime, so
+    // the validator's days-to-endTime matches the model's budget×runDays math exactly — no LLM date
+    // arithmetic (the failure mode the first live run exposed).
+    brief = input
+      ? {
+          propertyId: pack.opportunity.propertyId,
+          opportunity: pack.opportunity,
+          act: input.act,
+          objective: input.objective,
+          targeting: { cities: (input.cities ?? []).map((c) => ({ key: c.key, name: c.name, radius: c.radius })) },
+          dailyBudgetMinor: input.dailyBudgetMinor,
+          endTime: new Date(Date.now() + Math.max(1, Math.round(input.runDays)) * DAY_MS).toISOString(),
+          creativeBrief: input.creativeBrief,
+          rationale: input.rationale,
+        }
+      : null;
+
+    const v = brief
+      ? validateAdPlan(validationPack, brief)
+      : { ok: false, errors: ['the model returned no ad brief'], warnings: [] };
+    lastValidation = { ok: v.ok, errors: v.errors, warnings: v.warnings };
+    logger.info('adPlanner generateAdPlan attempt', { attempt, act: brief?.act, ok: v.ok, errors: v.errors.length });
+
+    if (v.ok) return { ok: true, brief, errors: [], warnings: v.warnings, attempts: attempt };
+    if (attempt > maxRepairs) break;
+
+    // Bounded repair: hand back the exact errors (via a tool_result, required after a tool_use) and
+    // ask to fix ONLY those and re-emit.
+    const repairText =
+      `The plan failed validation. Fix EXACTLY these and re-emit via emit_ad_brief:\n- ${lastValidation.errors.join('\n- ')}\n\n` +
+      `Reminder: cities only from candidateCities (exact keys); dailyBudgetMinor ≤ maxDailyBudgetMinor; ` +
+      `dailyBudgetMinor × runDays ≤ maxTotalSpendMinor (do the multiplication — both are integers you control).`;
+    messages.push({ role: 'assistant', content: resp.content });
+    messages.push({
+      role: 'user',
+      content: toolUseId ? [{ type: 'tool_result', tool_use_id: toolUseId, content: repairText }] : repairText,
+    });
+  }
+
+  return { ok: false, brief, errors: lastValidation.errors, warnings: lastValidation.warnings, attempts: maxRepairs + 1 };
+}

--- a/src/services/growth/metaAds/__tests__/brandHealth.test.ts
+++ b/src/services/growth/metaAds/__tests__/brandHealth.test.ts
@@ -1,0 +1,199 @@
+/** @jest-environment node */
+
+jest.mock('../adContext', () => ({ resolveAdContext: jest.fn() }));
+jest.mock('../client', () => ({ metaGraph: jest.fn() }));
+
+import { getPageHealth, getAdAccountHealth } from '../brandHealth';
+import { resolveAdContext } from '../adContext';
+import { metaGraph } from '../client';
+
+const mockResolveAdContext = resolveAdContext as jest.Mock;
+const mockMetaGraph = metaGraph as jest.Mock;
+
+const PROPERTY = 'prahova-mountain-chalet';
+const CTX = { adAccountId: 'act_1', pageId: 'page_1', token: 'systok' };
+
+/** Route each metaGraph call to a canned response by exact path (order-independent). */
+function routeByPath(responses: Record<string, unknown>) {
+  mockMetaGraph.mockImplementation((p: string) =>
+    Promise.resolve(p in responses ? responses[p] : { ok: false, error: `unexpected path: ${p}` })
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── getPageHealth ────────────────────────────────────────────────────────────
+describe('getPageHealth', () => {
+  it('returns no-ad-context for an unconfigured property, without calling Meta', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await getPageHealth(PROPERTY);
+    expect(res).toEqual({ ok: false, error: 'no-ad-context' });
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+  });
+
+  it('returns no-page-configured when the context has no pageId', async () => {
+    mockResolveAdContext.mockResolvedValue({ adAccountId: 'act_1', token: 'systok' });
+    const res = await getPageHealth(PROPERTY);
+    expect(res).toEqual({ ok: false, error: 'no-page-configured' });
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+  });
+
+  it('parses profile + aggregate insights, and flags a dormant page with an OTA website link', async () => {
+    mockResolveAdContext.mockResolvedValue(CTX);
+    routeByPath({
+      page_1: {
+        ok: true,
+        data: {
+          name: 'Comarnic Mountain Chalet',
+          username: 'ComarnicChalet',
+          link: 'https://facebook.com/page_1',
+          followers_count: 552,
+          is_published: true,
+          talking_about_count: 0,
+          category: 'Vacation Home Rental',
+          website: 'https://www.airbnb.com/rooms/43265214',
+          verification_status: 'not_verified',
+        },
+      },
+      'me/accounts': { ok: true, data: { data: [{ id: 'page_1', access_token: 'pagetok' }] } },
+      'page_1/insights': {
+        ok: true,
+        data: {
+          data: [
+            { name: 'page_follows', values: [{ value: 3 }] },
+            { name: 'page_views_total', values: [{ value: 0 }, { value: 12 }] }, // latest value wins
+          ],
+        },
+      },
+    });
+
+    const res = await getPageHealth(PROPERTY);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.followers).toBe(552);
+    expect(res.data.dormant).toBe(true);
+    expect(res.data.websiteIsOtaLink).toBe(true);
+    expect(res.data.canReadInsights).toBe(true);
+    expect(res.data.insights28d).toEqual({ page_follows: 3, page_views_total: 12 });
+    expect(res.data.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('page-website-points-to-ota'),
+        'page-dormant:talking_about_count=0',
+      ])
+    );
+  });
+
+  it('degrades to profile-only (canReadInsights=false) when no page token is derivable', async () => {
+    mockResolveAdContext.mockResolvedValue(CTX);
+    routeByPath({
+      page_1: { ok: true, data: { name: 'X', followers_count: 10, is_published: true, talking_about_count: 5 } },
+      'me/accounts': { ok: true, data: { data: [] } }, // system user not on the page
+    });
+
+    const res = await getPageHealth(PROPERTY);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.canReadInsights).toBe(false);
+    expect(res.data.insights28d).toEqual({});
+    expect(res.data.dormant).toBe(false);
+    expect(res.data.warnings).toContain('page-insights-unreadable:no-page-token-or-analyze-task');
+  });
+
+  it('propagates a profile read failure without throwing', async () => {
+    mockResolveAdContext.mockResolvedValue(CTX);
+    routeByPath({ page_1: { ok: false, error: 'timeout' } });
+    const res = await getPageHealth(PROPERTY);
+    expect(res).toEqual({ ok: false, error: 'timeout' });
+  });
+});
+
+// ── getAdAccountHealth ───────────────────────────────────────────────────────
+describe('getAdAccountHealth', () => {
+  it('returns no-ad-context for an unconfigured property, without calling Meta', async () => {
+    mockResolveAdContext.mockResolvedValue(null);
+    const res = await getAdAccountHealth(PROPERTY);
+    expect(res).toEqual({ ok: false, error: 'no-ad-context' });
+    expect(mockMetaGraph).not.toHaveBeenCalled();
+  });
+
+  it('flags no-spend-limit + no-conversion-history for the current live account shape', async () => {
+    mockResolveAdContext.mockResolvedValue(CTX);
+    routeByPath({
+      act_1: {
+        ok: true,
+        data: {
+          name: 'Bogdan-Comarnic',
+          account_status: 1,
+          currency: 'RON',
+          spend_cap: '0',
+          amount_spent: '44753',
+          funding_source_details: { display_string: 'VISA *0028' },
+        },
+      },
+      'act_1/insights': {
+        ok: true,
+        data: {
+          data: [
+            {
+              spend: '412.44',
+              impressions: '90609',
+              clicks: '6062',
+              ctr: '6.69',
+              cpc: '0.068',
+              reach: '41906',
+              actions: [{ action_type: 'link_click', value: '2648' }], // no purchase → no conversion history
+            },
+          ],
+        },
+      },
+      'act_1/campaigns': {
+        ok: true,
+        data: { data: [{ id: 'c1', effective_status: 'PAUSED' }, { id: 'c2', effective_status: 'PAUSED' }] },
+      },
+    });
+
+    const res = await getAdAccountHealth(PROPERTY);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.hasSpendLimit).toBe(false);
+    expect(res.data.spendCapMinor).toBe(0);
+    expect(res.data.amountSpentMinor).toBe(44753);
+    expect(res.data.hasConversionHistory).toBe(false);
+    expect(res.data.campaignCount).toBe(2);
+    expect(res.data.activeCampaignCount).toBe(0);
+    expect(res.data.lifetime.clicks).toBe(6062);
+    expect(res.data.warnings).toEqual(
+      expect.arrayContaining(['no-account-spend-limit', 'no-conversion-optimized-history'])
+    );
+  });
+
+  it('does not warn when a spend limit is set and there is purchase history', async () => {
+    mockResolveAdContext.mockResolvedValue(CTX);
+    routeByPath({
+      act_1: { ok: true, data: { account_status: 1, currency: 'RON', spend_cap: '50000', amount_spent: '10000' } },
+      'act_1/insights': {
+        ok: true,
+        data: { data: [{ spend: '100', actions: [{ action_type: 'offsite_conversion.fb_pixel_purchase', value: '4' }] }] },
+      },
+      'act_1/campaigns': { ok: true, data: { data: [{ id: 'c1', effective_status: 'ACTIVE' }] } },
+    });
+
+    const res = await getAdAccountHealth(PROPERTY);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.hasSpendLimit).toBe(true);
+    expect(res.data.hasConversionHistory).toBe(true);
+    expect(res.data.activeCampaignCount).toBe(1);
+    expect(res.data.warnings).not.toContain('no-account-spend-limit');
+    expect(res.data.warnings).not.toContain('no-conversion-optimized-history');
+  });
+
+  it('propagates an account read failure without throwing', async () => {
+    mockResolveAdContext.mockResolvedValue(CTX);
+    routeByPath({ act_1: { ok: false, error: 'bad-token' } });
+    const res = await getAdAccountHealth(PROPERTY);
+    expect(res).toEqual({ ok: false, error: 'bad-token' });
+  });
+});

--- a/src/services/growth/metaAds/brandHealth.ts
+++ b/src/services/growth/metaAds/brandHealth.ts
@@ -1,0 +1,320 @@
+/**
+ * brandHealth — the read-only Facebook PAGE-health + ad-account (ACQUISITION)
+ * sensors (promotion-system-architecture.md §3.1, build step 1).
+ *
+ * These are the first two "new sensors" the shared analyst reasons over beyond
+ * inventory/pace/audience: is the brand page alive and correctly configured, and
+ * what does the ad account's history tell us about acquisition. Both are PURE
+ * GETs — reading page/account data can never spend money — so, like `insights.ts`,
+ * the only precondition is a resolved ad context; there is no dark-launch gate.
+ *
+ * Every Meta call goes through `metaGraph` (the one module that touches
+ * graph.facebook.com), token in the Bearer header, never thrown — a Graph hiccup
+ * surfaces as `{ok:false,error}`. Verified against the live account 26 Jul 2026
+ * (docs/meta-ads-infrastructure-2026.md §11): the system-user token reads the
+ * page PROFILE directly and page AGGREGATE insights via a derived page token
+ * (ANALYZE task); reading post CONTENT / Instagram / posting needs added scopes
+ * (§11.2) and is deliberately NOT attempted here.
+ *
+ * Plain server module (NOT 'use server') — exports types + async functions.
+ */
+import { loggers } from '@/lib/logger';
+import { resolveAdContext, type AdContext } from './adContext';
+import { metaGraph, type GraphResult } from './client';
+
+const logger = loggers.ads;
+
+/**
+ * The page-insight metrics that are still VALID in Graph v25 (§11.1) — the
+ * classic ones (`page_impressions`, `page_fans`, demographics) were deprecated.
+ * Requesting an invalid metric fails the WHOLE call, so this list is curated.
+ */
+const VALID_PAGE_METRICS = [
+  'page_post_engagements',
+  'page_daily_follows_unique',
+  'page_follows',
+  'page_views_total',
+  'page_total_actions',
+] as const;
+
+/** A page website pointing at an OTA leaks direct-booking margin (the Comarnic page → airbnb link, §11.3). */
+const OTA_HOST = /airbnb|booking\.com|vrbo|expedia|trip\.com|hotels\.com/i;
+
+export interface PageHealth {
+  pageId: string;
+  name?: string;
+  username?: string;
+  link?: string;
+  followers: number;
+  isPublished: boolean;
+  talkingAboutCount: number;
+  category?: string;
+  websiteUrl?: string;
+  /** ⚠️ the page's own website field points at an OTA (leaks direct-booking margin). */
+  websiteIsOtaLink: boolean;
+  verificationStatus?: string;
+  /** Aggregate 28-day page insights (valid v25 metrics only); empty for a dormant page. */
+  insights28d: Record<string, number>;
+  /** Whether a page token was derivable AND insights read back (ANALYZE task present). */
+  canReadInsights: boolean;
+  /** No recent activity at all — the "keep the page alive" flag. */
+  dormant: boolean;
+  /** Human-actionable flags derived from the above (also fed to the analyst). */
+  warnings: string[];
+}
+
+export interface AdAccountHealth {
+  adAccountId: string;
+  name?: string;
+  accountStatusActive: boolean;
+  currency?: string;
+  /** Account-level spending limit, in MINOR units (bani). 0 = no limit set (the missing backstop). */
+  spendCapMinor: number;
+  hasSpendLimit: boolean;
+  /** Lifetime amount spent, in MINOR units (bani). */
+  amountSpentMinor: number;
+  funding?: string;
+  /** Lifetime performance — note `spend` here is in MAJOR units (RON), unlike the minor-unit fields above. */
+  lifetime: {
+    spend: number;
+    impressions: number;
+    clicks: number;
+    ctr: number;
+    cpc: number;
+    reach: number;
+  };
+  campaignCount: number;
+  activeCampaignCount: number;
+  /** Any past purchase-type conversion in lifetime insights — false = OUTCOME_SALES starts cold. */
+  hasConversionHistory: boolean;
+  warnings: string[];
+}
+
+// ── Meta response shapes (only the fields we read) ──────────────────────────
+interface PageProfileResponse {
+  name?: string;
+  username?: string;
+  link?: string;
+  followers_count?: number;
+  fan_count?: number;
+  is_published?: boolean;
+  talking_about_count?: number;
+  category?: string;
+  website?: string;
+  verification_status?: string;
+}
+interface MeAccountsResponse {
+  data?: Array<{ id: string; access_token?: string }>;
+}
+interface PageInsightsResponse {
+  data?: Array<{ name: string; values?: Array<{ value: unknown }> }>;
+}
+interface MetaAction {
+  action_type: string;
+  value: string;
+}
+interface AccountResponse {
+  name?: string;
+  account_status?: number;
+  currency?: string;
+  spend_cap?: string;
+  amount_spent?: string;
+  funding_source_details?: { display_string?: string };
+}
+interface AccountInsightsResponse {
+  data?: Array<{
+    spend?: string;
+    impressions?: string;
+    clicks?: string;
+    ctr?: string;
+    cpc?: string;
+    reach?: string;
+    actions?: MetaAction[];
+  }>;
+}
+interface CampaignsListResponse {
+  data?: Array<{ id: string; effective_status?: string }>;
+}
+
+/**
+ * Derive a PAGE access token from the system-user token (`me/accounts` returns
+ * the token for each assigned page — §11.1). Page aggregate insights require it
+ * even though the page PROFILE reads with the system-user token directly.
+ * Best-effort: returns undefined (not an error) if the page isn't assigned or
+ * the call fails — the caller degrades to profile-only.
+ */
+async function derivePageToken(ctx: AdContext, propertyId: string): Promise<string | undefined> {
+  const res = await metaGraph<MeAccountsResponse>('me/accounts', {
+    method: 'GET',
+    params: { fields: 'id,access_token' },
+    token: ctx.token,
+    propertyId,
+  });
+  if (!res.ok) return undefined;
+  return (res.data.data ?? []).find((a) => a.id === ctx.pageId)?.access_token;
+}
+
+/** Keep only numeric metric values (some metrics return breakdown objects we ignore here). */
+function parsePageInsights(resp: PageInsightsResponse): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const m of resp.data ?? []) {
+    const last = m.values?.[m.values.length - 1]?.value;
+    if (typeof last === 'number') out[m.name] = last;
+  }
+  return out;
+}
+
+/**
+ * Read the Facebook page's brand health for a property. Never throws; returns
+ * `{ok:false,error}` on an unconfigured property, a missing page, or a profile
+ * read failure. A missing page TOKEN (insights) is non-fatal — the result comes
+ * back with `canReadInsights:false` and profile data intact.
+ */
+export async function getPageHealth(propertyId: string): Promise<GraphResult<PageHealth>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('getPageHealth: no ad context for property', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+  if (!ctx.pageId) {
+    logger.warn('getPageHealth: no page configured for property', { propertyId });
+    return { ok: false, error: 'no-page-configured' };
+  }
+
+  const profileRes = await metaGraph<PageProfileResponse>(ctx.pageId, {
+    method: 'GET',
+    params: {
+      fields:
+        'id,name,username,link,followers_count,fan_count,is_published,talking_about_count,category,website,verification_status',
+    },
+    token: ctx.token,
+    propertyId,
+  });
+  if (!profileRes.ok) return profileRes;
+  const p = profileRes.data;
+
+  // Aggregate insights need a page token (ANALYZE task) — non-fatal if absent.
+  let insights28d: Record<string, number> = {};
+  let canReadInsights = false;
+  const pageToken = await derivePageToken(ctx, propertyId);
+  if (pageToken) {
+    const insRes = await metaGraph<PageInsightsResponse>(`${ctx.pageId}/insights`, {
+      method: 'GET',
+      params: { metric: VALID_PAGE_METRICS.join(','), period: 'days_28' },
+      token: pageToken,
+      propertyId,
+    });
+    if (insRes.ok) {
+      canReadInsights = true;
+      insights28d = parsePageInsights(insRes.data);
+    }
+  }
+
+  const followers = Number(p.followers_count ?? p.fan_count) || 0;
+  const talkingAboutCount = Number(p.talking_about_count) || 0;
+  const websiteUrl = p.website;
+  const websiteIsOtaLink = !!websiteUrl && OTA_HOST.test(websiteUrl);
+  const isPublished = p.is_published !== false;
+  const dormant = talkingAboutCount === 0;
+
+  const warnings: string[] = [];
+  if (websiteIsOtaLink) warnings.push(`page-website-points-to-ota:${websiteUrl}`);
+  if (dormant) warnings.push('page-dormant:talking_about_count=0');
+  if (!isPublished) warnings.push('page-not-published');
+  if (!canReadInsights) warnings.push('page-insights-unreadable:no-page-token-or-analyze-task');
+
+  return {
+    ok: true,
+    data: {
+      pageId: ctx.pageId,
+      name: p.name,
+      username: p.username,
+      link: p.link,
+      followers,
+      isPublished,
+      talkingAboutCount,
+      category: p.category,
+      websiteUrl,
+      websiteIsOtaLink,
+      verificationStatus: p.verification_status,
+      insights28d,
+      canReadInsights,
+      dormant,
+      warnings,
+    },
+  };
+}
+
+/**
+ * Read the ad account's acquisition health for a property — state (incl. the
+ * `spend_cap` backstop), lifetime performance, and campaign counts. Never
+ * throws; returns `{ok:false,error}` on an unconfigured property or an account
+ * read failure. Insights/campaign sub-reads that fail are treated as empty (an
+ * account that never ran legitimately has no rows), not a hard error.
+ */
+export async function getAdAccountHealth(propertyId: string): Promise<GraphResult<AdAccountHealth>> {
+  const ctx = await resolveAdContext(propertyId);
+  if (!ctx) {
+    logger.warn('getAdAccountHealth: no ad context for property', { propertyId });
+    return { ok: false, error: 'no-ad-context' };
+  }
+
+  const accRes = await metaGraph<AccountResponse>(ctx.adAccountId, {
+    method: 'GET',
+    params: { fields: 'id,name,account_status,currency,spend_cap,amount_spent,funding_source_details' },
+    token: ctx.token,
+    propertyId,
+  });
+  if (!accRes.ok) return accRes;
+  const a = accRes.data;
+
+  const insRes = await metaGraph<AccountInsightsResponse>(`${ctx.adAccountId}/insights`, {
+    method: 'GET',
+    params: { level: 'account', date_preset: 'maximum', fields: 'spend,impressions,clicks,ctr,cpc,reach,actions' },
+    token: ctx.token,
+    propertyId,
+  });
+  const row = insRes.ok ? insRes.data.data?.[0] : undefined;
+
+  const campRes = await metaGraph<CampaignsListResponse>(`${ctx.adAccountId}/campaigns`, {
+    method: 'GET',
+    params: { fields: 'id,effective_status', limit: 200 },
+    token: ctx.token,
+    propertyId,
+  });
+  const campaigns = campRes.ok ? campRes.data.data ?? [] : [];
+
+  const hasConversionHistory = !!row?.actions?.some((x) => /purchase/i.test(x.action_type));
+  const spendCapMinor = Number(a.spend_cap) || 0;
+
+  const warnings: string[] = [];
+  if (spendCapMinor <= 0) warnings.push('no-account-spend-limit');
+  if (!hasConversionHistory) warnings.push('no-conversion-optimized-history');
+  if (a.account_status !== 1) warnings.push(`account-not-active:status=${a.account_status ?? 'unknown'}`);
+
+  return {
+    ok: true,
+    data: {
+      adAccountId: ctx.adAccountId,
+      name: a.name,
+      accountStatusActive: a.account_status === 1,
+      currency: a.currency,
+      spendCapMinor,
+      hasSpendLimit: spendCapMinor > 0,
+      amountSpentMinor: Number(a.amount_spent) || 0,
+      funding: a.funding_source_details?.display_string,
+      lifetime: {
+        spend: Number(row?.spend) || 0,
+        impressions: Number(row?.impressions) || 0,
+        clicks: Number(row?.clicks) || 0,
+        ctr: Number(row?.ctr) || 0,
+        cpc: Number(row?.cpc) || 0,
+        reach: Number(row?.reach) || 0,
+      },
+      campaignCount: campaigns.length,
+      activeCampaignCount: campaigns.filter((c) => c.effective_status === 'ACTIVE').length,
+      hasConversionHistory,
+      warnings,
+    },
+  };
+}


### PR DESCRIPTION
Phase 1 of the unified promotion system (see `docs/promotion-system-architecture.md`). Builds the intelligence layer for Meta ads/page alongside the existing WhatsApp arm — one shared analyst/router, twin per-channel planners.

## What's included
- **Docs** — `docs/promotion-system-architecture.md` (the umbrella) + live Meta/page audit (§11 of the infra doc) + ads-intelligence phases (§15-17 of the ad-engine plan).
- **Step 1 — sensors** — read-only `brandHealth` (`getPageHealth`/`getAdAccountHealth`), wired into the analyst pack as a `currentSignals` block (live-only; withheld on backtest; flagged in `dataQuality`).
- **Step 2 — contract** — `Opportunity.instrument` generalized to `'whatsapp' | 'ads' | 'page'` + narrowed subtypes.
- **Step 3 — ad planner** — `AdBrief` + `validateAdPlan` (money/margin gate) + `adPlannerPack` + `adPlanner.generateAdPlan` (Claude → validated AdBrief, bounded repair). The analyst can now route an opportunity to ads and get a sound, reviewable plan.

## Safety — this ships DARK
The new ad-planner code is **not wired into any deployed route** — it's exercised only by CLI harnesses (`scripts/ad-*.ts`), not by any API or admin page. Nothing spends or posts. The only runtime-affecting change to the deployed app is the behavior-neutral `Opportunity` type generalization. `GROWTH_ADS_MODE` remains unset (dry-run).

## Tested
- 16 `validateAdPlan` + 9 `brandHealth` unit tests; full growth/campaign/ads suites green (186).
- `npm run build` passes.
- Live end-to-end: sensors return real page/account facts; the ad planner produces a VALID plan for the Sep 6-17 gap in 1 attempt (22s), grounded in real geo + gallery themes.
- The 60 failing suites in CI (auth/e2e/visual/pricing) are pre-existing and infra-dependent; none touch changed areas.

## Next
Step 4 — ad creative/copy intelligence + the `/admin/ads` framing→generate→review redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)