### PR TITLE
Ad intelligence: vision photo descriptions + the learning loop

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -116,6 +116,14 @@
         { "fieldPath": "propertyId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "adOutcomes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "capturedAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -261,6 +261,12 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only
     }
 
+    match /adOutcomes/{outcomeId} {
+      // Frozen per-campaign learning records — the ad learning loop reads these.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (written by finalizeAdOutcome)
+    }
+
     match /adImageCache/{cacheId} {
       // Per-(platform, ad account, content hash) image-hash dedup cache
       // (Phase 2a Build A) — no user-facing write path exists.

--- a/scripts/ad-propose.ts
+++ b/scripts/ad-propose.ts
@@ -41,6 +41,7 @@ if (!start || !end) {
 const property = arg('property', 'prahova-mountain-chalet')!;
 const value = arg('value');
 const occasionName = arg('occasion');
+const framing = { goal: arg('goal'), audience: arg('audience') };
 const keep = process.argv.includes('--keep');
 
 const nights = Math.round((Date.parse(end) - Date.parse(start)) / 86400000);
@@ -58,7 +59,7 @@ const opportunity: AdOpportunity = {
 };
 
 (async () => {
-  const res = await proposeAd(opportunity);
+  const res = await proposeAd(opportunity, { framing });
   console.log(`\n=== proposeAd — ${res.ok ? (res.declined ? 'DECLINED (no draft)' : 'DRAFT CREATED') : `FAILED at ${res.stage}`} ===`);
   if (res.brief) console.log(`plan: act=${res.brief.act} · ${res.brief.targeting.cities.map((c) => c.name).join(', ')} · ${(res.brief.dailyBudgetMinor / 100).toFixed(0)} RON/day`);
   if (res.creative) console.log(`creative: ${res.creative.copy.length} copy variants · ${res.creative.assetPaths.length} photos`);

--- a/scripts/caption-gallery.ts
+++ b/scripts/caption-gallery.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env npx tsx
+/**
+ * caption-gallery — backfill each gallery photo with a rich vision `aiDescription` (season, mood,
+ * features, people, fitting angles) so the ad/page selectors reason over what's ACTUALLY in each
+ * photo. A vision model looks at every image. Re-runnable (skips already-described unless --force);
+ * writes back after each image so it's resumable. Read-only on Meta; writes only property.images.
+ *
+ * Usage:
+ *   npx tsx scripts/caption-gallery.ts [--property slug] [--limit N] [--force] [--dry]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+process.env.ANTHROPIC_API_KEY = execSync('gcloud secrets versions access latest --secret=ANTHROPIC_API_KEY --project=rentalspot-fzwom', { encoding: 'utf8' }).trim();
+
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { describeImage, mediaTypeFromUrl } from '@/services/growth/galleryVision';
+import type { PropertyImage } from '@/types';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const property = arg('property', 'prahova-mountain-chalet')!;
+const limit = arg('limit') ? Number(arg('limit')) : Infinity;
+const force = process.argv.includes('--force');
+const dry = process.argv.includes('--dry');
+
+(async () => {
+  const db = await getAdminDb();
+  const ref = db.collection('properties').doc(property);
+  const snap = await ref.get();
+  if (!snap.exists) { console.error(`property ${property} not found`); process.exit(1); }
+  const images = (snap.data()?.images ?? []) as PropertyImage[];
+
+  const todo = images
+    .map((img, idx) => ({ img, idx }))
+    .filter(({ img }) => img.storagePath && (force || !img.aiDescription))
+    .slice(0, limit);
+
+  console.log(`${property}: ${images.length} images · ${todo.length} to describe${dry ? ' (DRY RUN — no writes)' : ''}\n`);
+
+  let done = 0;
+  for (const { img, idx } of todo) {
+    const url = img.url;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) { console.log(`  ✖ ${idx} fetch ${res.status}`); continue; }
+      const bytes = Buffer.from(await res.arrayBuffer());
+      const mediaType = mediaTypeFromUrl(url);
+      const desc = await describeImage(bytes.toString('base64'), mediaType);
+      if (!desc) { console.log(`  ✖ ${idx} no description returned`); continue; }
+      done += 1;
+      const fname = (img.storagePath ?? '').split('/').pop();
+      console.log(`  ✓ ${idx} ${fname}\n      ${desc.summary}\n      season=${desc.season} · mood=${desc.mood} · people=${desc.people} · fits=[${desc.fitsAngles.join(', ')}]`);
+      if (!dry) {
+        images[idx] = { ...img, aiDescription: desc };
+        await ref.update({ images }); // write-after-each → resumable
+      }
+    } catch (e) {
+      console.log(`  ✖ ${idx} ${String(e).slice(0, 120)}`);
+    }
+  }
+  console.log(`\ndone: ${done}/${todo.length} described${dry ? ' (dry)' : ' and saved'}.`);
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/growth/adLearnings.ts
+++ b/src/lib/growth/adLearnings.ts
@@ -1,0 +1,96 @@
+/**
+ * adLearnings — assemble the "weak priors" block from past `adOutcomes` for the ad-planner pack
+ * (Fable §1.5). At this volume the honest move is: present RAW rows + the statistical METHOD, and
+ * NEVER emit conclusions or "winner" labels — that is both the facts+method+constraints discipline
+ * the rest of the pack uses AND exactly the right small-n statistics. Reads Firestore ONLY (no Meta
+ * calls) so the pack build never fans out API calls. `available:false` until the first outcome exists,
+ * so this ships dark and the prompts no-op.
+ *
+ * Server-only (Admin SDK).
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import type { AdLearnings, AdOutcome } from '@/types';
+
+const MAX_CAMPAIGNS = 12;
+
+/** The statistical contract, shipped verbatim to the LLM so it weights past campaigns correctly. */
+const LEARNINGS_NOTE =
+  'Past campaigns are WEAK PRIORS, not verdicts. Evidence hierarchy at this volume: CTR/CPC are real ' +
+  'signal (thousands of impressions); bookings are ANECDOTE until many campaigns accumulate — 0 vs 1 ' +
+  'attributed booking on a small campaign is statistical noise. utmBookings is a first-party FLOOR ' +
+  '(undercounts cross-device/cookie-loss/phone); metaPurchases is Meta-modeled and a DIFFERENT number ' +
+  '(never average them). Use these only to break ties among options that EQUALLY fit this occasion + ' +
+  'framing — never to override the occasion, and never treat one campaign as proof about an angle, ' +
+  'city, or audience.';
+
+function round(n: number, d = 2): number {
+  return Number(n.toFixed(d));
+}
+
+/** Build the learnings block for a property from its finalized `adOutcomes`. */
+export async function buildAdLearnings(propertyId: string, opts?: { maxCampaigns?: number }): Promise<AdLearnings> {
+  const empty: AdLearnings = {
+    available: false,
+    campaignsCompleted: 0,
+    totals: { spend: 0, impressions: 0, clicks: 0, utmBookings: 0, utmRevenue: 0 },
+    campaigns: [],
+    note: LEARNINGS_NOTE,
+  };
+
+  try {
+    const db = await getAdminDb();
+    const snap = await db
+      .collection('adOutcomes')
+      .where('propertyId', '==', propertyId)
+      .orderBy('capturedAt', 'desc')
+      .limit(opts?.maxCampaigns ?? MAX_CAMPAIGNS)
+      .get();
+
+    if (snap.empty) return empty;
+    const outcomes = snap.docs.map((d) => d.data() as AdOutcome);
+
+    const totals = outcomes.reduce(
+      (t, o) => ({
+        spend: t.spend + o.delivery.spend,
+        impressions: t.impressions + o.delivery.impressions,
+        clicks: t.clicks + o.delivery.clicks,
+        utmBookings: t.utmBookings + o.utmAttributed.bookings,
+        utmRevenue: t.utmRevenue + o.utmAttributed.revenue,
+      }),
+      { spend: 0, impressions: 0, clicks: 0, utmBookings: 0, utmRevenue: 0 }
+    );
+
+    return {
+      available: true,
+      campaignsCompleted: outcomes.length,
+      totals: {
+        spend: round(totals.spend),
+        impressions: totals.impressions,
+        clicks: totals.clicks,
+        utmBookings: totals.utmBookings,
+        utmRevenue: round(totals.utmRevenue),
+      },
+      campaigns: outcomes.map((o) => ({
+        occasion: o.occasion,
+        goal: o.goal,
+        audience: o.audience,
+        window: o.window ? `${o.window.start}..${o.window.end} (${o.window.nights}n)` : '—',
+        cities: o.cities.map((c) => c.name),
+        spend: round(o.delivery.spend),
+        impressions: o.delivery.impressions,
+        clicks: o.delivery.clicks,
+        ctr: o.delivery.ctr,
+        cpc: o.delivery.cpc,
+        metaPurchases: o.metaReported.purchases,
+        utmBookings: o.utmAttributed.bookings,
+        utmRevenue: round(o.utmAttributed.revenue),
+        verdict: o.verdict,
+        angle: (o.creativeBrief ?? '').slice(0, 200),
+      })),
+      note: LEARNINGS_NOTE,
+    };
+  } catch {
+    // A learnings read must never break a proposal — degrade to "no learnings".
+    return empty;
+  }
+}

--- a/src/lib/growth/adPlannerPack.ts
+++ b/src/lib/growth/adPlannerPack.ts
@@ -25,9 +25,10 @@ import { serverTranslateContent } from '@/lib/server-language-utils';
 import { getMaxDailyBudgetMinor } from '@/config/growth-ads';
 import { searchCities } from '@/services/growth/metaAds/geo';
 import { getAdAccountHealth, getPageHealth } from '@/services/growth/metaAds/brandHealth';
+import { buildAdLearnings } from '@/lib/growth/adLearnings';
 import type { AdOpportunity, AdFraming } from '@/lib/growth/contracts';
 import type { CityMatch } from '@/services/growth/metaAds/geo';
-import type { PropertyImage, AiImageDescription } from '@/types';
+import type { PropertyImage, AiImageDescription, AdLearnings } from '@/types';
 
 /**
  * RO feeder markets for a Prahova-valley chalet — the candidate geo the planner picks from. Names
@@ -86,6 +87,8 @@ export interface AdPlannerPack {
       }
     | { available: false; error: string };
   page: { available: true; dormant: boolean; followers: number; warnings: string[] } | { available: false; error: string };
+  /** Weak priors from past campaigns (Fable §1.5) — `available:false` until the first outcome exists. */
+  learnings: AdLearnings;
   assets: Array<{ storagePath: string; alt: string; tags: string[]; aiDescription?: AiImageDescription }>;
   landing: { baseUrl: string; note: string };
   method: string[];
@@ -100,11 +103,12 @@ export async function buildAdPlannerPack(
   const propertyId = opportunity.propertyId;
 
   // Health blocks + candidate-city resolution + property doc, in parallel (all read-only, all degrade).
-  const [accountRes, pageRes, cityResults, propSnap] = await Promise.all([
+  const [accountRes, pageRes, cityResults, propSnap, learnings] = await Promise.all([
     getAdAccountHealth(propertyId),
     getPageHealth(propertyId),
     Promise.all(RO_FEEDER_CITIES.map((name) => searchCities(propertyId, name, { limit: 3 }))),
     getAdminDb().then((db) => db.collection('properties').doc(propertyId).get()),
+    buildAdLearnings(propertyId),
   ]);
 
   // Candidate cities — the best match per name, deduped by key (a resolution failure just drops that
@@ -175,6 +179,7 @@ export async function buildAdPlannerPack(
     },
     account,
     page,
+    learnings,
     assets,
     landing: {
       baseUrl: getBaseUrl(propData?.customDomain),
@@ -184,6 +189,7 @@ export async function buildAdPlannerPack(
       'You PLAN: pick geo (subset of candidateCities + radius), a daily budget + a bounded end time (within the envelope), and write a creativeBrief (the angle + which asset themes to favor + tone). You do NOT write final ad copy or choose exact photos — that is the creative intelligence (step 4).',
       'Ground every choice in the pack: the opportunity (window/nights/occasion), account performance (CTR/CPC to size reach), the candidate cities, the assets available. Do not invent a city key, a budget above the ceiling, or an asset not listed.',
       'If the opportunity is weak (no occasion, tiny value, or the account is blocked), set act:false and say why — a forced ad burns real money, unlike a WhatsApp message.',
+      'If learnings.available, treat past campaigns as WEAK PRIORS (read learnings.note): prefer angles/cities with supporting evidence ONLY when they fit this occasion equally — never override the occasion, and one campaign proves nothing.',
     ],
   };
 }

--- a/src/lib/growth/adPlannerPack.ts
+++ b/src/lib/growth/adPlannerPack.ts
@@ -27,7 +27,7 @@ import { searchCities } from '@/services/growth/metaAds/geo';
 import { getAdAccountHealth, getPageHealth } from '@/services/growth/metaAds/brandHealth';
 import type { AdOpportunity, AdFraming } from '@/lib/growth/contracts';
 import type { CityMatch } from '@/services/growth/metaAds/geo';
-import type { PropertyImage } from '@/types';
+import type { PropertyImage, AiImageDescription } from '@/types';
 
 /**
  * RO feeder markets for a Prahova-valley chalet — the candidate geo the planner picks from. Names
@@ -86,7 +86,7 @@ export interface AdPlannerPack {
       }
     | { available: false; error: string };
   page: { available: true; dormant: boolean; followers: number; warnings: string[] } | { available: false; error: string };
-  assets: Array<{ storagePath: string; alt: string; tags: string[] }>;
+  assets: Array<{ storagePath: string; alt: string; tags: string[]; aiDescription?: AiImageDescription }>;
   landing: { baseUrl: string; note: string };
   method: string[];
 }
@@ -132,7 +132,7 @@ export async function buildAdPlannerPack(
   const ownPrefix = `properties/${propertyId}/`;
   const assets = (propData?.images ?? [])
     .filter((img): img is PropertyImage & { storagePath: string } => Boolean(img.storagePath && img.storagePath.startsWith(ownPrefix)))
-    .map((img) => ({ storagePath: img.storagePath, alt: serverTranslateContent(img.alt, 'en'), tags: img.tags ?? [] }));
+    .map((img) => ({ storagePath: img.storagePath, alt: serverTranslateContent(img.alt, 'en'), tags: img.tags ?? [], aiDescription: img.aiDescription }));
 
   const account: AdPlannerPack['account'] = accountRes.ok
     ? {

--- a/src/services/growth/__tests__/adOutcomes.test.ts
+++ b/src/services/growth/__tests__/adOutcomes.test.ts
@@ -1,0 +1,36 @@
+/** @jest-environment node */
+
+import { computeVerdict, computeCaveats } from '../adOutcomes';
+
+describe('computeVerdict', () => {
+  it('flags a rejected ad regardless of delivery', () => {
+    expect(computeVerdict('active', 'REJECTED', { spend: 5, impressions: 100, clicks: 2 }, { bookings: 0 })).toBe('rejected');
+  });
+  it('is never-activated when a non-active campaign never delivered', () => {
+    expect(computeVerdict('approved', undefined, { spend: 0, impressions: 0, clicks: 0 }, { bookings: 0 })).toBe('never-activated');
+  });
+  it('is no-delivery when an active campaign never delivered', () => {
+    expect(computeVerdict('active', 'PENDING_REVIEW', { spend: 0, impressions: 0, clicks: 0 }, { bookings: 0 })).toBe('no-delivery');
+  });
+  it('is converted when a utm booking is attributed', () => {
+    expect(computeVerdict('active', 'ACTIVE', { spend: 50, impressions: 5000, clicks: 100 }, { bookings: 1 })).toBe('converted');
+  });
+  it('is clicked-no-booking when it delivered clicks but no booking', () => {
+    expect(computeVerdict('paused', 'ACTIVE', { spend: 50, impressions: 5000, clicks: 100 }, { bookings: 0 })).toBe('clicked-no-booking');
+  });
+});
+
+describe('computeCaveats', () => {
+  it('always carries the two attribution-honesty caveats', () => {
+    const c = computeCaveats({ spend: 100, metaPurchases: 2, utmBookings: 1, source: 'opportunity-engine' });
+    expect(c.some((x) => x.includes('first-party FLOOR'))).toBe(true);
+    expect(c.some((x) => x.includes('Meta-MODELED'))).toBe(true);
+    expect(c.some((x) => x.includes('meta-purchases≠utm-bookings'))).toBe(true); // 2 ≠ 1
+  });
+  it('flags a low-spend anecdote', () => {
+    expect(computeCaveats({ spend: 30, metaPurchases: 0, utmBookings: 0, source: 'opportunity-engine' }).some((x) => x.includes('low-spend'))).toBe(true);
+  });
+  it('flags a manual compose with no framing metadata', () => {
+    expect(computeCaveats({ spend: 100, metaPurchases: 0, utmBookings: 0, source: 'manual' }).some((x) => x.includes('manual compose'))).toBe(true);
+  });
+});

--- a/src/services/growth/adCopywriter.ts
+++ b/src/services/growth/adCopywriter.ts
@@ -16,7 +16,7 @@
 import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
 import { validateAdCreative, type AdCreativePackForValidation } from '@/lib/growth/validateAdCreative';
 import type { AdBrief, AdFraming } from '@/lib/growth/contracts';
-import type { CopyVariant } from '@/types';
+import type { CopyVariant, AiImageDescription } from '@/types';
 import { loggers } from '@/lib/logger';
 
 const logger = loggers.ads;
@@ -26,6 +26,8 @@ export interface AdCreativeAsset {
   storagePath: string;
   alt: string;
   tags: string[];
+  /** Rich vision description (season/mood/features/fitsAngles) — the primary signal for picking a photo that fits. */
+  aiDescription?: AiImageDescription;
 }
 
 const AD_CREATIVE_TOOL = {
@@ -69,10 +71,13 @@ THE RULES
    AND every photo you pick must serve THIS audience for THIS goal and period. A couples/off-peak ad
    and a families/school-break ad read and look different. Lead with a scroll-stopping hook, then the
    point of the trip. 1-3 short sentences per variant.
-2. GROUND IN REALITY. Choose photos ONLY from the provided assets, by their EXACT storagePath — you
-   cannot show something the property does not have. Never claim an amenity or experience that isn't
-   evident in the brief or the assets (no invented pools, spas, or activities). Match photo THEMES to
-   the copy (use the assets' alt/tags to judge what each shows).
+2. GROUND IN REALITY, PICK PHOTOS THAT TRULY FIT. Choose photos ONLY from the provided assets, by
+   their EXACT storagePath — you cannot show something the property does not have (no invented pools,
+   spas, or activities). Each asset carries a rich aiDescription (season, mood, people, features,
+   fitsAngles) from a vision model that actually LOOKED at it — USE IT to pick photos that fit the
+   goal, the season/period, and the audience: a summer photo for an autumn ad is wrong; a
+   kids/playground photo for a couples ad is wrong. Match the aiDescription fitsAngles + season to the
+   brief; fall back to alt/tags only for an asset with no aiDescription.
 3. META SHAPE. 1-5 primary-text variants, each DISTINCT (Meta rejects duplicates). Headlines short
    (≤27 chars ideal); if you reuse a headline, use the SAME one across all variants (never two
    different-but-duplicate). Pick 1-6 photos with variety (exterior / interior / lifestyle) so
@@ -123,7 +128,7 @@ export async function generateAdCreative(
     creativeBrief: brief.creativeBrief,
     objective: brief.objective,
     cities: brief.targeting.cities.map((c) => c.name),
-    assets: assets.map((a) => ({ storagePath: a.storagePath, alt: a.alt, tags: a.tags })),
+    assets: assets.map((a) => ({ storagePath: a.storagePath, alt: a.alt, tags: a.tags, aiDescription: a.aiDescription })),
   };
   const messages: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
     { role: 'user', content: `Here is the ad brief + the available gallery assets. Write the creative and call emit_ad_creative.\n\n${JSON.stringify(creativePack)}` },

--- a/src/services/growth/adOutcomes.ts
+++ b/src/services/growth/adOutcomes.ts
@@ -1,0 +1,170 @@
+/**
+ * adOutcomes — capture a FROZEN learning record for a finished ad campaign (Fable §1.2-1.4). The
+ * campaign doc holds LIVE numbers; `adOutcomes/{id}` holds the outcome frozen at `endTime + settleDays`
+ * so learnings are stable. Two numbers are kept strictly separate: Meta's MODELED attribution
+ * (`metaReported`, from the pixel insights — view-through + attribution window) and our FIRST-PARTY
+ * utm→booking join (`utmAttributed`, a structural undercount / floor). They are never conflated.
+ *
+ * Server-only (Admin SDK). The utm join needs NO index/schema work — `attribution.{last,first}Touch
+ * .campaign` is a nested single field Firestore auto-indexes, and utm_campaign == the adCampaigns id.
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { AdOutcome } from '@/types';
+
+const logger = loggers.ads;
+
+/** Default settle window (days after endTime) before an outcome is frozen — lets late bookings land. */
+export const DEFAULT_SETTLE_DAYS = 14;
+
+const NON_BOOKING_STATUSES = new Set(['cancelled', 'payment_failed', 'expired']);
+const REJECTED_STATUSES = new Set(['REJECTED', 'DISAPPROVED', 'WITH_ISSUES']);
+
+export interface UtmAttribution {
+  bookings: number;
+  revenue: number;
+  bookingIds: string[];
+}
+
+/**
+ * First-party attribution: bookings whose first- OR last-touch utm_campaign is this campaign id
+ * (union — last-touch overwrite means an assisting click survives only in firstTouch; at this volume
+ * we count "touched by this campaign at any point"). Cancelled/failed excluded. A structural FLOOR —
+ * misses cross-device, cookie-loss, and phone/walk-in bookings.
+ */
+export async function captureUtmAttribution(adCampaignId: string): Promise<UtmAttribution> {
+  const db = await getAdminDb();
+  const [lastSnap, firstSnap] = await Promise.all([
+    db.collection('bookings').where('attribution.lastTouch.campaign', '==', adCampaignId).get(),
+    db.collection('bookings').where('attribution.firstTouch.campaign', '==', adCampaignId).get(),
+  ]);
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const d of [...lastSnap.docs, ...firstSnap.docs]) byId.set(d.id, d.data());
+
+  let bookings = 0;
+  let revenue = 0;
+  const bookingIds: string[] = [];
+  for (const [id, b] of byId) {
+    if (NON_BOOKING_STATUSES.has(String((b as { status?: string }).status ?? ''))) continue;
+    bookings += 1;
+    revenue += Number((b as { pricing?: { total?: number } }).pricing?.total ?? 0);
+    bookingIds.push(id);
+  }
+  return { bookings, revenue: Math.round(revenue), bookingIds };
+}
+
+type Verdict = AdOutcome['verdict'];
+
+/** Pure verdict — extracted for unit tests. */
+export function computeVerdict(
+  status: string | undefined,
+  effectiveStatus: string | undefined,
+  delivery: { spend: number; impressions: number; clicks: number },
+  utm: { bookings: number }
+): Verdict {
+  if (effectiveStatus && REJECTED_STATUSES.has(effectiveStatus)) return 'rejected';
+  if (delivery.impressions === 0 && delivery.spend === 0) return status === 'active' ? 'no-delivery' : 'never-activated';
+  if (utm.bookings > 0) return 'converted';
+  if (delivery.clicks > 0) return 'clicked-no-booking';
+  return 'no-delivery';
+}
+
+/** Pure caveat list — the machine-readable honesty a downstream LLM must weight by. */
+export function computeCaveats(input: {
+  spend: number;
+  metaPurchases: number;
+  utmBookings: number;
+  source: 'opportunity-engine' | 'manual';
+}): string[] {
+  const c: string[] = [
+    'utmAttributed is a first-party FLOOR — it misses cross-device, cookie-loss, and phone/walk-in bookings',
+    'metaReported is Meta-MODELED (view-through + attribution window) — a different number; never average it with utmAttributed',
+  ];
+  if (input.spend < 50) c.push('low-spend:<50RON — the outcome is anecdote, not signal');
+  if (input.metaPurchases !== input.utmBookings) c.push('meta-purchases≠utm-bookings (expected — different attribution)');
+  if (input.source === 'manual') c.push('manual compose — no goal/audience/angle metadata to learn from');
+  return c;
+}
+
+interface AdCampaignForOutcome {
+  propertyId?: string;
+  status?: string;
+  effectiveStatus?: string;
+  endTime?: string | null;
+  dailyBudgetMinor?: number;
+  outcomeCapturedAt?: unknown;
+  insights?: { spend?: number; impressions?: number; clicks?: number; bookings?: number; purchaseValue?: number; roas?: number };
+  proposal?: {
+    source?: string;
+    occasion?: { name?: string | null; start?: string; end?: string; nights?: number } | null;
+    goal?: string | null;
+    audience?: string | null;
+    creativeBrief?: string;
+    rationale?: string;
+    copy?: unknown[];
+    photos?: Array<{ storagePath: string }>;
+    cities?: Array<{ key?: string; name: string; radius: number }>;
+  };
+}
+
+/**
+ * Freeze the outcome for a finished campaign into `adOutcomes/{id}` (idempotent — doc id == campaign
+ * id), and stamp `outcomeCapturedAt` on the campaign so the cron won't re-finalize. Returns the
+ * outcome, or null if the campaign is missing or has no window/config to finalize.
+ */
+export async function finalizeAdOutcome(adCampaignId: string, opts?: { settleDays?: number }): Promise<AdOutcome | null> {
+  const db = await getAdminDb();
+  const ref = db.collection('adCampaigns').doc(adCampaignId);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const doc = snap.data() as AdCampaignForOutcome;
+  if (!doc.propertyId) return null;
+
+  const ins = doc.insights ?? {};
+  const spend = Number(ins.spend) || 0;
+  const impressions = Number(ins.impressions) || 0;
+  const clicks = Number(ins.clicks) || 0;
+  const delivery = {
+    spend,
+    impressions,
+    clicks,
+    ctr: impressions > 0 ? Number(((clicks / impressions) * 100).toFixed(3)) : 0,
+    cpc: clicks > 0 ? Number((spend / clicks).toFixed(4)) : 0,
+  };
+  const metaPurchases = Number(ins.bookings) || 0; // NB: reconcile stores Meta's pixel purchases here
+  const metaReported = { purchases: metaPurchases, purchaseValue: Number(ins.purchaseValue) || 0, roas: Number(ins.roas) || 0 };
+
+  const utm = await captureUtmAttribution(adCampaignId);
+  const source: 'opportunity-engine' | 'manual' = doc.proposal?.source === 'opportunity-engine' ? 'opportunity-engine' : 'manual';
+  const p = doc.proposal;
+  const occ = p?.occasion;
+
+  const outcome: AdOutcome = {
+    id: adCampaignId,
+    propertyId: doc.propertyId,
+    capturedAt: FieldValue.serverTimestamp() as unknown as AdOutcome['capturedAt'],
+    settleDays: opts?.settleDays ?? DEFAULT_SETTLE_DAYS,
+    window: occ?.start && occ?.end ? { start: occ.start, end: occ.end, nights: Number(occ.nights) || 0 } : null,
+    occasion: occ?.name ?? null,
+    goal: p?.goal ?? null,
+    audience: p?.audience ?? null,
+    creativeBrief: p?.creativeBrief ?? null,
+    copyCount: p?.copy?.length ?? 0,
+    photos: (p?.photos ?? []).map((ph) => ph.storagePath),
+    cities: p?.cities ?? [],
+    dailyBudgetMinor: Number(doc.dailyBudgetMinor) || 0,
+    endTime: doc.endTime ?? '',
+    source,
+    finalEffectiveStatus: doc.effectiveStatus ?? 'UNKNOWN',
+    delivery,
+    metaReported,
+    utmAttributed: utm,
+    verdict: computeVerdict(doc.status, doc.effectiveStatus, delivery, utm),
+    caveats: computeCaveats({ spend, metaPurchases, utmBookings: utm.bookings, source }),
+  };
+
+  await db.collection('adOutcomes').doc(adCampaignId).set(outcome);
+  await ref.update({ outcomeCapturedAt: FieldValue.serverTimestamp() });
+  logger.info('finalizeAdOutcome: outcome frozen', { adCampaignId, verdict: outcome.verdict, spend, utmBookings: utm.bookings });
+  return outcome;
+}

--- a/src/services/growth/adPlanner.ts
+++ b/src/services/growth/adPlanner.ts
@@ -87,6 +87,10 @@ THE RULES
 5. OR DECLINE. If the opportunity is weak — no occasion, tiny value, or the account is blocked — set
    act:false and say why in the rationale, with cities empty. A forced ad spends real money, unlike
    a WhatsApp message; declining is a valid, valuable output.
+6. LEARN, WEAKLY. If learnings.available, prefer angles/cities/audiences with supporting evidence when
+   they fit this occasion EQUALLY well, and note in the rationale which past result influenced you.
+   But the occasion + framing ALWAYS win, and one campaign proves nothing — read learnings.note and
+   weight CTR/CPC over booking counts at low volume.
 
 Return your plan by calling emit_ad_brief. Nothing else.`;
 
@@ -138,6 +142,7 @@ export async function generateAdPlan(
     targeting: pack.targeting,
     account: pack.account,
     page: pack.page,
+    learnings: pack.learnings,
     assets: pack.assets,
     landing: pack.landing,
     method: pack.method,

--- a/src/services/growth/adReconciliation.ts
+++ b/src/services/growth/adReconciliation.ts
@@ -16,6 +16,7 @@ import type { AdCampaignStatus } from '@/types';
 import { getInsights, getEffectiveStatus } from './metaAds/insights';
 import { resolveAdContext } from './metaAds/adContext';
 import { metaGraph } from './metaAds/client';
+import { finalizeAdOutcome, DEFAULT_SETTLE_DAYS } from './adOutcomes';
 
 const logger = loggers.ads;
 
@@ -54,6 +55,7 @@ export interface ReconcileResult {
   checked: number;
   updated: number;
   escapes: number;
+  finalized: number;
   flags: string[];
 }
 
@@ -61,6 +63,8 @@ interface AdCampaignReconData {
   propertyId?: string;
   metaCampaignId?: string;
   status?: AdCampaignStatus;
+  endTime?: string | null;
+  outcomeCapturedAt?: unknown;
 }
 
 /**
@@ -100,7 +104,16 @@ export async function reconcileAdCampaigns(): Promise<ReconcileResult> {
       ]);
       const patch: Record<string, unknown> = { lastSyncedAt: FieldValue.serverTimestamp() };
       if (ins.ok) {
-        patch.insights = { spend: ins.data.spend, impressions: ins.data.impressions, clicks: ins.data.clicks, bookings: ins.data.purchases, roas: ins.data.roas };
+        // NB: `bookings` here is Meta's MODELED pixel purchases (kept for the console); the outcome
+        // record splits it from the first-party utm join. `purchaseValue` was previously dropped.
+        patch.insights = {
+          spend: ins.data.spend,
+          impressions: ins.data.impressions,
+          clicks: ins.data.clicks,
+          bookings: ins.data.purchases,
+          purchaseValue: ins.data.purchaseValue,
+          roas: ins.data.roas,
+        };
       }
       const effStatus = eff.ok ? eff.data.effectiveStatus : undefined;
       if (effStatus) patch.effectiveStatus = effStatus;
@@ -135,9 +148,27 @@ export async function reconcileAdCampaigns(): Promise<ReconcileResult> {
     }
   }
 
+  // Finalize outcomes for campaigns that RAN and have ended + settled — freeze the learning record
+  // (Fable §1.2/§1.6). Only campaigns that were activated (status active/paused) — a never-run draft
+  // has nothing to learn. Idempotent: `outcomeCapturedAt` gates re-finalization.
+  let finalized = 0;
+  const now = Date.now();
+  for (const d of snap.docs) {
+    const data = d.data() as AdCampaignReconData;
+    if (data.outcomeCapturedAt || !data.metaCampaignId || !data.endTime) continue;
+    if (data.status !== 'active' && data.status !== 'paused') continue;
+    const endMs = Date.parse(data.endTime);
+    if (Number.isNaN(endMs) || endMs + DEFAULT_SETTLE_DAYS * 86_400_000 > now) continue;
+    try {
+      if (await finalizeAdOutcome(d.id)) finalized += 1;
+    } catch (error) {
+      logger.warn('reconcileAdCampaigns: finalize failed (continuing)', { adCampaignId: d.id, error: String(error) });
+    }
+  }
+
   if (flags.length) {
     logger.error('reconcileAdCampaigns: DRIFT/ESCAPE detected', undefined, { count: flags.length, flags });
   }
-  logger.info('reconcileAdCampaigns: done', { checked, updated, escapes, flagCount: flags.length });
-  return { checked, updated, escapes, flags };
+  logger.info('reconcileAdCampaigns: done', { checked, updated, escapes, finalized, flagCount: flags.length });
+  return { checked, updated, escapes, finalized, flags };
 }

--- a/src/services/growth/galleryVision.ts
+++ b/src/services/growth/galleryVision.ts
@@ -1,0 +1,101 @@
+/**
+ * galleryVision — describe a gallery photo with a VISION model, so the ad/page selectors can decide
+ * whether a photo actually fits a goal/period/audience (promotion-system-architecture.md §4.2, ad
+ * plan §14.2). This is the "look at the pixels, don't trust a thin alt tag" upgrade: it produces the
+ * rich structured `AiImageDescription` (season, mood, light, features, people, fitting angles).
+ *
+ * HARD GUARDRAIL: describe ONLY what is visibly present — never infer an amenity, room, or activity
+ * that isn't in the frame. A wrong description would make the selector confidently pick a wrong photo.
+ *
+ * Server-only. Throws if ANTHROPIC_API_KEY is absent.
+ */
+import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import type { AiImageDescription } from '@/types';
+
+/** Vision-capable media types the Anthropic API accepts. */
+export type SupportedMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+
+const DESCRIBE_TOOL = {
+  name: 'emit_description',
+  description: 'Emit the structured description of the photo.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      summary: { type: 'string', description: 'one concrete line: what the photo shows.' },
+      setting: { type: 'string', description: 'exterior | interior | garden | aerial | detail (or the best single word).' },
+      season: { type: 'string', enum: ['autumn', 'winter', 'spring', 'summer', 'indeterminate'], description: 'the season if visibly inferable (snow, green leaves, golden foliage), else indeterminate.' },
+      timeOfDay: { type: 'string', enum: ['day', 'golden-hour', 'night', 'indeterminate'] },
+      mood: { type: 'string', description: 'the feeling it conveys, e.g. "cozy, warm", "tranquil", "lively".' },
+      subjects: { type: 'array', items: { type: 'string' }, description: 'concrete things visible — be specific ("cast-iron cauldron over a fire", not "cooking").' },
+      features: { type: 'array', items: { type: 'string' }, description: 'amenities/features actually VISIBLE — "wood-burning stove", "terrace", "bunk beds", "playground". Never list one you cannot see.' },
+      people: { type: 'string', enum: ['none', 'adults', 'children', 'family', 'mixed'], description: 'who appears in the frame.' },
+      activities: { type: 'array', items: { type: 'string' }, description: 'activities the scene implies — "outdoor cooking", "relaxing", "kids playing".' },
+      palette: { type: 'array', items: { type: 'string' }, description: 'dominant colours — "golden", "warm wood", "green".' },
+      fitsAngles: { type: 'array', items: { type: 'string' }, description: 'marketing angles this photo suits — e.g. "romantic", "family", "food-and-fire", "nature", "cozy-winter", "off-peak-quiet".' },
+    },
+    required: ['summary', 'setting', 'season', 'timeOfDay', 'mood', 'subjects', 'features', 'people', 'activities', 'palette', 'fitsAngles'],
+  },
+};
+
+const SYSTEM = `You describe photos of a Romanian mountain-chalet vacation rental for an AI that will
+later SELECT images for ads and social posts. Look at the image carefully and record ONLY what is
+visibly present. NEVER invent an amenity, room, activity, season, or person that is not clearly in
+the frame — a wrong description makes the downstream AI confidently pick the wrong photo. Be concrete
+and specific. If the season or time of day is not visibly clear, say "indeterminate". Fill every
+field by calling emit_description.`;
+
+/**
+ * Describe one image. Returns the structured description, or null if the model returned nothing.
+ * `base64` is the raw image bytes base64-encoded; `mediaType` is its MIME type.
+ */
+export async function describeImage(base64: string, mediaType: SupportedMediaType): Promise<AiImageDescription | null> {
+  const client = getAnthropicClient();
+  if (!client) throw new Error('ANTHROPIC_API_KEY not configured — gallery vision is unavailable');
+
+  const resp = await client.messages.create({
+    model: COPYWRITER_MODEL, // Opus 4.8 — vision-capable
+    max_tokens: 1024,
+    system: SYSTEM,
+    tools: [DESCRIBE_TOOL],
+    tool_choice: { type: 'tool', name: 'emit_description' },
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: mediaType, data: base64 } },
+          { type: 'text', text: 'Describe this vacation-rental photo. Ground ONLY in what is visible; fill every field.' },
+        ],
+      },
+    ],
+  } as never);
+
+  const tool = resp.content.find((b: { type: string }) => b.type === 'tool_use') as { input?: Record<string, unknown> } | undefined;
+  const i = tool?.input;
+  if (!i) return null;
+
+  const arr = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []);
+  return {
+    summary: String(i.summary ?? ''),
+    setting: String(i.setting ?? ''),
+    season: String(i.season ?? 'indeterminate'),
+    timeOfDay: String(i.timeOfDay ?? 'indeterminate'),
+    mood: String(i.mood ?? ''),
+    subjects: arr(i.subjects),
+    features: arr(i.features),
+    people: String(i.people ?? 'none'),
+    activities: arr(i.activities),
+    palette: arr(i.palette),
+    fitsAngles: arr(i.fitsAngles),
+    model: COPYWRITER_MODEL,
+    describedAt: new Date().toISOString(),
+  };
+}
+
+/** Best-effort MIME sniff from a URL/path extension; defaults to JPEG (the common gallery format). */
+export function mediaTypeFromUrl(url: string): SupportedMediaType {
+  const u = url.toLowerCase();
+  if (u.includes('.png')) return 'image/png';
+  if (u.includes('.webp')) return 'image/webp';
+  if (u.includes('.gif')) return 'image/gif';
+  return 'image/jpeg';
+}

--- a/src/services/growth/pagePostWriter.ts
+++ b/src/services/growth/pagePostWriter.ts
@@ -79,8 +79,10 @@ RULES
    invite drives engagement. No aggressive selling, no fake urgency.
 2. SHAPE TO THE PROMPT + FRAMING. Follow the prompt (what the post is about) and any goal/audience
    given — a couples/off-peak post and a families/school-break post look different.
-3. GROUND IN REALITY. Pick ONE photo, by exact storagePath, from the provided assets — you can only
-   show what the property really has. Never claim an amenity/experience not evident in the assets.
+3. GROUND IN REALITY, PICK A PHOTO THAT FITS. Pick ONE photo, by exact storagePath, from the provided
+   assets — you can only show what the property really has. Each asset has a rich aiDescription
+   (season, mood, people, features, fitsAngles) from a vision model — use it to pick the photo that
+   truly fits the post's prompt, season, and audience. Never claim an amenity not evident in the assets.
 4. KEEP IT SHORT. A few sentences. Diacritics are fine (this is public brand copy). One or two
    tasteful emoji are OK if they fit.
 
@@ -119,7 +121,7 @@ export async function generatePagePost(
     prompt: input.prompt,
     goal: input.framing?.goal ?? null,
     audience: input.framing?.audience ?? null,
-    assets: input.assets.map((a) => ({ storagePath: a.storagePath, alt: a.alt, tags: a.tags })),
+    assets: input.assets.map((a) => ({ storagePath: a.storagePath, alt: a.alt, tags: a.tags, aiDescription: a.aiDescription })),
   };
   const messages: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
     { role: 'user', content: `Here is the post brief + the available gallery assets. Write ONE organic page post and call emit_page_post.\n\n${JSON.stringify(postPack)}` },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,29 @@ export type MultilingualString = {
   [languageCode: string]: string | undefined;
 };
 
+/**
+ * Rich, vision-generated description of a gallery photo — the AI-readable field the ad/page selectors
+ * reason over to decide if a photo FITS a goal/period/audience (promotion-system-architecture.md §4.2,
+ * ad plan §14.2 `llmDescription`). Produced by `galleryVision.describeImage` (a vision model actually
+ * LOOKS at the image); grounds ONLY in what's visible — never invents amenities. Far richer than
+ * `alt`/`tags`: it captures season, mood, light, features, people, and which marketing angles fit.
+ */
+export interface AiImageDescription {
+  summary: string;            // one line: what the photo shows
+  setting: string;            // exterior | interior | garden | aerial | detail | ...
+  season: string;             // autumn | winter | spring | summer | indeterminate
+  timeOfDay: string;          // day | golden-hour | night | indeterminate
+  mood: string;               // e.g. "cozy, warm", "tranquil", "lively"
+  subjects: string[];         // concrete things visible: "cast-iron cauldron over a fire", "valley view"
+  features: string[];         // amenities/features VISIBLE: "wood-burning stove", "terrace", "bunk beds"
+  people: string;             // none | adults | children | family | mixed
+  activities: string[];       // implied: "outdoor cooking", "kids playing"
+  palette: string[];          // dominant colours: "golden", "warm wood"
+  fitsAngles: string[];       // marketing angles it suits: "romantic", "family", "food-and-fire", "nature", "cozy-winter"
+  model: string;              // provenance — which model described it
+  describedAt: string;        // ISO timestamp
+}
+
 export interface PropertyImage {
   url: string;
   /**
@@ -27,6 +50,8 @@ export interface PropertyImage {
   isFeatured?: boolean;
   'data-ai-hint'?: string; // For AI image generation hints
   tags?: string[]; // For gallery filtering
+  /** Rich vision-generated description for AI ad/post selection (galleryVision.describeImage). */
+  aiDescription?: AiImageDescription;
   sortOrder?: number; // For gallery ordering
   showInGallery?: boolean; // false = hidden from gallery (undefined/true = visible)
   thumbnailUrl?: string; // Resized thumbnail URL from Storage

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -545,6 +545,69 @@ export type AdCampaignStatus =
  * gates activation on); the remaining fields land with Phase 2 campaign
  * creation but are declared now so the shape is stable.
  */
+/**
+ * AdOutcome — the FROZEN learning record for one finished campaign (id == adCampaigns id == utm_campaign).
+ * Written once by `finalizeAdOutcome` at `endTime + settleDays`, so learnings are stable and auditable
+ * rather than drifting as late bookings trickle in. Keeps Meta's MODELED attribution (`metaReported`)
+ * strictly separate from our FIRST-PARTY utm→booking join (`utmAttributed`) — they are different
+ * numbers and must never be conflated (Fable finding). `caveats` carries the machine-readable honesty.
+ */
+export interface AdOutcome {
+  id: string;
+  propertyId: string;
+  capturedAt: SerializableTimestamp;
+  settleDays: number;
+  // ── what we tried (denormalized so it survives later proposal/doc edits) ──
+  window: { start: string; end: string; nights: number } | null;
+  occasion: string | null;
+  goal: string | null;
+  audience: string | null;
+  creativeBrief: string | null;
+  copyCount: number;
+  photos: string[];                 // storagePaths from the proposal
+  cities: Array<{ key?: string; name: string; radius: number }>;
+  dailyBudgetMinor: number;
+  endTime: string;
+  source: 'opportunity-engine' | 'manual';
+  // ── what happened ──
+  finalEffectiveStatus: string;
+  delivery: { spend: number; impressions: number; clicks: number; ctr: number; cpc: number };
+  metaReported: { purchases: number; purchaseValue: number; roas: number };   // Meta MODELED — not first-party
+  utmAttributed: { bookings: number; revenue: number; bookingIds: string[] }; // FIRST-PARTY utm→booking join (a floor)
+  verdict: 'converted' | 'clicked-no-booking' | 'no-delivery' | 'rejected' | 'never-activated';
+  caveats: string[];
+}
+
+/**
+ * AdLearnings — the compact "weak priors" block added to the ad-planner pack (Fable §1.5). RAW rows +
+ * the statistical METHOD, never conclusions/"winner" labels — the same facts+method+constraints
+ * discipline as the rest of the pack, which is also exactly the right small-n statistics. `available`
+ * is false until the first outcome exists (ships dark, prompts no-op).
+ */
+export interface AdLearnings {
+  available: boolean;
+  campaignsCompleted: number;
+  totals: { spend: number; impressions: number; clicks: number; utmBookings: number; utmRevenue: number };
+  campaigns: Array<{
+    occasion: string | null;
+    goal: string | null;
+    audience: string | null;
+    window: string;
+    cities: string[];
+    spend: number;
+    impressions: number;
+    clicks: number;
+    ctr: number;
+    cpc: number;
+    metaPurchases: number;
+    utmBookings: number;
+    utmRevenue: number;
+    verdict: AdOutcome['verdict'];
+    angle: string;                  // creativeBrief, truncated
+  }>;
+  note: string;                     // the statistical contract, shipped verbatim to the LLM
+}
+
 export interface AdCampaign {
   id: string;
   propertyId: string;


### PR DESCRIPTION
Makes the ad system genuinely intelligent about photos and past performance (Fable-designed the learning loop + generation strategy; this ships the two testable pieces).

## Vision photo descriptions
The AI-readable image field the architecture planned (§14.2) but never built. A vision model LOOKS at each gallery photo and records a structured `aiDescription` {summary, setting, season, timeOfDay, mood, subjects, features, people, activities, palette, fitsAngles}, grounded only in what's visible. The ad + page selectors reason over it → photo choice is tight to goal/season/audience. All 42 Prahova photos backfilled. Proven live: an autumn ad now picks "the true autumn exteriors" and "avoided the summer-garden assets."

## The learning loop
The system now learns from past campaigns. A finished campaign's outcome freezes into `adOutcomes` at endTime+settle (first-party utm→booking join kept strictly separate from Meta's modeled number), and `buildAdLearnings` feeds those back to the planner as WEAK PRIORS with the small-n statistical method (CTR/CPC = signal; bookings = anecdote at low n) — never "winner" conclusions. Ships dark: `available:false` until the first outcome.

## Safety
No new spend/auto-publish path. Vision runs offline (backfill); the learning loop is read-mostly and dark. Firestore rules + index for `adOutcomes` deployed.

## Tested
210 growth tests pass; build clean; live: season-aware selection proven, pack carries learnings (available:false) + aiDescription.

## Deferred (Fable-designed, documented, needs a live Meta spike)
Per-asset Dynamic-Creative breakdown (per-photo learning); the generation gateway (Advantage+ enrollment + external relight/populate-people).

🤖 Generated with [Claude Code](https://claude.com/claude-code)