### PR TITLE
Complete the promotion pipeline: ad coherence + reconciliation cron + page-post generator

### DIFF
--- a/scripts/ad-creative.ts
+++ b/scripts/ad-creative.ts
@@ -36,6 +36,7 @@ if (!start || !end) {
 const property = arg('property', 'prahova-mountain-chalet')!;
 const value = arg('value');
 const occasionName = arg('occasion');
+const framing = { goal: arg('goal'), audience: arg('audience') };
 
 const nights = Math.round((Date.parse(end) - Date.parse(start)) / 86400000);
 const daysOut = Math.max(0, Math.round((Date.parse(start) - Date.now()) / 86400000));
@@ -57,7 +58,8 @@ const short = (p: string) => p.split('/').pop();
 
 (async () => {
   const t0 = Date.now();
-  const pack = await buildAdPlannerPack(opportunity);
+  if (framing.goal || framing.audience) console.log(`framing → goal: ${framing.goal ?? '(none)'} · audience: ${framing.audience ?? '(none)'}`);
+  const pack = await buildAdPlannerPack(opportunity, { framing });
   const plan = await generateAdPlan(opportunity, { pack });
   console.log(`\n=== PLAN — ${plan.ok ? 'VALID' : 'REJECTED'} (${plan.attempts} attempt(s)) ===`);
   const b = plan.brief;
@@ -68,7 +70,7 @@ const short = (p: string) => p.split('/').pop();
   console.log(`cities: ${b.targeting.cities.map((c) => `${c.name} r${c.radius}km`).join(', ')}`);
   console.log(`budget: ${ron(b.dailyBudgetMinor)}/day · end ${b.endTime.slice(0, 10)}`);
 
-  const creative = await generateAdCreative(b, pack.assets);
+  const creative = await generateAdCreative(b, pack.assets, { framing });
   const secs = Math.round((Date.now() - t0) / 1000);
   console.log(`\n=== CREATIVE — ${creative.ok ? 'VALID' : 'REJECTED'} (${creative.attempts} attempt(s), ${secs}s total) ===`);
   const c = creative.creative;

--- a/scripts/ad-reconcile.ts
+++ b/scripts/ad-reconcile.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env npx tsx
+/** ad-reconcile — run the reconciliation backstop once and print the result. Read-mostly (refreshes
+ *  our docs' insights/status + flags drift/escapes); never spends. Token from Secret Manager. */
+import * as dotenv from 'dotenv'; import * as path from 'path'; import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+process.env.META_ADS_TOKENS = execSync('gcloud secrets versions access latest --secret=META_ADS_TOKENS --project=rentalspot-fzwom', { encoding: 'utf8' }).trim();
+import { reconcileAdCampaigns } from '@/services/growth/adReconciliation';
+(async () => { console.log(JSON.stringify(await reconcileAdCampaigns(), null, 2)); process.exit(0); })().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/page-post.ts
+++ b/scripts/page-post.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env npx tsx
+/** page-post — draft an organic FB page post (manual-post v1). Prints the caption + chosen photo for
+ *  the operator to post by hand. Never publishes. Tokens from Secret Manager. */
+import * as dotenv from 'dotenv'; import * as path from 'path'; import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+const secret = (n: string) => execSync(`gcloud secrets versions access latest --secret=${n} --project=rentalspot-fzwom`, { encoding: 'utf8' }).trim();
+process.env.ANTHROPIC_API_KEY = secret('ANTHROPIC_API_KEY');
+import { generatePagePost } from '@/services/growth/pagePostWriter';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { serverTranslateContent } from '@/lib/server-language-utils';
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const property = arg('property', 'prahova-mountain-chalet')!;
+const prompt = arg('prompt', 'A warm early-autumn hello from the mountains — golden leaves, quiet mornings, and the fire pit ready for cool evenings.')!;
+const framing = { goal: arg('goal'), audience: arg('audience') };
+(async () => {
+  const db = await getAdminDb();
+  const doc = await db.collection('properties').doc(property).get();
+  const images = ((doc.data()?.images ?? []) as Array<{storagePath?:string; alt?:unknown; tags?:string[]}>)
+    .filter((i) => i.storagePath?.startsWith(`properties/${property}/`))
+    .map((i) => ({ storagePath: i.storagePath as string, alt: serverTranslateContent(i.alt as never, 'en'), tags: i.tags ?? [] }));
+  const res = await generatePagePost({ propertyId: property, prompt, assets: images, framing });
+  console.log(`\n=== page post — ${res.ok ? 'VALID' : 'REJECTED'} (${res.attempts} attempt(s)) ===`);
+  if (res.post) { console.log(`\n${res.post.message}\n\nphoto: ${res.post.assetPath.split('/').pop()}`); if (res.post.notes) console.log(`notes: ${res.post.notes}`); }
+  if (res.warnings.length) console.log(`\n⚠ ${res.warnings.join(' · ')}`);
+  if (!res.ok) console.log(`\n✖ ${res.errors.join(' · ')}`);
+  process.exit(res.ok ? 0 : 1);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/admin/ads/_components/ad-detail-panel.tsx
+++ b/src/app/admin/ads/_components/ad-detail-panel.tsx
@@ -51,6 +51,22 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
         )}
       </CardHeader>
       <CardContent className="space-y-4 text-sm">
+        {(proposal.goal || proposal.audience) && (
+          <div className="space-y-1 rounded-md border bg-muted/30 p-2 text-xs">
+            {proposal.goal && (
+              <p>
+                <span className="font-medium text-foreground">Goal: </span>
+                <span className="text-muted-foreground">{proposal.goal}</span>
+              </p>
+            )}
+            {proposal.audience && (
+              <p>
+                <span className="font-medium text-foreground">Audience: </span>
+                <span className="text-muted-foreground">{proposal.audience}</span>
+              </p>
+            )}
+          </div>
+        )}
         {proposal.cities.length > 0 && (
           <div className="flex flex-wrap items-center gap-1.5">
             <MapPin className="h-3.5 w-3.5 text-muted-foreground" />

--- a/src/app/admin/ads/_components/generate-form.tsx
+++ b/src/app/admin/ads/_components/generate-form.tsx
@@ -25,6 +25,8 @@ export function GenerateForm({ propertyId }: { propertyId: string }) {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [occasion, setOccasion] = useState('');
+  const [goal, setGoal] = useState('');
+  const [audience, setAudience] = useState('');
   const [value, setValue] = useState('');
   const [declined, setDeclined] = useState<string | null>(null);
 
@@ -44,6 +46,8 @@ export function GenerateForm({ propertyId }: { propertyId: string }) {
         start: startDate,
         end: endDate,
         occasion: occasion.trim() || undefined,
+        goal: goal.trim() || undefined,
+        audience: audience.trim() || undefined,
         valueAtRisk: value ? Number(value) : undefined,
       });
       if (!res.ok) {
@@ -94,6 +98,32 @@ export function GenerateForm({ propertyId }: { propertyId: string }) {
           />
           <p className="text-xs text-muted-foreground">
             A real reason to come now. With no occasion the planner may decline — an ad with nothing to say wastes spend.
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="goal">Goal — the outcome you want (optional)</Label>
+          <Textarea
+            id="goal"
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+            rows={2}
+            placeholder="e.g. Fill these nights with high-margin DIRECT bookings — quality over volume"
+          />
+          <p className="text-xs text-muted-foreground">Shapes the whole ad — angle, budget posture, and the call to action.</p>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="audience">Audience — who it&apos;s for (optional)</Label>
+          <Textarea
+            id="audience"
+            value={audience}
+            onChange={(e) => setAudience(e.target.value)}
+            rows={2}
+            placeholder="e.g. Adult couples wanting a quiet off-peak weekend — food, fire, no crowds"
+          />
+          <p className="text-xs text-muted-foreground">
+            Steers the copy angle and which photos are picked (not Meta targeting — Advantage+ handles that).
           </p>
         </div>
 

--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -485,6 +485,8 @@ export async function generateAdProposalAction(input: {
   end: string;
   occasion?: string;
   valueAtRisk?: number;
+  goal?: string;
+  audience?: string;
 }): Promise<
   | { ok: true; adCampaignId: string }
   | { ok: true; declined: true; rationale: string }
@@ -515,8 +517,9 @@ export async function generateAdProposalAction(input: {
       rationale: 'operator-initiated (console)',
     };
 
+    const framing = { goal: input.goal?.trim() || undefined, audience: input.audience?.trim() || undefined };
     logger.info('generateAdProposalAction: generating', { actor, propertyId: input.propertyId, window: `${input.start}..${input.end}` });
-    const res = await proposeAd(opportunity);
+    const res = await proposeAd(opportunity, { framing });
 
     if (!res.ok) return { ok: false, error: res.errors.join('; ') || 'proposal-failed', stage: res.stage };
     if (res.declined || !res.draft || !res.brief || !res.creative) {
@@ -539,6 +542,8 @@ export async function generateAdProposalAction(input: {
           end: res.brief.opportunity.window.end,
           nights: res.brief.opportunity.window.nights,
         },
+        goal: framing.goal ?? null,
+        audience: framing.audience ?? null,
         copy: res.creative.copy,
         photos,
         cities: res.brief.targeting.cities.map((c) => ({ name: c.name, radius: c.radius })),

--- a/src/app/api/cron/ad-reconcile/route.ts
+++ b/src/app/api/cron/ad-reconcile/route.ts
@@ -1,0 +1,32 @@
+/**
+ * ad-reconcile cron — the ads money-path BACKSTOP (promotion-system-architecture.md §8). Pulls
+ * Meta's effective_status + fresh insights for every live-capable adCampaigns doc, updates our
+ * records, and FLAGS drift (a campaign delivering that we think is paused, a REJECTED ad, or an
+ * ACTIVE campaign in the account we don't track). Read-mostly — never activates/pauses/spends.
+ *
+ * Intended cadence: hourly-to-daily via Cloud Scheduler (GET). Cheap and idempotent; a slow cadence
+ * is safe because the account-level spend limit is the hard backstop.
+ *
+ * Auth: Cloud Scheduler header (X-Appengine-Cron) or a Bearer token — same gate as the other crons.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { reconcileAdCampaigns } from '@/services/growth/adReconciliation';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  const cronHeader = request.headers.get('X-Appengine-Cron');
+  if (!cronHeader && !authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const result = await reconcileAdCampaigns();
+    logger.info('ad-reconcile cron ran', { checked: result.checked, updated: result.updated, escapes: result.escapes, flags: result.flags.length });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    logger.error('ad-reconcile cron failed', error as Error);
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/lib/growth/adPlannerPack.ts
+++ b/src/lib/growth/adPlannerPack.ts
@@ -25,7 +25,7 @@ import { serverTranslateContent } from '@/lib/server-language-utils';
 import { getMaxDailyBudgetMinor } from '@/config/growth-ads';
 import { searchCities } from '@/services/growth/metaAds/geo';
 import { getAdAccountHealth, getPageHealth } from '@/services/growth/metaAds/brandHealth';
-import type { AdOpportunity } from '@/lib/growth/contracts';
+import type { AdOpportunity, AdFraming } from '@/lib/growth/contracts';
 import type { CityMatch } from '@/services/growth/metaAds/geo';
 import type { PropertyImage } from '@/types';
 
@@ -62,6 +62,8 @@ function pickBestCity(query: string, matches: CityMatch[]): CityMatch | undefine
 export interface AdPlannerPack {
   meta: { generatedFor: string; asOf: string; generator: string; opportunityId: string };
   opportunity: AdOpportunity;
+  /** The operator's OUTCOME + AUDIENCE steering — shapes the creativeBrief (and thus copy + photos). */
+  framing: { goal: string | null; audience: string | null; note: string };
   constraints: {
     maxDailyBudgetMinor: number;
     /** Spend envelope for this plan, bani = min(revenue-at-risk, absolute cap). Null if value unknown → planner sizes conservatively. */
@@ -92,7 +94,7 @@ export interface AdPlannerPack {
 /** Build the ad-planner fact pack for one ads-routed opportunity. `asOf` defaults to now (UTC date). */
 export async function buildAdPlannerPack(
   opportunity: AdOpportunity,
-  opts?: { asOf?: Date }
+  opts?: { asOf?: Date; framing?: AdFraming }
 ): Promise<AdPlannerPack> {
   const asOf = opts?.asOf ?? new Date();
   const propertyId = opportunity.propertyId;
@@ -156,6 +158,11 @@ export async function buildAdPlannerPack(
   return {
     meta: { generatedFor: propertyId, asOf: asOf.toISOString().slice(0, 10), generator: 'src/lib/growth/adPlannerPack.ts', opportunityId: opportunity.id },
     opportunity,
+    framing: {
+      goal: opts?.framing?.goal?.trim() || null,
+      audience: opts?.framing?.audience?.trim() || null,
+      note: 'The OUTCOME (goal) + AUDIENCE the operator wants for THIS period. Shape EVERYTHING to these together: the creativeBrief\'s angle, the copy the copywriter will write, AND which asset themes to favor must all serve this goal + this audience. Audience steers the copy angle + photo themes (NOT Meta demographics — Advantage+ owns those). If goal/audience are null, infer sensible ones from the occasion + what the property sells, and say what you assumed.',
+    },
     constraints: {
       maxDailyBudgetMinor: getMaxDailyBudgetMinor(),
       maxTotalSpendMinor,

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -135,6 +135,21 @@ export function effectiveDiscountPct(offer: CampaignOffer | undefined | null): n
  * copy qualify the audience. `validateAdPlan` is the money/margin gate (budget ceiling,
  * future end time, geo present, cities ⊆ the pack's candidates — narrows-never-widens).
  */
+/**
+ * The operator (or analyst) FRAMING that shapes an ad to the OUTCOME + AUDIENCE, on top of the
+ * opportunity's period/occasion. Threaded through the planner's `creativeBrief` so the copy AND the
+ * photo choice BOTH bend to it — the connective tissue that makes the ad one coherent thing rather
+ * than disparate stages. `audience` steers the copy ANGLE + photo THEMES (not Meta demographics —
+ * Advantage+ owns those), so a "couples, off-peak, food-and-fire" ad reads and looks different from
+ * a "families, school-break, playground" ad for the very same window.
+ */
+export interface AdFraming {
+  /** What success looks like — e.g. "fill these nights with high-margin DIRECT bookings", not just clicks. */
+  goal?: string;
+  /** Who the ad is for — e.g. "adult couples for a quiet off-peak weekend" / "families with kids for the school break". */
+  audience?: string;
+}
+
 export interface AdBrief {
   propertyId: string;
   opportunity: AdOpportunity;   // the ads arm only ever plans an ads-routed opportunity

--- a/src/services/growth/__tests__/adReconciliation.test.ts
+++ b/src/services/growth/__tests__/adReconciliation.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+
+import { detectDrift } from '../adReconciliation';
+
+describe('detectDrift', () => {
+  it('returns no flags when Meta reports no effective_status', () => {
+    expect(detectDrift('active', undefined)).toEqual([]);
+  });
+
+  it('is silent when our status and Meta agree (active/ACTIVE)', () => {
+    expect(detectDrift('active', 'ACTIVE')).toEqual([]);
+  });
+
+  it('is silent when a paused doc is paused on Meta', () => {
+    expect(detectDrift('paused', 'PAUSED')).toEqual([]);
+  });
+
+  it('flags a REJECTED / problem effective_status', () => {
+    expect(detectDrift('active', 'REJECTED').some((f) => f.includes('will not deliver'))).toBe(true);
+    expect(detectDrift('active', 'WITH_ISSUES').some((f) => f.includes('WITH_ISSUES'))).toBe(true);
+  });
+
+  it('flags the dangerous drift — DELIVERING when our record says it should not be', () => {
+    const flags = detectDrift('paused', 'ACTIVE');
+    expect(flags.some((f) => f.includes('DELIVERING when it should not be'))).toBe(true);
+    // approved (not yet activated) delivering is also dangerous
+    expect(detectDrift('approved', 'ACTIVE').some((f) => f.includes('DELIVERING'))).toBe(true);
+  });
+
+  it('flags the benign drift — we think active but Meta shows it paused (nothing running)', () => {
+    expect(detectDrift('active', 'CAMPAIGN_PAUSED').some((f) => f.includes('not actually delivering'))).toBe(true);
+  });
+});

--- a/src/services/growth/__tests__/pagePostWriter.test.ts
+++ b/src/services/growth/__tests__/pagePostWriter.test.ts
@@ -1,0 +1,36 @@
+/** @jest-environment node */
+
+import { validatePagePost } from '../pagePostWriter';
+
+const PACK = {
+  propertyId: 'prahova-mountain-chalet',
+  assetPaths: ['properties/prahova-mountain-chalet/autumn.jpg', 'properties/prahova-mountain-chalet/fire.jpg'],
+};
+const okMsg = 'Toamna se așterne peste Valea Prahovei — frunze aurii și dimineți liniștite. Veniți să vă bucurați de munte.';
+
+describe('validatePagePost', () => {
+  it('accepts a sane message + a real owned photo', () => {
+    expect(validatePagePost({ message: okMsg, assetPath: PACK.assetPaths[0] }, PACK).ok).toBe(true);
+  });
+  it('rejects a too-short message', () => {
+    const res = validatePagePost({ message: 'salut', assetPath: PACK.assetPaths[0] }, PACK);
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('too short'))).toBe(true);
+  });
+  it('rejects a photo not in the gallery (cannot invent one)', () => {
+    const res = validatePagePost({ message: okMsg, assetPath: 'properties/prahova-mountain-chalet/nope.jpg' }, PACK);
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('not in the available gallery assets'))).toBe(true);
+  });
+  it('rejects a photo owned by another property', () => {
+    const pack = { ...PACK, assetPaths: [...PACK.assetPaths, 'properties/other/x.jpg'] };
+    const res = validatePagePost({ message: okMsg, assetPath: 'properties/other/x.jpg' }, pack);
+    expect(res.ok).toBe(false);
+    expect(res.errors.some((e) => e.includes('not owned by'))).toBe(true);
+  });
+  it('warns (not errors) on a long message', () => {
+    const res = validatePagePost({ message: 'a '.repeat(300), assetPath: PACK.assetPaths[0] }, PACK);
+    expect(res.ok).toBe(true);
+    expect(res.warnings.some((w) => w.includes('long for a page post'))).toBe(true);
+  });
+});

--- a/src/services/growth/adCopywriter.ts
+++ b/src/services/growth/adCopywriter.ts
@@ -15,7 +15,7 @@
  */
 import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
 import { validateAdCreative, type AdCreativePackForValidation } from '@/lib/growth/validateAdCreative';
-import type { AdBrief } from '@/lib/growth/contracts';
+import type { AdBrief, AdFraming } from '@/lib/growth/contracts';
 import type { CopyVariant } from '@/types';
 import { loggers } from '@/lib/logger';
 
@@ -64,8 +64,11 @@ STRANGERS in Romanian feeder cities (not past guests) — write PUBLIC brand cop
 personal, in ROMANIAN (the target market).
 
 THE RULES
-1. FOLLOW THE BRIEF. Write to the brief's angle, tone, and occasion (brief.creativeBrief). Lead with
-   a scroll-stopping hook, then the point of the trip. 1-3 short sentences per variant.
+1. FOLLOW THE BRIEF, SERVE THE GOAL + AUDIENCE. Write to the brief's angle, tone, and occasion
+   (brief.creativeBrief), and to the pack's goal (the outcome) + audience (who) — every copy variant
+   AND every photo you pick must serve THIS audience for THIS goal and period. A couples/off-peak ad
+   and a families/school-break ad read and look different. Lead with a scroll-stopping hook, then the
+   point of the trip. 1-3 short sentences per variant.
 2. GROUND IN REALITY. Choose photos ONLY from the provided assets, by their EXACT storagePath — you
    cannot show something the property does not have. Never claim an amenity or experience that isn't
    evident in the brief or the assets (no invented pools, spas, or activities). Match photo THEMES to
@@ -101,7 +104,7 @@ interface EmitAdCreativeInput {
 export async function generateAdCreative(
   brief: AdBrief,
   assets: AdCreativeAsset[],
-  opts?: { maxRepairs?: number }
+  opts?: { maxRepairs?: number; framing?: AdFraming }
 ): Promise<GenerateAdCreativeResult> {
   if (!brief.act) return { ok: false, creative: null, errors: ['brief is act:false — there is no creative to write for a declined plan'], warnings: [], attempts: 0 };
   if (!assets.length) return { ok: false, creative: null, errors: ['no gallery assets available to build a creative'], warnings: [], attempts: 0 };
@@ -113,6 +116,8 @@ export async function generateAdCreative(
   const maxRepairs = opts?.maxRepairs ?? 1;
 
   const creativePack = {
+    goal: opts?.framing?.goal ?? null,
+    audience: opts?.framing?.audience ?? null,
     occasion: brief.opportunity.occasion,
     window: brief.opportunity.window,
     creativeBrief: brief.creativeBrief,

--- a/src/services/growth/adPlanner.ts
+++ b/src/services/growth/adPlanner.ts
@@ -15,7 +15,7 @@
 import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
 import { buildAdPlannerPack, type AdPlannerPack } from '@/lib/growth/adPlannerPack';
 import { validateAdPlan, type AdPlannerPackForValidation } from '@/lib/growth/validateAdPlan';
-import type { AdBrief, AdOpportunity } from '@/lib/growth/contracts';
+import type { AdBrief, AdOpportunity, AdFraming } from '@/lib/growth/contracts';
 import { loggers } from '@/lib/logger';
 
 const logger = loggers.ads;
@@ -57,6 +57,15 @@ HOW MUCH (a daily budget within the envelope), HOW LONG (a bounded end date), an
 creativeBrief (the angle + which asset themes to favor + tone). You PLAN only — you do NOT write the
 final ad copy or choose exact photos (the creative stage does that), and nothing you emit spends
 money until a human approves and activates it.
+
+SHAPE THE WHOLE AD TO THE FRAMING. The pack's framing.goal (the OUTCOME wanted) and framing.audience
+(WHO) — together with the occasion + the period to fill — must shape your creativeBrief as ONE
+coherent thing: the angle, the tone, and which asset THEMES to favor all serve this goal + this
+audience for this window. A "couples, off-peak, food-and-fire" ad and a "families, school-break,
+playground" ad for the SAME dates get materially different briefs and different photo themes. Write
+the creativeBrief so a downstream copywriter cannot help but produce copy AND pick photos that match.
+If framing.goal/audience are null, INFER sensible ones from the occasion + what the property sells,
+and state the assumption in your rationale.
 
 THE RULES
 1. NARROW, NEVER WIDEN. Pick cities ONLY from the pack's targeting.candidateCities, using their exact
@@ -108,14 +117,14 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  */
 export async function generateAdPlan(
   opportunity: AdOpportunity,
-  opts?: { asOf?: Date; maxRepairs?: number; pack?: AdPlannerPack }
+  opts?: { asOf?: Date; maxRepairs?: number; pack?: AdPlannerPack; framing?: AdFraming }
 ): Promise<GenerateAdPlanResult> {
   const client = getAnthropicClient();
   if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app ad planner is unavailable');
 
   // Reuse a prebuilt pack when the caller already has one (the orchestrator builds it ONCE and feeds
   // both the planner and the copywriter) — else build it here.
-  const pack = opts?.pack ?? (await buildAdPlannerPack(opportunity, { asOf: opts?.asOf }));
+  const pack = opts?.pack ?? (await buildAdPlannerPack(opportunity, { asOf: opts?.asOf, framing: opts?.framing }));
   const validationPack: AdPlannerPackForValidation = {
     constraints: { maxDailyBudgetMinor: pack.constraints.maxDailyBudgetMinor, maxTotalSpendMinor: pack.constraints.maxTotalSpendMinor },
     targeting: { candidateCityKeys: pack.targeting.candidateCityKeys },
@@ -124,6 +133,7 @@ export async function generateAdPlan(
 
   const packJson = JSON.stringify({
     opportunity: pack.opportunity,
+    framing: pack.framing,
     constraints: pack.constraints,
     targeting: pack.targeting,
     account: pack.account,

--- a/src/services/growth/adProposal.ts
+++ b/src/services/growth/adProposal.ts
@@ -19,7 +19,7 @@ import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
 import { generateAdPlan } from './adPlanner';
 import { generateAdCreative } from './adCopywriter';
 import { composeAndCreateAd } from './adComposer';
-import type { AdOpportunity, AdBrief } from '@/lib/growth/contracts';
+import type { AdOpportunity, AdBrief, AdFraming } from '@/lib/growth/contracts';
 import type { ComposeAndCreateAdInput, CopyVariant } from '@/types';
 import { loggers } from '@/lib/logger';
 
@@ -43,10 +43,10 @@ export interface AdProposalResult {
  * Produce a PAUSED ad draft for an opportunity. Returns at the first stage that fails (with its
  * errors), or `declined:true` if the planner chose not to act, or the created draft ids on success.
  */
-export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date }): Promise<AdProposalResult> {
-  const pack = await buildAdPlannerPack(opportunity, { asOf: opts?.asOf });
+export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date; framing?: AdFraming }): Promise<AdProposalResult> {
+  const pack = await buildAdPlannerPack(opportunity, { asOf: opts?.asOf, framing: opts?.framing });
 
-  // 1. Plan (geo + budget + timing + creative brief).
+  // 1. Plan (geo + budget + timing + creative brief) — the pack carries the framing (goal + audience).
   const plan = await generateAdPlan(opportunity, { pack });
   if (!plan.ok || !plan.brief) {
     logger.warn('proposeAd: planning failed', { opportunityId: opportunity.id, errors: plan.errors });
@@ -58,8 +58,8 @@ export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date
     return { ok: true, stage: 'plan', declined: true, brief, errors: [] };
   }
 
-  // 2. Creative (grounded copy + real photos).
-  const creativeRes = await generateAdCreative(brief, pack.assets);
+  // 2. Creative (grounded copy + real photos) — reinforce the same goal + audience shaping.
+  const creativeRes = await generateAdCreative(brief, pack.assets, { framing: opts?.framing });
   if (!creativeRes.ok || !creativeRes.creative) {
     logger.warn('proposeAd: creative failed', { opportunityId: opportunity.id, errors: creativeRes.errors });
     return { ok: false, stage: 'creative', declined: false, brief, errors: creativeRes.errors };

--- a/src/services/growth/adReconciliation.ts
+++ b/src/services/growth/adReconciliation.ts
@@ -1,0 +1,143 @@
+/**
+ * adReconciliation — the money-path BACKSTOP cron (promotion-system-architecture.md §8, ad plan
+ * §13 C2/M2 / §16.6). Our `status` on an `adCampaigns` doc is what WE believe; Meta's
+ * `effective_status` is the truth. This job periodically pulls the truth for every live-capable
+ * campaign, refreshes its insights, and FLAGS any drift — a campaign delivering that we think is
+ * paused, a REJECTED ad, or an ACTIVE campaign in the account that we don't track at all (a
+ * shared-token escape). Flags are logged loudly so an operator notices; the account-level spend
+ * limit remains the hard backstop that survives even this.
+ *
+ * Read-mostly: it GETs insights/status and UPDATEs our own docs' `insights`/`effectiveStatus` — it
+ * never activates, pauses, or spends. Server-only.
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { AdCampaignStatus } from '@/types';
+import { getInsights, getEffectiveStatus } from './metaAds/insights';
+import { resolveAdContext } from './metaAds/adContext';
+import { metaGraph } from './metaAds/client';
+
+const logger = loggers.ads;
+
+/** Meta `effective_status` values that mean "not delivering as we'd expect" (won't run, or under review). */
+const PROBLEM_STATUSES = new Set(['DISAPPROVED', 'REJECTED', 'WITH_ISSUES', 'PENDING_REVIEW', 'DELETED', 'ARCHIVED']);
+/** A campaign-level `effective_status` of ACTIVE means Meta considers it live (spending-capable). */
+const DELIVERING = 'ACTIVE';
+
+/** Doc statuses whose Meta chain can plausibly deliver — worth reconciling (drafts/failed have no live chain). */
+const LIVE_CAPABLE: AdCampaignStatus[] = ['active', 'approved', 'paused'];
+
+/**
+ * Pure drift detector — compares OUR believed `status` against Meta's `effectiveStatus`. Extracted so
+ * the (integration-heavy) reconcile loop's judgement is exhaustively unit-testable. Returns a list of
+ * human-readable drift flags (empty = consistent).
+ */
+export function detectDrift(status: string | undefined, effectiveStatus: string | undefined): string[] {
+  const flags: string[] = [];
+  if (!effectiveStatus) return flags;
+
+  if (PROBLEM_STATUSES.has(effectiveStatus)) {
+    flags.push(`effective_status=${effectiveStatus} — will not deliver as expected`);
+  }
+  // Delivering money while our record says it shouldn't be — the dangerous drift.
+  if (effectiveStatus === DELIVERING && status !== 'active') {
+    flags.push(`effective_status=ACTIVE but our status="${status ?? 'unknown'}" — DELIVERING when it should not be`);
+  }
+  // We think it's live but Meta shows it paused/stopped — benign, but worth surfacing (nothing's running).
+  if (status === 'active' && ['PAUSED', 'CAMPAIGN_PAUSED', 'ADSET_PAUSED'].includes(effectiveStatus)) {
+    flags.push(`our status=active but effective_status=${effectiveStatus} — not actually delivering`);
+  }
+  return flags;
+}
+
+export interface ReconcileResult {
+  checked: number;
+  updated: number;
+  escapes: number;
+  flags: string[];
+}
+
+interface AdCampaignReconData {
+  propertyId?: string;
+  metaCampaignId?: string;
+  status?: AdCampaignStatus;
+}
+
+/**
+ * Reconcile every live-capable `adCampaigns` doc against Meta, refresh insights + effective_status,
+ * and scan each configured account for ACTIVE campaigns we don't track (escapes). Never throws per
+ * doc — one failure doesn't abort the run. Returns counts + the flag list (also logged).
+ */
+export async function reconcileAdCampaigns(): Promise<ReconcileResult> {
+  const db = await getAdminDb();
+  const snap = await db.collection('adCampaigns').get();
+  const flags: string[] = [];
+  let checked = 0;
+  let updated = 0;
+
+  // Our tracked Meta campaign ids per property — for the account-level escape scan.
+  const trackedByProperty = new Map<string, Set<string>>();
+  for (const d of snap.docs) {
+    const data = d.data() as AdCampaignReconData;
+    if (data.propertyId && data.metaCampaignId) {
+      const set = trackedByProperty.get(data.propertyId) ?? new Set<string>();
+      set.add(data.metaCampaignId);
+      trackedByProperty.set(data.propertyId, set);
+    }
+  }
+
+  // Per-doc reconcile.
+  for (const d of snap.docs) {
+    const data = d.data() as AdCampaignReconData;
+    if (!data.propertyId || !data.metaCampaignId) continue;
+    if (!data.status || !LIVE_CAPABLE.includes(data.status)) continue;
+    checked += 1;
+
+    try {
+      const [ins, eff] = await Promise.all([
+        getInsights(data.propertyId, data.metaCampaignId),
+        getEffectiveStatus(data.propertyId, data.metaCampaignId),
+      ]);
+      const patch: Record<string, unknown> = { lastSyncedAt: FieldValue.serverTimestamp() };
+      if (ins.ok) {
+        patch.insights = { spend: ins.data.spend, impressions: ins.data.impressions, clicks: ins.data.clicks, bookings: ins.data.purchases, roas: ins.data.roas };
+      }
+      const effStatus = eff.ok ? eff.data.effectiveStatus : undefined;
+      if (effStatus) patch.effectiveStatus = effStatus;
+      await d.ref.update(patch);
+      updated += 1;
+
+      for (const f of detectDrift(data.status, effStatus)) flags.push(`${d.id} (${data.propertyId}): ${f}`);
+    } catch (error) {
+      logger.warn('reconcileAdCampaigns: per-doc reconcile failed (continuing)', { adCampaignId: d.id, error: String(error) });
+    }
+  }
+
+  // Account-level escape scan: any campaign ACTIVE in the account that we don't track.
+  let escapes = 0;
+  for (const [propertyId, tracked] of trackedByProperty) {
+    try {
+      const ctx = await resolveAdContext(propertyId);
+      if (!ctx) continue;
+      const res = await metaGraph<{ data?: Array<{ id: string; name?: string; effective_status?: string }> }>(
+        `${ctx.adAccountId}/campaigns`,
+        { method: 'GET', params: { fields: 'id,name,effective_status', limit: 200 }, token: ctx.token, propertyId }
+      );
+      if (!res.ok) continue;
+      for (const c of res.data.data ?? []) {
+        if (c.effective_status === DELIVERING && !tracked.has(c.id)) {
+          escapes += 1;
+          flags.push(`ESCAPE (${propertyId}): Meta campaign ${c.id} "${c.name ?? ''}" is ACTIVE but NOT tracked by us`);
+        }
+      }
+    } catch (error) {
+      logger.warn('reconcileAdCampaigns: escape scan failed (continuing)', { propertyId, error: String(error) });
+    }
+  }
+
+  if (flags.length) {
+    logger.error('reconcileAdCampaigns: DRIFT/ESCAPE detected', undefined, { count: flags.length, flags });
+  }
+  logger.info('reconcileAdCampaigns: done', { checked, updated, escapes, flagCount: flags.length });
+  return { checked, updated, escapes, flags };
+}

--- a/src/services/growth/pagePostWriter.ts
+++ b/src/services/growth/pagePostWriter.ts
@@ -1,0 +1,157 @@
+/**
+ * pagePostWriter (in-app) — drafts an ORGANIC Facebook page post to keep the brand page alive
+ * (promotion-system-architecture.md §4.3). The page-arm twin of the ad copywriter, but simpler: an
+ * organic post is ONE warm caption + ONE real photo, not a paid ad. It is grounded in the property's
+ * real gallery + the public brand voice, and shaped to the same goal/audience framing.
+ *
+ * DELIVERY PHILOSOPHY (mirrors WhatsApp): the server DRAFTS, it does not publish. v1 is manual — the
+ * operator reviews the draft and posts it by hand (copy the caption, download the photo), exactly
+ * like the wa.me one-tap send. API auto-publish is the later upgrade and needs the owner's one-time
+ * token-scope grant (pages_manage_posts + a CREATE_CONTENT page task, infra doc §11.2) plus a
+ * contract spike — NOT built blind here.
+ *
+ * Truth is anchored in CODE (validatePagePost): the chosen photo must be a REAL owned gallery asset.
+ * Server-only. Degrades (throws) if ANTHROPIC_API_KEY is absent.
+ */
+import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import type { AdFraming } from '@/lib/growth/contracts';
+import type { AdCreativeAsset } from './adCopywriter';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+const MESSAGE_MIN = 20;
+const MESSAGE_MAX = 2000;
+
+export interface PagePost {
+  message: string;
+  assetPath: string;
+  notes?: string;
+}
+
+export interface PagePostValidationResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/** Pure validator: the post must have a sane-length message and ONE photo that is a real owned asset. */
+export function validatePagePost(
+  post: { message: string; assetPath: string },
+  pack: { propertyId: string; assetPaths: string[] }
+): PagePostValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const msg = (post.message ?? '').trim();
+  if (msg.length < MESSAGE_MIN) errors.push(`message too short (${msg.length} < ${MESSAGE_MIN})`);
+  else if (msg.length > MESSAGE_MAX) errors.push(`message too long (${msg.length} > ${MESSAGE_MAX})`);
+  else if (msg.length > 500) warnings.push(`message ${msg.length} chars — long for a page post; shorter usually performs better`);
+
+  if (!post.assetPath) errors.push('no photo chosen');
+  else if (!pack.assetPaths.includes(post.assetPath)) errors.push(`photo not in the available gallery assets: ${post.assetPath}`);
+  else if (!post.assetPath.startsWith(`properties/${pack.propertyId}/`)) errors.push(`photo not owned by ${pack.propertyId}`);
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+const PAGE_POST_TOOL = {
+  name: 'emit_page_post',
+  description: 'Emit one organic Facebook page post: the caption and the chosen photo.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      message: { type: 'string', description: 'the post caption in ROMANIAN — warm, organic, community feel (NOT a hard-sell ad). Short, a few sentences; a light question or invite is good for engagement.' },
+      assetPath: { type: 'string', description: 'ONE photo by EXACT storagePath from the assets — the one that best carries the post. Never invent a path.' },
+      notes: { type: 'string', description: 'brief note on the choice (optional).' },
+    },
+    required: ['message', 'assetPath'],
+  },
+};
+
+const SYSTEM = `You write ORGANIC Facebook page posts for a small Romanian mountain-chalet rental — to keep
+the page alive and warm, NOT to run a paid ad. Audience: the page's followers + locals in Romania.
+Write in ROMANIAN, in a warm, genuine, public brand voice — a real host sharing a moment, not a
+billboard.
+
+RULES
+1. ORGANIC, NOT AN AD. A page post shares something real — a seasonal moment, a small update, a
+   view, an invitation to come enjoy the mountains. Warm and human; a light question or "come see"
+   invite drives engagement. No aggressive selling, no fake urgency.
+2. SHAPE TO THE PROMPT + FRAMING. Follow the prompt (what the post is about) and any goal/audience
+   given — a couples/off-peak post and a families/school-break post look different.
+3. GROUND IN REALITY. Pick ONE photo, by exact storagePath, from the provided assets — you can only
+   show what the property really has. Never claim an amenity/experience not evident in the assets.
+4. KEEP IT SHORT. A few sentences. Diacritics are fine (this is public brand copy). One or two
+   tasteful emoji are OK if they fit.
+
+Return the post by calling emit_page_post. Nothing else.`;
+
+export interface GeneratePagePostResult {
+  ok: boolean;
+  post: PagePost | null;
+  errors: string[];
+  warnings: string[];
+  attempts: number;
+}
+
+interface EmitPagePostInput {
+  message: string;
+  assetPath: string;
+  notes?: string;
+}
+
+/**
+ * Draft an organic page post. Runs the LLM, validates (real owned photo + sane message), and on
+ * failure feeds the errors back for ONE bounded repair. Produces a DRAFT only — never publishes.
+ */
+export async function generatePagePost(
+  input: { propertyId: string; prompt: string; assets: AdCreativeAsset[]; framing?: AdFraming },
+  opts?: { maxRepairs?: number }
+): Promise<GeneratePagePostResult> {
+  if (!input.assets.length) return { ok: false, post: null, errors: ['no gallery assets available'], warnings: [], attempts: 0 };
+  const client = getAnthropicClient();
+  if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app page-post writer is unavailable');
+
+  const validationPack = { propertyId: input.propertyId, assetPaths: input.assets.map((a) => a.storagePath) };
+  const maxRepairs = opts?.maxRepairs ?? 1;
+
+  const postPack = {
+    prompt: input.prompt,
+    goal: input.framing?.goal ?? null,
+    audience: input.framing?.audience ?? null,
+    assets: input.assets.map((a) => ({ storagePath: a.storagePath, alt: a.alt, tags: a.tags })),
+  };
+  const messages: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
+    { role: 'user', content: `Here is the post brief + the available gallery assets. Write ONE organic page post and call emit_page_post.\n\n${JSON.stringify(postPack)}` },
+  ];
+
+  let post: PagePost | null = null;
+  let lastValidation = { ok: false, errors: [] as string[], warnings: [] as string[] };
+
+  for (let attempt = 1; attempt <= maxRepairs + 1; attempt++) {
+    const resp = await client.messages.create({
+      model: COPYWRITER_MODEL,
+      max_tokens: 1024,
+      system: SYSTEM,
+      tools: [PAGE_POST_TOOL],
+      tool_choice: { type: 'tool', name: 'emit_page_post' },
+      messages: messages as never,
+    });
+    const toolUse = resp.content.find((b: { type: string }) => b.type === 'tool_use') as { id?: string; input?: EmitPagePostInput } | undefined;
+    const emitted = toolUse?.input;
+    post = emitted ? { message: emitted.message, assetPath: emitted.assetPath, notes: emitted.notes } : null;
+
+    const v = post ? validatePagePost(post, validationPack) : { ok: false, errors: ['the model returned no post'], warnings: [] };
+    lastValidation = { ok: v.ok, errors: v.errors, warnings: v.warnings };
+    logger.info('pagePostWriter generatePagePost attempt', { attempt, ok: v.ok, errors: v.errors.length });
+
+    if (v.ok) return { ok: true, post, errors: [], warnings: v.warnings, attempts: attempt };
+    if (attempt > maxRepairs) break;
+
+    const repairText = `The post failed validation. Fix EXACTLY these and re-emit via emit_page_post:\n- ${lastValidation.errors.join('\n- ')}\n\nReminder: pick ONE photo by exact storagePath from the assets; message ${MESSAGE_MIN}-${MESSAGE_MAX} chars.`;
+    messages.push({ role: 'assistant', content: resp.content });
+    messages.push({ role: 'user', content: toolUse?.id ? [{ type: 'tool_result', tool_use_id: toolUse.id, content: repairText }] : repairText });
+  }
+
+  return { ok: false, post, errors: lastValidation.errors, warnings: lastValidation.warnings, attempts: maxRepairs + 1 };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -562,6 +562,9 @@ export interface AdCampaign {
   proposal?: {
     source: 'opportunity-engine';
     occasion?: { name: string | null; start: string; end: string; nights: number } | null;
+    /** The operator's outcome + audience steering, shown at review so it's clear what shaped the ad. */
+    goal?: string | null;
+    audience?: string | null;
     copy: CopyVariant[];
     photos: Array<{ storagePath: string; url: string }>;
     cities: Array<{ name: string; radius: number }>;


### PR DESCRIPTION
Completes the buildable/testable pipeline (`docs/promotion-system-architecture.md`).

## What's included
- **Coherence** — an explicit `AdFraming` {goal, audience} threads pack → planner brief → copywriter → photo choice, so the copy AND the photos bend to the outcome + audience, not just the occasion. Proven live: the same window with couples vs families framings produced materially different copy and photo selections.
- **Reconciliation cron** (`/api/cron/ad-reconcile`) — the money-path backstop: pulls Meta's effective_status + fresh insights for every live-capable campaign, updates our records, and flags drift (delivering-when-paused, REJECTED, or an ACTIVE untracked campaign = escape). Read-mostly; never spends.
- **Organic page-post generator** (`generatePagePost`) — drafts a warm, grounded RO page post (caption + a real gallery photo), framing-shaped. Delivery mirrors WhatsApp: server DRAFTS, operator posts by hand — no scope needed.

## Safety — still DARK
No automatic spend or posting path. Ads still require operator generate→approve→activate with `GROWTH_ADS_MODE` unset; the reconciliation cron is read-mostly; page posts are drafted only.

## Tested
- 225 growth/ads tests pass; `npm run build` passes.
- Live: two-framing coherence proof; reconcile run (checked:0/escapes:0, zero side effects); page post drafted (1 attempt).

## Owner-gated remainders (not code)
- **Ads go-live**: set the account spend limit (still `0`) + flip `GROWTH_ADS_MODE=live`.
- **Page auto-publish**: one-time token-scope grant (`pages_manage_posts` + `CREATE_CONTENT` task) — until then, page posts are manual.
- Schedule the reconcile cron (Cloud Scheduler → GET `/api/cron/ad-reconcile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)