### PR TITLE
Ads intelligence (step 4): creative copywriter + orchestrator + /admin/ads generate→review

### DIFF
--- a/scripts/ad-creative.ts
+++ b/scripts/ad-creative.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env npx tsx
+/**
+ * ad-creative — run the FULL ad intelligence chain for a window and print it: build the pack once →
+ * ad planner (AdBrief) → ad copywriter (copy + photos). Prototyping/verification only; it PLANS and
+ * WRITES, it never creates or activates anything on Meta. Tokens from Secret Manager.
+ *
+ * Usage:
+ *   npx tsx scripts/ad-creative.ts --start 2026-09-06 --end 2026-09-17 --value 6372 [--occasion "..."] [--property slug]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+const secret = (name: string) =>
+  execSync(`gcloud secrets versions access latest --secret=${name} --project=rentalspot-fzwom`, { encoding: 'utf8' }).trim();
+process.env.META_ADS_TOKENS = secret('META_ADS_TOKENS');
+process.env.ANTHROPIC_API_KEY = secret('ANTHROPIC_API_KEY');
+
+import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
+import { generateAdPlan } from '@/services/growth/adPlanner';
+import { generateAdCreative } from '@/services/growth/adCopywriter';
+import type { AdOpportunity } from '@/lib/growth/contracts';
+
+const arg = (n: string, d?: string): string | undefined => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? process.argv[i + 1] : d;
+};
+
+const start = arg('start');
+const end = arg('end');
+if (!start || !end) {
+  console.error('required: --start YYYY-MM-DD --end YYYY-MM-DD [--value RON] [--occasion "..."] [--property slug]');
+  process.exit(2);
+}
+const property = arg('property', 'prahova-mountain-chalet')!;
+const value = arg('value');
+const occasionName = arg('occasion');
+
+const nights = Math.round((Date.parse(end) - Date.parse(start)) / 86400000);
+const daysOut = Math.max(0, Math.round((Date.parse(start) - Date.now()) / 86400000));
+
+const opportunity: AdOpportunity = {
+  id: `adhoc-${start}-${end}`,
+  propertyId: property,
+  source: 'gap',
+  window: { start, end, nights },
+  daysOut,
+  occasion: occasionName ? { name: occasionName, type: 'ad-hoc', startDate: start, endDate: end } : null,
+  valueAtRisk: value ? Number(value) : null,
+  instrument: 'ads',
+  rationale: 'ad-hoc creative (CLI)',
+};
+
+const ron = (minor: number) => `${(minor / 100).toFixed(2)} RON`;
+const short = (p: string) => p.split('/').pop();
+
+(async () => {
+  const t0 = Date.now();
+  const pack = await buildAdPlannerPack(opportunity);
+  const plan = await generateAdPlan(opportunity, { pack });
+  console.log(`\n=== PLAN — ${plan.ok ? 'VALID' : 'REJECTED'} (${plan.attempts} attempt(s)) ===`);
+  const b = plan.brief;
+  if (!plan.ok || !b || !b.act) {
+    console.log(b ? `act:${b.act} · ${b.rationale}` : `errors: ${plan.errors.join(' · ')}`);
+    process.exit(plan.ok ? 0 : 1);
+  }
+  console.log(`cities: ${b.targeting.cities.map((c) => `${c.name} r${c.radius}km`).join(', ')}`);
+  console.log(`budget: ${ron(b.dailyBudgetMinor)}/day · end ${b.endTime.slice(0, 10)}`);
+
+  const creative = await generateAdCreative(b, pack.assets);
+  const secs = Math.round((Date.now() - t0) / 1000);
+  console.log(`\n=== CREATIVE — ${creative.ok ? 'VALID' : 'REJECTED'} (${creative.attempts} attempt(s), ${secs}s total) ===`);
+  const c = creative.creative;
+  if (c) {
+    c.copy.forEach((v, i) => {
+      console.log(`\n[${i + 1}] (${v.cta})${v.headline ? `  «${v.headline}»` : ''}`);
+      console.log(`    ${v.primary}`);
+    });
+    console.log(`\nphotos (${c.assetPaths.length}): ${c.assetPaths.map(short).join(', ')}`);
+    if (c.notes) console.log(`notes: ${c.notes}`);
+  }
+  if (creative.warnings.length) console.log(`\n⚠ ${creative.warnings.join(' · ')}`);
+  if (!creative.ok) console.log(`\n✖ ${creative.errors.join(' · ')}`);
+  process.exit(creative.ok ? 0 : 1);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ad-propose.ts
+++ b/scripts/ad-propose.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env npx tsx
+/**
+ * ad-propose — run the FULL ad proposal pipeline for a window: opportunity → plan → creative →
+ * composeAndCreateAd, producing a real PAUSED draft (zero spend), then SELF-CLEAN (delete the Meta
+ * objects + the adCampaigns doc) unless --keep. This validates the whole intelligence→draft chain
+ * end to end. Nothing ever activates or spends — creation is PAUSED; activation is a separate gate.
+ *
+ * GROWTH_ADS_ENABLED is set in-process (compose's master switch); GROWTH_ADS_MODE stays unset, so
+ * even if a draft were activated it would be a no-op dry-run. Tokens from Secret Manager.
+ *
+ * Usage:
+ *   npx tsx scripts/ad-propose.ts --start 2026-09-06 --end 2026-09-17 --value 6372 [--occasion "..."] [--keep]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+process.env.GROWTH_ADS_ENABLED = 'true'; // enable compose (zero-spend creation); MODE stays unset
+const secret = (name: string) =>
+  execSync(`gcloud secrets versions access latest --secret=${name} --project=rentalspot-fzwom`, { encoding: 'utf8' }).trim();
+process.env.META_ADS_TOKENS = secret('META_ADS_TOKENS');
+process.env.ANTHROPIC_API_KEY = secret('ANTHROPIC_API_KEY');
+
+import { proposeAd } from '@/services/growth/adProposal';
+import { deleteResource } from '@/services/growth/metaAds/client';
+import { resolveAdContext } from '@/services/growth/metaAds/adContext';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import type { AdOpportunity } from '@/lib/growth/contracts';
+
+const arg = (n: string, d?: string): string | undefined => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? process.argv[i + 1] : d;
+};
+const start = arg('start');
+const end = arg('end');
+if (!start || !end) {
+  console.error('required: --start YYYY-MM-DD --end YYYY-MM-DD [--value RON] [--occasion "..."] [--property slug] [--keep]');
+  process.exit(2);
+}
+const property = arg('property', 'prahova-mountain-chalet')!;
+const value = arg('value');
+const occasionName = arg('occasion');
+const keep = process.argv.includes('--keep');
+
+const nights = Math.round((Date.parse(end) - Date.parse(start)) / 86400000);
+const daysOut = Math.max(0, Math.round((Date.parse(start) - Date.now()) / 86400000));
+const opportunity: AdOpportunity = {
+  id: `adhoc-${start}-${end}`,
+  propertyId: property,
+  source: 'gap',
+  window: { start, end, nights },
+  daysOut,
+  occasion: occasionName ? { name: occasionName, type: 'ad-hoc', startDate: start, endDate: end } : null,
+  valueAtRisk: value ? Number(value) : null,
+  instrument: 'ads',
+  rationale: 'ad-hoc proposal (CLI, self-cleaning)',
+};
+
+(async () => {
+  const res = await proposeAd(opportunity);
+  console.log(`\n=== proposeAd — ${res.ok ? (res.declined ? 'DECLINED (no draft)' : 'DRAFT CREATED') : `FAILED at ${res.stage}`} ===`);
+  if (res.brief) console.log(`plan: act=${res.brief.act} · ${res.brief.targeting.cities.map((c) => c.name).join(', ')} · ${(res.brief.dailyBudgetMinor / 100).toFixed(0)} RON/day`);
+  if (res.creative) console.log(`creative: ${res.creative.copy.length} copy variants · ${res.creative.assetPaths.length} photos`);
+  if (res.errors.length) console.log(`errors: ${res.errors.join(' · ')}`);
+  if (res.draft) {
+    console.log(`draft ids: adCampaign=${res.draft.adCampaignId} campaign=${res.draft.metaCampaignId} adset=${res.draft.metaAdSetId} ad=${res.draft.metaAdId} creative=${res.draft.creativeId}`);
+
+    if (keep) {
+      console.log('\n--keep: PAUSED draft left in place for inspection (remember to delete it in Ads Manager / Firestore).');
+    } else {
+      console.log('\nself-cleaning (zero spend was possible — everything was PAUSED)…');
+      const ctx = await resolveAdContext(property);
+      if (ctx) {
+        // NB: a Dynamic-Creative AD cannot be deleted directly (Meta err 100/1340029) — deleting the
+        // parent ad set (and the campaign) CASCADES to the ad. Creatives are account-level, deleted
+        // separately. So: adSet → campaign (cascade the ad) → creative.
+        for (const id of [res.draft.metaAdSetId, res.draft.metaCampaignId, res.draft.creativeId]) {
+          const d = await deleteResource(id, ctx.token, property);
+          console.log(`  delete ${id}: ${d.ok ? 'ok' : d.error}`);
+        }
+      }
+      const db = await getAdminDb();
+      await db.collection('adCampaigns').doc(res.draft.adCampaignId).delete();
+      console.log(`  deleted adCampaigns/${res.draft.adCampaignId}`);
+    }
+  }
+  process.exit(res.ok ? 0 : 1);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/admin/ads/_components/ad-detail-panel.tsx
+++ b/src/app/admin/ads/_components/ad-detail-panel.tsx
@@ -28,9 +28,76 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, ExternalLink, RefreshCw, Ban, ShieldCheck, Rocket } from 'lucide-react';
+import Image from 'next/image';
+import { Loader2, ExternalLink, RefreshCw, Ban, ShieldCheck, Rocket, Sparkles, Trash2, MapPin } from 'lucide-react';
 import type { AdCampaign } from '@/types';
-import { approveAdAction, activateAdAction, pauseAdAction, refreshAdInsightsAction } from '../actions';
+import { approveAdAction, activateAdAction, pauseAdAction, refreshAdInsightsAction, discardAdDraftAction } from '../actions';
+
+/** The AI proposal (copy + photos + geo + rationale) shown for in-console review when a draft was drafted by the Opportunity Engine. */
+function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal']> }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-muted-foreground" />
+          Proposal
+          <Badge variant="secondary" className="text-[10px]">Opportunity Engine</Badge>
+        </CardTitle>
+        {proposal.occasion && (
+          <CardDescription>
+            {proposal.occasion.name ? `${proposal.occasion.name} · ` : ''}
+            {proposal.occasion.start} → {proposal.occasion.end} ({proposal.occasion.nights}n)
+          </CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {proposal.cities.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <MapPin className="h-3.5 w-3.5 text-muted-foreground" />
+            {proposal.cities.map((c) => (
+              <Badge key={c.name} variant="outline" className="text-[11px]">
+                {c.name} · {c.radius}km
+              </Badge>
+            ))}
+          </div>
+        )}
+        {proposal.photos.length > 0 && (
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+            {proposal.photos.map((p) => (
+              <div key={p.storagePath} className="relative aspect-square overflow-hidden rounded-md border">
+                {p.url ? (
+                  <Image src={p.url} alt="" fill className="object-cover" sizes="120px" />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-[10px] text-muted-foreground">no preview</div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground">Copy variants ({proposal.copy.length})</p>
+          {proposal.copy.map((v, i) => (
+            <div key={i} className="rounded-md border p-2">
+              {v.headline && <p className="text-xs font-medium">{v.headline}</p>}
+              <p className="text-sm">{v.primary}</p>
+              <p className="mt-1 text-[10px] uppercase text-muted-foreground">{v.cta}</p>
+            </div>
+          ))}
+        </div>
+        {proposal.creativeBrief && (
+          <details className="rounded-md border bg-muted/30 p-2">
+            <summary className="cursor-pointer text-xs font-medium text-muted-foreground">Creative brief &amp; rationale</summary>
+            <p className="mt-2 text-xs text-muted-foreground">{proposal.creativeBrief}</p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">Why: </span>
+              {proposal.rationale}
+            </p>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   draft: 'outline',
@@ -64,7 +131,9 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
   const [activating, startActivate] = useTransition();
   const [pausing, startPause] = useTransition();
   const [refreshing, startRefresh] = useTransition();
+  const [discarding, startDiscard] = useTransition();
   const [approveOpen, setApproveOpen] = useState(false);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
   const [spendCapRon, setSpendCapRon] = useState('50');
 
   const days = daysToEndTime(campaign.endTime);
@@ -115,6 +184,18 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
     });
   };
 
+  const discard = () => {
+    startDiscard(async () => {
+      const res = await discardAdDraftAction(campaign.id);
+      if (res.ok) {
+        toast({ title: 'Draft discarded' });
+        router.push('/admin/ads');
+      } else {
+        toast({ title: 'Could not discard', description: res.error, variant: 'destructive' });
+      }
+    });
+  };
+
   const refresh = () => {
     startRefresh(async () => {
       const res = await refreshAdInsightsAction(campaign.id);
@@ -134,6 +215,8 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
 
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+      <div className="space-y-6">
+      {campaign.proposal && <ProposalCard proposal={campaign.proposal} />}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -197,6 +280,7 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
           </Button>
         </CardFooter>
       </Card>
+      </div>
 
       <Card className="h-fit">
         <CardHeader>
@@ -270,6 +354,23 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
             {pausing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Ban className="mr-1 h-4 w-4" />}
             Pause
           </Button>
+
+          {campaign.status === 'draft' &&
+            (confirmDiscard ? (
+              <div className="flex items-center justify-center gap-2 text-xs">
+                <span className="text-muted-foreground">Delete this draft?</span>
+                <Button size="sm" variant="destructive" className="h-7" onClick={discard} disabled={discarding}>
+                  {discarding ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Yes, discard'}
+                </Button>
+                <Button size="sm" variant="ghost" className="h-7" onClick={() => setConfirmDiscard(false)} disabled={discarding}>
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button className="w-full" variant="ghost" size="sm" onClick={() => setConfirmDiscard(true)}>
+                <Trash2 className="mr-1 h-4 w-4" /> Discard draft
+              </Button>
+            ))}
         </CardContent>
       </Card>
     </div>

--- a/src/app/admin/ads/_components/generate-form.tsx
+++ b/src/app/admin/ads/_components/generate-form.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+/**
+ * Generate an ad from an OPPORTUNITY (framing → generate). The operator gives the window + occasion;
+ * the intelligence chain (plan → creative) drafts a PAUSED, zero-spend ad, and the next screen is
+ * the review. This is the ads-side analog of the campaigns framing/proposal flow — the operator
+ * shapes the substance (which window, which occasion), the AI does the geo + budget + copy + photos.
+ */
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Sparkles, AlertCircle } from 'lucide-react';
+import { generateAdProposalAction } from '../actions';
+
+export function GenerateForm({ propertyId }: { propertyId: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [pending, start] = useTransition();
+
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [occasion, setOccasion] = useState('');
+  const [value, setValue] = useState('');
+  const [declined, setDeclined] = useState<string | null>(null);
+
+  const generate = () => {
+    if (!startDate || !endDate) {
+      toast({ title: 'Pick the window', description: 'Both start and end dates are required.', variant: 'destructive' });
+      return;
+    }
+    if (Date.parse(endDate) <= Date.parse(startDate)) {
+      toast({ title: 'Check the dates', description: 'End must be after start.', variant: 'destructive' });
+      return;
+    }
+    setDeclined(null);
+    start(async () => {
+      const res = await generateAdProposalAction({
+        propertyId,
+        start: startDate,
+        end: endDate,
+        occasion: occasion.trim() || undefined,
+        valueAtRisk: value ? Number(value) : undefined,
+      });
+      if (!res.ok) {
+        toast({ title: 'Could not generate', description: `${res.stage ? `[${res.stage}] ` : ''}${res.error}`, variant: 'destructive' });
+        return;
+      }
+      if ('declined' in res) {
+        setDeclined(res.rationale);
+        return;
+      }
+      toast({ title: 'Draft created', description: 'PAUSED on Meta, zero spend. Review and approve it next.' });
+      router.push(`/admin/ads/${res.adCampaignId}`);
+    });
+  };
+
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-muted-foreground" />
+          Generate from an opportunity
+        </CardTitle>
+        <CardDescription>
+          Give the window and the occasion. The engine plans the geo + budget, writes the copy, and picks photos from
+          this property&apos;s gallery — then drops a PAUSED, zero-spend draft you review and approve. Nothing spends.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor="start">Window start</Label>
+            <Input id="start" type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="end">Window end</Label>
+            <Input id="end" type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="occasion">Occasion (optional but strong)</Label>
+          <Textarea
+            id="occasion"
+            value={occasion}
+            onChange={(e) => setOccasion(e.target.value)}
+            rows={2}
+            placeholder="e.g. Autumn school break — a family week in the mountains before winter"
+          />
+          <p className="text-xs text-muted-foreground">
+            A real reason to come now. With no occasion the planner may decline — an ad with nothing to say wastes spend.
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="value">Revenue at risk (RON, optional)</Label>
+          <Input id="value" type="number" min={0} step="1" value={value} onChange={(e) => setValue(e.target.value)} placeholder="e.g. 6000" />
+          <p className="text-xs text-muted-foreground">Nights × rate for this window, if known — it caps the spend envelope.</p>
+        </div>
+
+        {declined && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+            <p className="mb-1 flex items-center gap-1 font-medium">
+              <AlertCircle className="h-4 w-4" /> The planner declined — no draft was created
+            </p>
+            <p className="text-amber-800">{declined}</p>
+          </div>
+        )}
+      </CardContent>
+      <CardFooter>
+        <Button onClick={generate} disabled={pending}>
+          {pending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Sparkles className="mr-2 h-4 w-4" />}
+          Generate draft
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -43,6 +43,9 @@ import { pauseCampaign, type PauseResult } from '@/services/growth/metaAds/lifec
 import { getInsights, getEffectiveStatus } from '@/services/growth/metaAds/insights';
 import { resolveAdContext } from '@/services/growth/metaAds/adContext';
 import { searchCities, type CityMatch } from '@/services/growth/metaAds/geo';
+import { deleteResource } from '@/services/growth/metaAds/client';
+import { proposeAd } from '@/services/growth/adProposal';
+import type { AdOpportunity } from '@/lib/growth/contracts';
 
 const logger = loggers.ads;
 
@@ -460,6 +463,144 @@ export async function refreshAdInsightsAction(adCampaignId: string): Promise<
     return { ok: true, insights, effectiveStatus };
   } catch (error) {
     logger.error('refreshAdInsightsAction failed', error as Error, { adCampaignId });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Opportunity-Engine: generate a PAUSED ad DRAFT from a window (framing → generate)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an AI ad proposal for an opportunity window and land it as a PAUSED, reviewable draft
+ * (promotion-system-architecture.md §4.2). Super-admin gate; the whole intelligence chain runs in
+ * `proposeAd` (plan → creative → composeAndCreateAd, zero spend). On a created draft we ALSO persist
+ * a `proposal` blob (copy + photo URLs + cities + rationale) onto the doc so the detail page can
+ * review it in-console. A planner DECLINE is a valid, non-error outcome (no draft). No money logic
+ * here — spend cap + activation stay the existing approve/activate gates.
+ */
+export async function generateAdProposalAction(input: {
+  propertyId: string;
+  start: string;
+  end: string;
+  occasion?: string;
+  valueAtRisk?: number;
+}): Promise<
+  | { ok: true; adCampaignId: string }
+  | { ok: true; declined: true; rationale: string }
+  | { ok: false; error: string; stage?: string }
+> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+
+  try {
+    const nights = Math.max(1, Math.round((Date.parse(input.end) - Date.parse(input.start)) / 86400000));
+    const daysOut = Math.max(0, Math.round((Date.parse(input.start) - Date.now()) / 86400000));
+    const opportunity: AdOpportunity = {
+      id: `oe-${input.propertyId}-${input.start}-${input.end}`,
+      propertyId: input.propertyId,
+      source: 'gap',
+      window: { start: input.start, end: input.end, nights },
+      daysOut,
+      occasion: input.occasion?.trim()
+        ? { name: input.occasion.trim(), type: 'ad-hoc', startDate: input.start, endDate: input.end }
+        : null,
+      valueAtRisk: input.valueAtRisk ?? null,
+      instrument: 'ads',
+      rationale: 'operator-initiated (console)',
+    };
+
+    logger.info('generateAdProposalAction: generating', { actor, propertyId: input.propertyId, window: `${input.start}..${input.end}` });
+    const res = await proposeAd(opportunity);
+
+    if (!res.ok) return { ok: false, error: res.errors.join('; ') || 'proposal-failed', stage: res.stage };
+    if (res.declined || !res.draft || !res.brief || !res.creative) {
+      return { ok: true, declined: true, rationale: res.brief?.rationale ?? 'The planner declined to run an ad for this window.' };
+    }
+
+    // Persist the reviewable proposal blob (resolve photo URLs from the property gallery).
+    const db = await getAdminDb();
+    const propDoc = await db.collection('properties').doc(input.propertyId).get();
+    const images = (propDoc.data()?.images ?? []) as PropertyImage[];
+    const urlByPath = new Map(images.filter((i) => i.storagePath).map((i) => [i.storagePath!, i.thumbnailUrl || i.url]));
+    const photos = res.creative.assetPaths.map((storagePath) => ({ storagePath, url: urlByPath.get(storagePath) ?? '' }));
+
+    await db.collection('adCampaigns').doc(res.draft.adCampaignId).update({
+      proposal: {
+        source: 'opportunity-engine',
+        occasion: {
+          name: res.brief.opportunity.occasion?.name ?? null,
+          start: res.brief.opportunity.window.start,
+          end: res.brief.opportunity.window.end,
+          nights: res.brief.opportunity.window.nights,
+        },
+        copy: res.creative.copy,
+        photos,
+        cities: res.brief.targeting.cities.map((c) => ({ name: c.name, radius: c.radius })),
+        creativeBrief: res.brief.creativeBrief,
+        rationale: res.brief.rationale,
+      },
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    logger.info('generateAdProposalAction: draft created', { actor, adCampaignId: res.draft.adCampaignId });
+    revalidatePath('/admin/ads');
+    return { ok: true, adCampaignId: res.draft.adCampaignId };
+  } catch (error) {
+    logger.error('generateAdProposalAction failed', error as Error, { propertyId: input.propertyId });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+/**
+ * Discard a draft ad — delete its Meta chain (ad set + campaign cascade the ad; creative is
+ * account-level) and the Firestore doc. Only a `draft` or `failed` campaign may be discarded (never
+ * an approved/active one — pause that first). Super-admin gate. A Dynamic-Creative ad can't be
+ * deleted directly (Meta err 100/1340029), so we delete the ad set + campaign (which cascade the ad)
+ * + the creative.
+ */
+export async function discardAdDraftAction(adCampaignId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('adCampaigns').doc(adCampaignId);
+    const snap = await ref.get();
+    if (!snap.exists) return { ok: false, error: 'not-found' };
+    const doc = snap.data() as AdCampaignDocData;
+    if (doc.status !== 'draft' && doc.status !== 'failed') {
+      return { ok: false, error: `cannot-discard:${doc.status ?? 'unknown'} (pause an active/approved ad first)` };
+    }
+
+    // Best-effort delete of the Meta objects (never blocks the doc removal).
+    if (doc.propertyId && doc.metaCampaignId) {
+      const ctx = await resolveAdContext(doc.propertyId);
+      if (ctx) {
+        const ids = [...(doc.metaAdSetIds ?? []), doc.metaCampaignId, ...(doc.creativeRef ? [doc.creativeRef] : [])];
+        for (const id of ids) {
+          const del = await deleteResource(id, ctx.token, doc.propertyId);
+          if (!del.ok) logger.warn('discardAdDraftAction: Meta delete failed (continuing)', { adCampaignId, id, error: del.error });
+        }
+      }
+    }
+
+    await ref.delete();
+    logger.info('discardAdDraftAction: discarded', { actor, adCampaignId });
+    revalidatePath('/admin/ads');
+    return { ok: true };
+  } catch (error) {
+    logger.error('discardAdDraftAction failed', error as Error, { adCampaignId });
     return { ok: false, error: 'internal-error' };
   }
 }

--- a/src/app/admin/ads/generate/page.tsx
+++ b/src/app/admin/ads/generate/page.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import { AdminPage } from '@/components/admin';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { GenerateForm } from '../_components/generate-form';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function GenerateAdPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+
+  return (
+    <AdminPage
+      title="Generate ad"
+      description="Draft a PAUSED, zero-spend ad from an opportunity window — the engine plans, writes, and picks photos; you review and approve."
+    >
+      <PropertyUrlSync />
+      <div className="mb-4">
+        <Link href={`/admin/ads?propertyId=${property}`}>
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="mr-1 h-4 w-4" /> Back to ads
+          </Button>
+        </Link>
+      </div>
+      <GenerateForm propertyId={property} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/ads/page.tsx
+++ b/src/app/admin/ads/page.tsx
@@ -3,7 +3,7 @@ import { AdminPage, EmptyState } from '@/components/admin';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
-import { Target, Plus } from 'lucide-react';
+import { Target, Plus, Sparkles } from 'lucide-react';
 import { fetchAdCampaignsAction } from './actions';
 import { AdTable } from './_components/ad-table';
 
@@ -25,12 +25,20 @@ export default async function AdsPage({
       title="Ads"
       description="Compose, approve, and activate Meta (Facebook + Instagram) ads from a property photo. Dark-launched — composing always creates a zero-spend PAUSED draft; activation only spends once both engine switches are on."
       actions={
-        <Button asChild>
-          <Link href={`/admin/ads/new?propertyId=${property}`}>
-            <Plus className="mr-1 h-4 w-4" />
-            New ad
-          </Link>
-        </Button>
+        <div className="flex gap-2">
+          <Button asChild>
+            <Link href={`/admin/ads/generate?propertyId=${property}`}>
+              <Sparkles className="mr-1 h-4 w-4" />
+              Generate from opportunity
+            </Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/admin/ads/new?propertyId=${property}`}>
+              <Plus className="mr-1 h-4 w-4" />
+              New ad
+            </Link>
+          </Button>
+        </div>
       }
     >
       <PropertyUrlSync />

--- a/src/lib/growth/__tests__/validateAdCreative.test.ts
+++ b/src/lib/growth/__tests__/validateAdCreative.test.ts
@@ -1,0 +1,96 @@
+/** @jest-environment node */
+
+import { validateAdCreative, type AdCreativePackForValidation } from '../validateAdCreative';
+import type { CopyVariant } from '@/types';
+
+const PACK: AdCreativePackForValidation = {
+  propertyId: 'prahova-mountain-chalet',
+  assetPaths: [
+    'properties/prahova-mountain-chalet/autumn-chalet.jpg',
+    'properties/prahova-mountain-chalet/fireplace.jpg',
+    'properties/prahova-mountain-chalet/valley-view.jpg',
+  ],
+};
+
+const cv = (primary: string, headline?: string, cta: CopyVariant['cta'] = 'learn_more'): CopyVariant => ({ primary, headline, cta });
+
+const OK = {
+  copy: [
+    cv('O evadare linistita in Valea Prahovei, printre paduri aurii de toamna.', 'Cabana in munte'),
+    cv('Weekend la munte, departe de oras — foc in semineu si liniste.', 'Toamna la cabana'),
+  ],
+  assetPaths: ['properties/prahova-mountain-chalet/autumn-chalet.jpg', 'properties/prahova-mountain-chalet/fireplace.jpg'],
+};
+
+describe('validateAdCreative — happy path', () => {
+  it('accepts well-formed copy + real, owned, distinct photos', () => {
+    const res = validateAdCreative(PACK, OK);
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+  });
+});
+
+describe('validateAdCreative — copy', () => {
+  it('rejects zero copy variants', () => {
+    const res = validateAdCreative(PACK, { ...OK, copy: [] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('no copy variant'))).toBe(true);
+  });
+  it('rejects too many copy variants', () => {
+    const res = validateAdCreative(PACK, { ...OK, copy: Array.from({ length: 6 }, (_, i) => cv(`Un text de reclama numarul ${i} destul de lung.`)) });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('too many copy variants'))).toBe(true);
+  });
+  it('rejects an empty and a too-short primary', () => {
+    expect(validateAdCreative(PACK, { ...OK, copy: [cv('')] }).errors.some((e) => e.includes('empty primary'))).toBe(true);
+    expect(validateAdCreative(PACK, { ...OK, copy: [cv('prea scurt')] }).errors.some((e) => e.includes('too short'))).toBe(true);
+  });
+  it('warns (not errors) on a primary over the soft "See more" length', () => {
+    const long = 'x'.repeat(200);
+    const res = validateAdCreative(PACK, { ...OK, copy: [cv(long, 'ok')] });
+    expect(res.ok).toBe(true);
+    expect(res.warnings.some((w) => w.includes('See more'))).toBe(true);
+  });
+  it('errors on a headline past the hard max', () => {
+    const res = validateAdCreative(PACK, { ...OK, copy: [cv('Un text de reclama valid si suficient de lung.', 'x'.repeat(41))] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('headline too long'))).toBe(true);
+  });
+  it('rejects an unknown CTA', () => {
+    const res = validateAdCreative(PACK, { ...OK, copy: [cv('Un text de reclama valid si suficient de lung.', 'ok', 'sign_up' as never)] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('unknown cta'))).toBe(true);
+  });
+  it('rejects duplicate primaries and duplicate headlines (Meta asset_feed_spec dedup)', () => {
+    const dupP = validateAdCreative(PACK, { ...OK, copy: [cv('Acelasi text de reclama repetat aici.'), cv('Acelasi text de reclama repetat aici.')] });
+    expect(dupP.errors.some((e) => e.includes('duplicate primary'))).toBe(true);
+    const dupH = validateAdCreative(PACK, {
+      ...OK,
+      copy: [cv('Primul text de reclama distinct.', 'Acelasi titlu'), cv('Al doilea text de reclama distinct.', 'Acelasi titlu')],
+    });
+    expect(dupH.errors.some((e) => e.includes('duplicate headline'))).toBe(true);
+  });
+});
+
+describe('validateAdCreative — photos (grounding)', () => {
+  it('rejects zero photos', () => {
+    expect(validateAdCreative(PACK, { ...OK, assetPaths: [] }).errors.some((e) => e.includes('no photo'))).toBe(true);
+  });
+  it('rejects a photo not in the available assets (cannot invent a photo)', () => {
+    const res = validateAdCreative(PACK, { ...OK, assetPaths: ['properties/prahova-mountain-chalet/does-not-exist.jpg'] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('not in the available gallery assets'))).toBe(true);
+  });
+  it('rejects a photo owned by a different property', () => {
+    const pack = { ...PACK, assetPaths: [...PACK.assetPaths, 'properties/other-property/pool.jpg'] };
+    const res = validateAdCreative(pack, { ...OK, assetPaths: ['properties/other-property/pool.jpg'] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('not owned by'))).toBe(true);
+  });
+  it('rejects the same photo selected twice', () => {
+    const p = 'properties/prahova-mountain-chalet/autumn-chalet.jpg';
+    const res = validateAdCreative(PACK, { ...OK, assetPaths: [p, p] });
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('more than once'))).toBe(true);
+  });
+});

--- a/src/lib/growth/validateAdCreative.ts
+++ b/src/lib/growth/validateAdCreative.ts
@@ -1,0 +1,108 @@
+/**
+ * validateAdCreative — the deterministic gate between the ad copywriter (an LLM) and
+ * `composeAndCreateAd`. The creative-stage twin of `validateDrafts`: where that guards a per-guest
+ * WhatsApp message's grounding + voice, this guards an ad's COPY + PHOTO selection before it can
+ * become a PAUSED Meta ad. Its duties (promotion-system-architecture.md §4.2):
+ *
+ *   1. Photo grounding (narrows-never-widens) — every chosen photo must be one of the pack's
+ *      available assets AND owned by this property. This is the ad-side truth anchor: you cannot
+ *      show a pool/sauna that does not exist because you can only pick REAL gallery photos.
+ *   2. Meta shape — 1..MAX_COPY_VARIANTS copy variants, 1..MAX_IMAGES photos, a valid CTA, and copy
+ *      lengths inside Meta's limits (hard errors) / recommendations (warnings, §10).
+ *   3. No duplicates — Meta rejects DUPLICATE values within an `asset_feed_spec` array (err 100/
+ *      1815809, §9f addendum): two copy variants sharing a headline, or the same photo twice, are
+ *      rejected at create time — so reject them here, before the Meta call.
+ *
+ * Pure — no Firestore, no network, no Meta — exhaustively unit-testable and importable by both the
+ * in-app copywriter and any CLI harness. A failure feeds back to the copywriter (bounded repair).
+ */
+import type { CopyVariant } from '@/types';
+
+/** Meta's `asset_feed_spec` ceilings (docs/meta-ads-infrastructure-2026.md §10). */
+const MAX_IMAGES = 10;
+const MAX_COPY_VARIANTS = 5;
+
+/** Copy-length bounds. Hard errors bracket what Meta will accept; soft warnings mirror its "shorter performs better" guidance (§10). */
+const PRIMARY_MIN = 20;
+const PRIMARY_MAX = 500;
+const PRIMARY_SOFT = 150; // primary text past ~150 chars risks the "…See more" cut-off (FB feed)
+const HEADLINE_MAX = 40;
+const HEADLINE_SOFT = 27; // Meta's recommended headline length
+
+const VALID_CTAS = new Set<CopyVariant['cta']>(['learn_more', 'book_now', 'contact_us']);
+
+export interface AdCreativePackForValidation {
+  propertyId: string;
+  /** The gallery storagePaths the copywriter may choose from (from `adPlannerPack.assets`). */
+  assetPaths: string[];
+}
+
+export interface AdCreativeForValidation {
+  copy: CopyVariant[];
+  /** The chosen photo storagePaths — a SUBSET of the pack's assetPaths. */
+  assetPaths: string[];
+}
+
+export interface AdCreativeValidationResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export function validateAdCreative(
+  pack: AdCreativePackForValidation,
+  creative: AdCreativeForValidation
+): AdCreativeValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // ── copy ────────────────────────────────────────────────────────────────
+  const copy = creative.copy ?? [];
+  if (copy.length < 1) errors.push('no copy variant — an ad needs at least one primary text');
+  if (copy.length > MAX_COPY_VARIANTS) errors.push(`too many copy variants (${copy.length} > ${MAX_COPY_VARIANTS})`);
+
+  const primaries: string[] = [];
+  const headlines: string[] = [];
+  copy.forEach((c, i) => {
+    const p = (c.primary ?? '').trim();
+    if (!p) {
+      errors.push(`variant ${i}: empty primary text`);
+    } else {
+      if (p.length < PRIMARY_MIN) errors.push(`variant ${i}: primary too short (${p.length} < ${PRIMARY_MIN})`);
+      else if (p.length > PRIMARY_MAX) errors.push(`variant ${i}: primary too long (${p.length} > ${PRIMARY_MAX})`);
+      else if (p.length > PRIMARY_SOFT) warnings.push(`variant ${i}: primary ${p.length} chars — past ~${PRIMARY_SOFT} risks a "See more" cut-off`);
+      primaries.push(p);
+    }
+    if (c.headline != null && c.headline.trim()) {
+      const h = c.headline.trim();
+      if (h.length > HEADLINE_MAX) errors.push(`variant ${i}: headline too long (${h.length} > ${HEADLINE_MAX})`);
+      else if (h.length > HEADLINE_SOFT) warnings.push(`variant ${i}: headline ${h.length} chars — over Meta's recommended ${HEADLINE_SOFT}`);
+      headlines.push(h);
+    }
+    if (!VALID_CTAS.has(c.cta)) errors.push(`variant ${i}: unknown cta "${c.cta}"`);
+  });
+
+  // Meta rejects duplicate values within an asset_feed_spec array (§9f addendum).
+  const dupPrimary = [...new Set(primaries.filter((p, i) => primaries.indexOf(p) !== i))];
+  if (dupPrimary.length) errors.push(`duplicate primary text — Meta rejects duplicate asset_feed_spec values; make each unique`);
+  const dupHeadline = [...new Set(headlines.filter((h, i) => headlines.indexOf(h) !== i))];
+  if (dupHeadline.length) errors.push(`duplicate headline — Meta rejects duplicate asset_feed_spec values; make each unique (or share ONE headline across all variants)`);
+
+  // ── photos ──────────────────────────────────────────────────────────────
+  const chosen = creative.assetPaths ?? [];
+  if (chosen.length < 1) errors.push('no photo selected — an ad needs at least one image');
+  if (chosen.length > MAX_IMAGES) errors.push(`too many photos (${chosen.length} > ${MAX_IMAGES})`);
+
+  const available = new Set(pack.assetPaths);
+  const offList = chosen.filter((p) => !available.has(p));
+  if (offList.length) errors.push(`selected ${offList.length} photo(s) not in the available gallery assets: ${offList.join(', ')}`);
+
+  const ownPrefix = `properties/${pack.propertyId}/`;
+  const foreign = chosen.filter((p) => !p.startsWith(ownPrefix));
+  if (foreign.length) errors.push(`selected ${foreign.length} photo(s) not owned by ${pack.propertyId}`);
+
+  const dupPhoto = [...new Set(chosen.filter((p, i) => chosen.indexOf(p) !== i))];
+  if (dupPhoto.length) errors.push(`the same photo selected more than once — Meta rejects duplicate images in asset_feed_spec`);
+
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/src/services/growth/adCopywriter.ts
+++ b/src/services/growth/adCopywriter.ts
@@ -1,0 +1,162 @@
+/**
+ * adCopywriter (in-app) — turns an approved ad BRIEF (`AdBrief`) + the property's real gallery into
+ * the actual Meta ad CREATIVE: 1–5 grounded copy variants (primary text + headline + CTA) and a
+ * photo selection. The creative twin of `copywriter.ts`: same shape (forced tool call → validate →
+ * one bounded repair), but it writes PUBLIC brand copy for strangers in the target market, not a
+ * personal message to a known guest.
+ *
+ * Truth is anchored by CODE, not trust: `validateAdCreative` enforces that every chosen photo is a
+ * REAL, owned gallery asset (you cannot show an amenity the property lacks), copy fits Meta's limits,
+ * and nothing is duplicated (Meta rejects duplicate asset_feed_spec values). The LLM owns the voice,
+ * the angle, and which real photos best carry it. The output threads straight into
+ * `composeAndCreateAd` (step 4b): `copy` → `CopyVariant[]`, `assetPaths` → `assetRefs`.
+ *
+ * Server-only. Degrades (throws a clear error) if ANTHROPIC_API_KEY is absent.
+ */
+import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import { validateAdCreative, type AdCreativePackForValidation } from '@/lib/growth/validateAdCreative';
+import type { AdBrief } from '@/lib/growth/contracts';
+import type { CopyVariant } from '@/types';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+/** One gallery asset offered to the copywriter (from `adPlannerPack.assets`). */
+export interface AdCreativeAsset {
+  storagePath: string;
+  alt: string;
+  tags: string[];
+}
+
+const AD_CREATIVE_TOOL = {
+  name: 'emit_ad_creative',
+  description: 'Emit the ad creative: the copy variants and the chosen photos.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      copy: {
+        type: 'array',
+        description: '1-5 DISTINCT copy variants (Meta A/B-tests them). Each: primary text, an optional short headline, and a CTA.',
+        items: {
+          type: 'object',
+          properties: {
+            primary: { type: 'string', description: 'the main ad text (Romanian). Lead with the hook; keep under ~150 chars where you can to avoid a "See more" cut-off.' },
+            headline: { type: 'string', description: 'a short headline, ideally ≤27 chars (Romanian).' },
+            cta: { type: 'string', enum: ['learn_more', 'book_now', 'contact_us'], description: "call-to-action; 'learn_more' is the safe default." },
+          },
+          required: ['primary', 'cta'],
+        },
+      },
+      assetPaths: {
+        type: 'array',
+        description: 'the chosen photos, by EXACT storagePath from the pack\'s assets — 1-6 that carry the brief\'s themes (favor variety: exterior / interior / lifestyle). Never invent a path.',
+        items: { type: 'string' },
+      },
+      notes: { type: 'string', description: 'brief note on the creative choices (optional).' },
+    },
+    required: ['copy', 'assetPaths'],
+  },
+};
+
+const SYSTEM = `You are the ad creative writer for a small Romanian mountain-chalet rental. You turn an
+approved ad BRIEF into the actual Meta ad: the copy and the photo selection. The audience is
+STRANGERS in Romanian feeder cities (not past guests) — write PUBLIC brand copy, warm but not
+personal, in ROMANIAN (the target market).
+
+THE RULES
+1. FOLLOW THE BRIEF. Write to the brief's angle, tone, and occasion (brief.creativeBrief). Lead with
+   a scroll-stopping hook, then the point of the trip. 1-3 short sentences per variant.
+2. GROUND IN REALITY. Choose photos ONLY from the provided assets, by their EXACT storagePath — you
+   cannot show something the property does not have. Never claim an amenity or experience that isn't
+   evident in the brief or the assets (no invented pools, spas, or activities). Match photo THEMES to
+   the copy (use the assets' alt/tags to judge what each shows).
+3. META SHAPE. 1-5 primary-text variants, each DISTINCT (Meta rejects duplicates). Headlines short
+   (≤27 chars ideal); if you reuse a headline, use the SAME one across all variants (never two
+   different-but-duplicate). Pick 1-6 photos with variety (exterior / interior / lifestyle) so
+   Dynamic Creative has range. CTA: 'learn_more' unless 'book_now' clearly fits.
+4. DIRECT BOOKING. The destination is the property's own site — a light nudge to book direct is good,
+   but the ad's job is to earn the click, not to close.
+
+Return the creative by calling emit_ad_creative. Nothing else.`;
+
+export interface GenerateAdCreativeResult {
+  ok: boolean;
+  creative: { copy: CopyVariant[]; assetPaths: string[]; notes?: string } | null;
+  errors: string[];
+  warnings: string[];
+  attempts: number;
+}
+
+interface EmitAdCreativeInput {
+  copy: CopyVariant[];
+  assetPaths: string[];
+  notes?: string;
+}
+
+/**
+ * Generate the ad creative for an approved (acting) brief. Runs the LLM, validates, and on failure
+ * feeds the validator errors back for ONE bounded repair before returning — never ships copy that
+ * fails Meta's shape or a photo that isn't a real owned asset.
+ */
+export async function generateAdCreative(
+  brief: AdBrief,
+  assets: AdCreativeAsset[],
+  opts?: { maxRepairs?: number }
+): Promise<GenerateAdCreativeResult> {
+  if (!brief.act) return { ok: false, creative: null, errors: ['brief is act:false — there is no creative to write for a declined plan'], warnings: [], attempts: 0 };
+  if (!assets.length) return { ok: false, creative: null, errors: ['no gallery assets available to build a creative'], warnings: [], attempts: 0 };
+
+  const client = getAnthropicClient();
+  if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app ad copywriter is unavailable');
+
+  const validationPack: AdCreativePackForValidation = { propertyId: brief.propertyId, assetPaths: assets.map((a) => a.storagePath) };
+  const maxRepairs = opts?.maxRepairs ?? 1;
+
+  const creativePack = {
+    occasion: brief.opportunity.occasion,
+    window: brief.opportunity.window,
+    creativeBrief: brief.creativeBrief,
+    objective: brief.objective,
+    cities: brief.targeting.cities.map((c) => c.name),
+    assets: assets.map((a) => ({ storagePath: a.storagePath, alt: a.alt, tags: a.tags })),
+  };
+  const messages: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
+    { role: 'user', content: `Here is the ad brief + the available gallery assets. Write the creative and call emit_ad_creative.\n\n${JSON.stringify(creativePack)}` },
+  ];
+
+  let creative: GenerateAdCreativeResult['creative'] = null;
+  let lastValidation = { ok: false, errors: [] as string[], warnings: [] as string[] };
+
+  for (let attempt = 1; attempt <= maxRepairs + 1; attempt++) {
+    const resp = await client.messages.create({
+      model: COPYWRITER_MODEL, // Opus 4.8 (no `thinking`: incompatible with forced tool_choice)
+      max_tokens: 2048,
+      system: SYSTEM,
+      tools: [AD_CREATIVE_TOOL],
+      tool_choice: { type: 'tool', name: 'emit_ad_creative' },
+      messages: messages as never,
+    });
+    const toolUse = resp.content.find((b: { type: string }) => b.type === 'tool_use') as { id?: string; input?: EmitAdCreativeInput } | undefined;
+    const input = toolUse?.input;
+    const toolUseId = toolUse?.id;
+
+    creative = input ? { copy: input.copy ?? [], assetPaths: input.assetPaths ?? [], notes: input.notes } : null;
+
+    const v = creative
+      ? validateAdCreative(validationPack, { copy: creative.copy, assetPaths: creative.assetPaths })
+      : { ok: false, errors: ['the model returned no creative'], warnings: [] };
+    lastValidation = { ok: v.ok, errors: v.errors, warnings: v.warnings };
+    logger.info('adCopywriter generateAdCreative attempt', { attempt, variants: creative?.copy.length, photos: creative?.assetPaths.length, ok: v.ok, errors: v.errors.length });
+
+    if (v.ok) return { ok: true, creative, errors: [], warnings: v.warnings, attempts: attempt };
+    if (attempt > maxRepairs) break;
+
+    const repairText =
+      `The creative failed validation. Fix EXACTLY these and re-emit via emit_ad_creative:\n- ${lastValidation.errors.join('\n- ')}\n\n` +
+      `Reminder: photos only by exact storagePath from the assets; 1-5 DISTINCT copy variants; no duplicate headlines (or share one); valid CTA.`;
+    messages.push({ role: 'assistant', content: resp.content });
+    messages.push({ role: 'user', content: toolUseId ? [{ type: 'tool_result', tool_use_id: toolUseId, content: repairText }] : repairText });
+  }
+
+  return { ok: false, creative, errors: lastValidation.errors, warnings: lastValidation.warnings, attempts: maxRepairs + 1 };
+}

--- a/src/services/growth/adPlanner.ts
+++ b/src/services/growth/adPlanner.ts
@@ -13,7 +13,7 @@
  * Server-only. Degrades (throws a clear error) if ANTHROPIC_API_KEY is absent.
  */
 import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
-import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
+import { buildAdPlannerPack, type AdPlannerPack } from '@/lib/growth/adPlannerPack';
 import { validateAdPlan, type AdPlannerPackForValidation } from '@/lib/growth/validateAdPlan';
 import type { AdBrief, AdOpportunity } from '@/lib/growth/contracts';
 import { loggers } from '@/lib/logger';
@@ -108,12 +108,14 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  */
 export async function generateAdPlan(
   opportunity: AdOpportunity,
-  opts?: { asOf?: Date; maxRepairs?: number }
+  opts?: { asOf?: Date; maxRepairs?: number; pack?: AdPlannerPack }
 ): Promise<GenerateAdPlanResult> {
   const client = getAnthropicClient();
   if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app ad planner is unavailable');
 
-  const pack = await buildAdPlannerPack(opportunity, { asOf: opts?.asOf });
+  // Reuse a prebuilt pack when the caller already has one (the orchestrator builds it ONCE and feeds
+  // both the planner and the copywriter) — else build it here.
+  const pack = opts?.pack ?? (await buildAdPlannerPack(opportunity, { asOf: opts?.asOf }));
   const validationPack: AdPlannerPackForValidation = {
     constraints: { maxDailyBudgetMinor: pack.constraints.maxDailyBudgetMinor, maxTotalSpendMinor: pack.constraints.maxTotalSpendMinor },
     targeting: { candidateCityKeys: pack.targeting.candidateCityKeys },

--- a/src/services/growth/adProposal.ts
+++ b/src/services/growth/adProposal.ts
@@ -1,0 +1,102 @@
+/**
+ * adProposal — the orchestrator that turns ONE ads-routed opportunity into a PAUSED, reviewable ad
+ * DRAFT, end to end (promotion-system-architecture.md §4.2). It is the single seam the brain / the
+ * `/admin/ads` "Generate" action / the `/api/growth/ad-proposals` endpoint all call:
+ *
+ *   opportunity → buildAdPlannerPack → generateAdPlan (AdBrief) → generateAdCreative (copy+photos)
+ *              → composeAndCreateAd (PAUSED Meta chain + adCampaigns draft)
+ *
+ * The pack is built ONCE and fed to both LLM stages. Every money/geo/creative guard already lives in
+ * the stages it belongs to (`validateAdPlan`, `validateAdCreative`, `adComposer`'s budget policy) —
+ * this orchestrator only sequences them and assembles the neutral `ComposeAndCreateAdInput`. It does
+ * NOT spend or activate: `composeAndCreateAd` creates everything PAUSED (zero spend), and activation
+ * stays the separate human money-gate (`adExecutionGateway`). A planner DECLINE (act:false) is a
+ * valid, non-error outcome — no draft is created.
+ *
+ * Server-only. Throws only if the LLM is unconfigured (ANTHROPIC_API_KEY absent, via the stages).
+ */
+import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
+import { generateAdPlan } from './adPlanner';
+import { generateAdCreative } from './adCopywriter';
+import { composeAndCreateAd } from './adComposer';
+import type { AdOpportunity, AdBrief } from '@/lib/growth/contracts';
+import type { ComposeAndCreateAdInput, CopyVariant } from '@/types';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+export type AdProposalStage = 'plan' | 'creative' | 'compose';
+
+export interface AdProposalResult {
+  ok: boolean;
+  stage: AdProposalStage;
+  /** The planner chose NOT to act (weak opportunity). `ok:true`, no draft created. */
+  declined: boolean;
+  brief?: AdBrief;
+  creative?: { copy: CopyVariant[]; assetPaths: string[]; notes?: string };
+  /** The created PAUSED draft ids (present only on a full success). */
+  draft?: { adCampaignId: string; metaCampaignId: string; metaAdSetId: string; metaAdId: string; creativeId: string };
+  errors: string[];
+}
+
+/**
+ * Produce a PAUSED ad draft for an opportunity. Returns at the first stage that fails (with its
+ * errors), or `declined:true` if the planner chose not to act, or the created draft ids on success.
+ */
+export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date }): Promise<AdProposalResult> {
+  const pack = await buildAdPlannerPack(opportunity, { asOf: opts?.asOf });
+
+  // 1. Plan (geo + budget + timing + creative brief).
+  const plan = await generateAdPlan(opportunity, { pack });
+  if (!plan.ok || !plan.brief) {
+    logger.warn('proposeAd: planning failed', { opportunityId: opportunity.id, errors: plan.errors });
+    return { ok: false, stage: 'plan', declined: false, errors: plan.errors };
+  }
+  const brief = plan.brief;
+  if (!brief.act) {
+    logger.info('proposeAd: planner declined', { opportunityId: opportunity.id, rationale: brief.rationale });
+    return { ok: true, stage: 'plan', declined: true, brief, errors: [] };
+  }
+
+  // 2. Creative (grounded copy + real photos).
+  const creativeRes = await generateAdCreative(brief, pack.assets);
+  if (!creativeRes.ok || !creativeRes.creative) {
+    logger.warn('proposeAd: creative failed', { opportunityId: opportunity.id, errors: creativeRes.errors });
+    return { ok: false, stage: 'creative', declined: false, brief, errors: creativeRes.errors };
+  }
+  const creative = creativeRes.creative;
+
+  // 3. Compose into a PAUSED Meta chain + adCampaigns draft (zero spend).
+  const input: ComposeAndCreateAdInput = {
+    propertyId: brief.propertyId,
+    assetRefs: creative.assetPaths.map((storagePath) => ({ kind: 'gallery' as const, storagePath })),
+    copy: creative.copy,
+    objective: brief.objective,
+    landingBaseUrl: pack.landing.baseUrl,
+    dailyBudgetMinor: brief.dailyBudgetMinor,
+    targeting: { cities: brief.targeting.cities },
+    endTime: brief.endTime,
+  };
+  const compose = await composeAndCreateAd(input);
+  if (!compose.ok) {
+    logger.warn('proposeAd: compose failed', { opportunityId: opportunity.id, stage: compose.stage, error: compose.error });
+    return { ok: false, stage: 'compose', declined: false, brief, creative, errors: [`${compose.stage}:${compose.error}`] };
+  }
+
+  logger.info('proposeAd: PAUSED draft created', { opportunityId: opportunity.id, adCampaignId: compose.adCampaignId });
+  return {
+    ok: true,
+    stage: 'compose',
+    declined: false,
+    brief,
+    creative,
+    draft: {
+      adCampaignId: compose.adCampaignId,
+      metaCampaignId: compose.metaCampaignId,
+      metaAdSetId: compose.metaAdSetId,
+      metaAdId: compose.metaAdId,
+      creativeId: compose.creativeId,
+    },
+    errors: [],
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -553,6 +553,21 @@ export interface AdCampaign {
     bookings?: number;
     roas?: number;
   };
+  /**
+   * Opportunity-Engine proposal content (promotion-system-architecture.md §4.2) — the AI-drafted
+   * plan + copy + photos, stored so the operator can REVIEW it in the console before approving
+   * (the Meta chain already exists — Model A). Present only on drafts created via the "Generate from
+   * an opportunity" flow (`generateAdProposalAction` / `proposeAd`), absent on manual composes.
+   */
+  proposal?: {
+    source: 'opportunity-engine';
+    occasion?: { name: string | null; start: string; end: string; nights: number } | null;
+    copy: CopyVariant[];
+    photos: Array<{ storagePath: string; url: string }>;
+    cities: Array<{ name: string; radius: number }>;
+    creativeBrief: string;
+    rationale: string;
+  };
   lastSyncedAt?: SerializableTimestamp;
   createdAt?: SerializableTimestamp;
   updatedAt?: SerializableTimestamp;


### PR DESCRIPTION
Step 4 of the promotion system (`docs/promotion-system-architecture.md` §4.2) — turns the ad *planner* (step 3) into a full, operator-drivable ads arm.

## What's included
- **4a — creative intelligence** — `validateAdCreative` (12 tests: photo grounding = chosen photos ⊆ real owned assets, Meta copy shape, no-dup asset_feed_spec) + `adCopywriter.generateAdCreative` (Claude → grounded RO copy + real photo pick, bounded repair).
- **4b — orchestrator** — `adProposal.proposeAd`: opportunity → pack → plan → creative → `composeAndCreateAd` = a PAUSED, reviewable draft, **zero spend**. Pack built once, fed to both LLM stages.
- **4c — operator UI** — `/admin/ads` now has **"Generate from opportunity"** (`/admin/ads/generate` → framing → `proposeAd` → PAUSED draft + persisted `proposal` blob); the detail page shows a **ProposalCard** (copy + photos + cities + rationale) for in-console review → the existing **Approve → Activate** money-gates + a **Discard** action. `AdCampaign.proposal` field added.

## Safety — still DARK
The intelligence code isn't wired into any *automatic* path. An operator must click Generate (creates a PAUSED, zero-spend draft) and then Approve + Activate to spend — and `GROWTH_ADS_MODE` remains unset (activation is a no-op dry-run). Nothing spends on deploy.

## Tested
- 214 growth + ads-console tests pass; `npm run build` passes (all `/admin/ads` routes compile incl. the new `/admin/ads/generate`).
- Live end-to-end (Sep 6-17 gap): full chain creates a real PAUSED draft (5 grounded RO copy variants + 6 real gallery photos) and self-cleans — account confirmed with no orphans.
- UI runtime not browser-verified (needs the app + a super-admin session).

## Deferred / next
- `/api/growth/ad-proposals` brain-seam endpoint (brain not running).
- Step 5 (organic page instrument — needs a token-scope grant) · Step 6 (reconciliation cron + go-live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)