### PR TITLE
Self-maintaining vision + missing-shot generation guidance

### DIFF
--- a/scripts/ad-creative.ts
+++ b/scripts/ad-creative.ts
@@ -81,6 +81,10 @@ const short = (p: string) => p.split('/').pop();
     });
     console.log(`\nphotos (${c.assetPaths.length}): ${c.assetPaths.map(short).join(', ')}`);
     if (c.notes) console.log(`notes: ${c.notes}`);
+    if (c.assetGaps?.length) {
+      console.log(`\nMISSING SHOTS (${c.assetGaps.length}):`);
+      c.assetGaps.forEach((g) => console.log(`  - [${g.transform}] ${g.need}\n    nearest: ${short(g.nearestAssetPath)} — ${g.whyInsufficient}`));
+    }
   }
   if (creative.warnings.length) console.log(`\n⚠ ${creative.warnings.join(' · ')}`);
   if (!creative.ok) console.log(`\n✖ ${creative.errors.join(' · ')}`);

--- a/src/app/admin/ads/_components/ad-detail-panel.tsx
+++ b/src/app/admin/ads/_components/ad-detail-panel.tsx
@@ -35,6 +35,7 @@ import { approveAdAction, activateAdAction, pauseAdAction, refreshAdInsightsActi
 
 /** The AI proposal (copy + photos + geo + rationale) shown for in-console review when a draft was drafted by the Opportunity Engine. */
 function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal']> }) {
+  const { toast } = useToast();
   return (
     <Card>
       <CardHeader>
@@ -109,6 +110,45 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
               {proposal.rationale}
             </p>
           </details>
+        )}
+
+        {(proposal.assetGaps?.length ?? 0) > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-amber-700">
+              Missing shots the AI wanted ({proposal.assetGaps!.length}) — generate these & upload, and they self-describe
+            </p>
+            {proposal.assetGaps!.map((g, i) => (
+              <div key={i} className="rounded-md border border-amber-200 bg-amber-50/40 p-2 text-xs">
+                <p className="font-medium">
+                  {g.need}
+                  <Badge variant="outline" className="ml-1 text-[10px]">{g.transform}</Badge>
+                </p>
+                <p className="mt-0.5 text-muted-foreground">{g.whyInsufficient}</p>
+                <div className="mt-2 flex items-start gap-2">
+                  {g.nearestAssetUrl && (
+                    <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded border" title="Edit this base photo">
+                      <Image src={g.nearestAssetUrl} alt="" fill className="object-cover" sizes="56px" />
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="mb-1 text-[10px] text-muted-foreground">Paste into your image-AI, using the photo on the left as the base:</p>
+                    <code className="block whitespace-pre-wrap rounded bg-muted p-1.5 text-[10px] leading-snug">{g.generationPrompt}</code>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="mt-1 h-6 text-[10px]"
+                      onClick={() => {
+                        void navigator.clipboard?.writeText(g.generationPrompt);
+                        toast({ title: 'Prompt copied' });
+                      }}
+                    >
+                      Copy prompt
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -45,6 +45,7 @@ import { resolveAdContext } from '@/services/growth/metaAds/adContext';
 import { searchCities, type CityMatch } from '@/services/growth/metaAds/geo';
 import { deleteResource } from '@/services/growth/metaAds/client';
 import { proposeAd } from '@/services/growth/adProposal';
+import { buildGenerationPrompt } from '@/lib/growth/generationPrompt';
 import type { AdOpportunity } from '@/lib/growth/contracts';
 
 const logger = loggers.ads;
@@ -531,7 +532,17 @@ export async function generateAdProposalAction(input: {
     const propDoc = await db.collection('properties').doc(input.propertyId).get();
     const images = (propDoc.data()?.images ?? []) as PropertyImage[];
     const urlByPath = new Map(images.filter((i) => i.storagePath).map((i) => [i.storagePath!, i.thumbnailUrl || i.url]));
+    const descByPath = new Map(images.filter((i) => i.storagePath).map((i) => [i.storagePath!, i.aiDescription?.summary ?? '']));
     const photos = res.creative.assetPaths.map((storagePath) => ({ storagePath, url: urlByPath.get(storagePath) ?? '' }));
+    // Missing-shot gaps the copywriter declared → each with a ready generation prompt (manual-gen v1).
+    const assetGaps = (res.creative.assetGaps ?? []).map((g) => ({
+      need: g.need,
+      nearestAssetPath: g.nearestAssetPath,
+      nearestAssetUrl: urlByPath.get(g.nearestAssetPath) ?? '',
+      whyInsufficient: g.whyInsufficient,
+      transform: g.transform,
+      generationPrompt: buildGenerationPrompt(g.transform, g.need, descByPath.get(g.nearestAssetPath) ?? ''),
+    }));
 
     await db.collection('adCampaigns').doc(res.draft.adCampaignId).update({
       proposal: {
@@ -549,6 +560,7 @@ export async function generateAdProposalAction(input: {
         cities: res.brief.targeting.cities.map((c) => ({ name: c.name, radius: c.radius })),
         creativeBrief: res.brief.creativeBrief,
         rationale: res.brief.rationale,
+        assetGaps,
       },
       updatedAt: FieldValue.serverTimestamp(),
     });

--- a/src/app/api/cron/caption-gallery/route.ts
+++ b/src/app/api/cron/caption-gallery/route.ts
@@ -1,0 +1,42 @@
+/**
+ * caption-gallery cron — keep the vision `aiDescription` layer current as the gallery grows. It
+ * describes any gallery photo that lacks an aiDescription (i.e. a newly uploaded one), across all
+ * properties, so the ad/page photo-selectors always reason over a fully-described catalog without
+ * anyone running a script. Bounded per run (cost guard); idempotent (skips already-described).
+ *
+ * Intended cadence: daily via Cloud Scheduler (GET). Auth: Cloud Scheduler header or a Bearer token.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { captionUndescribedImages } from '@/services/growth/galleryVision';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.ads;
+
+/** Cap images described per run so one cron invocation stays bounded (new uploads are few). */
+const PER_RUN_LIMIT = 30;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  const cronHeader = request.headers.get('X-Appengine-Cron');
+  if (!cronHeader && !authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const db = await getAdminDb();
+    const props = await db.collection('properties').get();
+    let described = 0;
+    let remaining = PER_RUN_LIMIT;
+    for (const doc of props.docs) {
+      if (remaining <= 0) break;
+      const res = await captionUndescribedImages(doc.id, { limit: remaining });
+      described += res.described;
+      remaining -= res.described;
+    }
+    logger.info('caption-gallery cron ran', { described });
+    return NextResponse.json({ ok: true, described });
+  } catch (error) {
+    logger.error('caption-gallery cron failed', error as Error);
+    return NextResponse.json({ ok: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/lib/growth/__tests__/generationPrompt.test.ts
+++ b/src/lib/growth/__tests__/generationPrompt.test.ts
@@ -1,0 +1,24 @@
+/** @jest-environment node */
+
+import { buildGenerationPrompt } from '../generationPrompt';
+
+describe('buildGenerationPrompt', () => {
+  it('splices the need into a fixed skeleton and always includes the never-invent guardrail', () => {
+    const p = buildGenerationPrompt('seasonal', 'winter snow on the ground and trees', 'A wood chalet among green trees');
+    expect(p).toContain('winter snow on the ground and trees');
+    expect(p).toContain('A wood chalet among green trees'); // the base summary
+    expect(p).toMatch(/do not add, remove, or alter/i); // the guardrail
+    expect(p).toMatch(/season\/weather/i); // the seasonal skeleton
+  });
+
+  it('uses a distinct skeleton per transform', () => {
+    expect(buildGenerationPrompt('relight', 'golden-hour light', 's')).toMatch(/lighting\/time-of-day/i);
+    expect(buildGenerationPrompt('populate_people', 'a family cooking', 's')).toMatch(/add people/i);
+  });
+
+  it('degrades gracefully with no base summary', () => {
+    const p = buildGenerationPrompt('relight', 'sunset', '');
+    expect(p).toContain('Edit the attached base photo');
+    expect(p).toMatch(/do not add, remove, or alter/i);
+  });
+});

--- a/src/lib/growth/generationPrompt.ts
+++ b/src/lib/growth/generationPrompt.ts
@@ -1,0 +1,36 @@
+/**
+ * generationPrompt — build a GUARDED image-generation prompt from an asset gap (Fable §2.3). The
+ * prompt is assembled from a FIXED skeleton per transform, with the requester's need spliced inside —
+ * a free-form instruction never becomes the whole prompt. The hard rule in every skeleton: edit only
+ * the requested aspect of a REAL base photo; never add, remove, or invent rooms, structures, or
+ * amenities. This is the same guardrail the (future) generation gateway will enforce in code; here it
+ * produces a ready-to-paste prompt for the operator's own image-AI (manual-generation v1).
+ *
+ * Pure — no imports beyond the type.
+ */
+import type { AdAssetGap } from '@/types';
+
+const NEVER = 'Do NOT add, remove, or alter any rooms, buildings, structures, furniture, or amenities — keep the exact same scene, layout, and viewpoint. Only a natural, realistic edit; no text, no logos, no watermarks.';
+
+/**
+ * Compose the generation prompt for a gap. `baseSummary` is the nearest real photo's one-line
+ * description (from its aiDescription) so the operator/model knows what it is editing.
+ */
+export function buildGenerationPrompt(
+  transform: AdAssetGap['transform'],
+  need: string,
+  baseSummary: string
+): string {
+  const base = baseSummary ? `Base photo (edit THIS image): ${baseSummary}.` : 'Edit the attached base photo.';
+  const want = need.trim();
+  switch (transform) {
+    case 'relight':
+      return `${base}\nChange ONLY the lighting/time-of-day to achieve: ${want}. ${NEVER}`;
+    case 'seasonal':
+      return `${base}\nChange ONLY the season/weather to: ${want} (e.g. autumn golden foliage, or winter snow on the ground and trees). Alter only seasonal elements — trees, ground, sky, light. ${NEVER}`;
+    case 'populate_people':
+      return `${base}\nAdd people naturally ${want}, placed believably within THIS exact scene at a realistic scale. Candid, not posed; no faces in sharp focus. ${NEVER}`;
+    default:
+      return `${base}\n${want}. ${NEVER}`;
+  }
+}

--- a/src/lib/growth/validateAdCreative.ts
+++ b/src/lib/growth/validateAdCreative.ts
@@ -41,6 +41,8 @@ export interface AdCreativeForValidation {
   copy: CopyVariant[];
   /** The chosen photo storagePaths — a SUBSET of the pack's assetPaths. */
   assetPaths: string[];
+  /** Declared missing-photo gaps — each must anchor to a REAL offered photo (never-invent applies to gaps too). */
+  assetGaps?: Array<{ nearestAssetPath: string }>;
 }
 
 export interface AdCreativeValidationResult {
@@ -103,6 +105,11 @@ export function validateAdCreative(
 
   const dupPhoto = [...new Set(chosen.filter((p, i) => chosen.indexOf(p) !== i))];
   if (dupPhoto.length) errors.push(`the same photo selected more than once — Meta rejects duplicate images in asset_feed_spec`);
+
+  // ── gaps ── a declared gap must anchor to a REAL offered photo (never invent a scene).
+  for (const g of creative.assetGaps ?? []) {
+    if (!available.has(g.nearestAssetPath)) errors.push(`assetGap.nearestAssetPath is not a real offered photo: ${g.nearestAssetPath}`);
+  }
 
   return { ok: errors.length === 0, errors, warnings };
 }

--- a/src/services/growth/adCopywriter.ts
+++ b/src/services/growth/adCopywriter.ts
@@ -54,6 +54,20 @@ const AD_CREATIVE_TOOL = {
         description: 'the chosen photos, by EXACT storagePath from the pack\'s assets — 1-6 that carry the brief\'s themes (favor variety: exterior / interior / lifestyle). Never invent a path.',
         items: { type: 'string' },
       },
+      assetGaps: {
+        type: 'array',
+        description: 'ONLY when a theme the brief genuinely needs has NO fitting real photo in the assets. Do NOT skip real photos to force a gap. Each: what is missing, the nearest real asset (exact storagePath), why it falls short, and the transform that would fix it.',
+        items: {
+          type: 'object',
+          properties: {
+            need: { type: 'string', description: 'the missing shot, e.g. "a family at the fire pit at winter dusk"' },
+            nearestAssetPath: { type: 'string', description: 'the nearest REAL offered storagePath — the base photo to edit' },
+            whyInsufficient: { type: 'string', description: 'why that nearest photo does not fully work' },
+            transform: { type: 'string', enum: ['relight', 'populate_people', 'seasonal'], description: 'the edit that would fix it' },
+          },
+          required: ['need', 'nearestAssetPath', 'whyInsufficient', 'transform'],
+        },
+      },
       notes: { type: 'string', description: 'brief note on the creative choices (optional).' },
     },
     required: ['copy', 'assetPaths'],
@@ -84,12 +98,24 @@ THE RULES
    Dynamic Creative has range. CTA: 'learn_more' unless 'book_now' clearly fits.
 4. DIRECT BOOKING. The destination is the property's own site — a light nudge to book direct is good,
    but the ad's job is to earn the click, not to close.
+5. DECLARE MISSING SHOTS (only real gaps). If a theme the brief genuinely needs has NO fitting real
+   photo, STILL pick the best real photos for assetPaths, AND add an assetGaps entry: what is missing,
+   the nearest real photo (its storagePath), why it falls short, and the transform (relight/seasonal/
+   populate_people). Never skip real photos to force a gap, and never invent a scene — the gap always
+   points at a real photo to edit.
 
 Return the creative by calling emit_ad_creative. Nothing else.`;
 
+export interface RawAssetGap {
+  need: string;
+  nearestAssetPath: string;
+  whyInsufficient: string;
+  transform: 'relight' | 'populate_people' | 'seasonal';
+}
+
 export interface GenerateAdCreativeResult {
   ok: boolean;
-  creative: { copy: CopyVariant[]; assetPaths: string[]; notes?: string } | null;
+  creative: { copy: CopyVariant[]; assetPaths: string[]; notes?: string; assetGaps?: RawAssetGap[] } | null;
   errors: string[];
   warnings: string[];
   attempts: number;
@@ -99,6 +125,7 @@ interface EmitAdCreativeInput {
   copy: CopyVariant[];
   assetPaths: string[];
   notes?: string;
+  assetGaps?: RawAssetGap[];
 }
 
 /**
@@ -150,10 +177,10 @@ export async function generateAdCreative(
     const input = toolUse?.input;
     const toolUseId = toolUse?.id;
 
-    creative = input ? { copy: input.copy ?? [], assetPaths: input.assetPaths ?? [], notes: input.notes } : null;
+    creative = input ? { copy: input.copy ?? [], assetPaths: input.assetPaths ?? [], notes: input.notes, assetGaps: input.assetGaps ?? [] } : null;
 
     const v = creative
-      ? validateAdCreative(validationPack, { copy: creative.copy, assetPaths: creative.assetPaths })
+      ? validateAdCreative(validationPack, { copy: creative.copy, assetPaths: creative.assetPaths, assetGaps: creative.assetGaps })
       : { ok: false, errors: ['the model returned no creative'], warnings: [] };
     lastValidation = { ok: v.ok, errors: v.errors, warnings: v.warnings };
     logger.info('adCopywriter generateAdCreative attempt', { attempt, variants: creative?.copy.length, photos: creative?.assetPaths.length, ok: v.ok, errors: v.errors.length });

--- a/src/services/growth/adProposal.ts
+++ b/src/services/growth/adProposal.ts
@@ -17,7 +17,7 @@
  */
 import { buildAdPlannerPack } from '@/lib/growth/adPlannerPack';
 import { generateAdPlan } from './adPlanner';
-import { generateAdCreative } from './adCopywriter';
+import { generateAdCreative, type RawAssetGap } from './adCopywriter';
 import { composeAndCreateAd } from './adComposer';
 import type { AdOpportunity, AdBrief, AdFraming } from '@/lib/growth/contracts';
 import type { ComposeAndCreateAdInput, CopyVariant } from '@/types';
@@ -33,7 +33,7 @@ export interface AdProposalResult {
   /** The planner chose NOT to act (weak opportunity). `ok:true`, no draft created. */
   declined: boolean;
   brief?: AdBrief;
-  creative?: { copy: CopyVariant[]; assetPaths: string[]; notes?: string };
+  creative?: { copy: CopyVariant[]; assetPaths: string[]; notes?: string; assetGaps?: RawAssetGap[] };
   /** The created PAUSED draft ids (present only on a full success). */
   draft?: { adCampaignId: string; metaCampaignId: string; metaAdSetId: string; metaAdId: string; creativeId: string };
   errors: string[];

--- a/src/services/growth/galleryVision.ts
+++ b/src/services/growth/galleryVision.ts
@@ -10,6 +10,7 @@
  * Server-only. Throws if ANTHROPIC_API_KEY is absent.
  */
 import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import { loggers } from '@/lib/logger';
 import type { AiImageDescription } from '@/types';
 
 /** Vision-capable media types the Anthropic API accepts. */
@@ -98,4 +99,46 @@ export function mediaTypeFromUrl(url: string): SupportedMediaType {
   if (u.includes('.webp')) return 'image/webp';
   if (u.includes('.gif')) return 'image/gif';
   return 'image/jpeg';
+}
+
+/**
+ * Describe every gallery photo that has a storagePath but no `aiDescription` yet, and save it back —
+ * so a NEWLY uploaded image gets a rich description without anyone running a script (called by the
+ * caption-gallery cron and available as an on-demand admin action). Writes after each image so it's
+ * resumable; never throws per image. Returns how many were described. `getAdminDb` is imported lazily
+ * to keep this module client-safe at type level (the Anthropic call is the only hard server dep).
+ */
+export async function captionUndescribedImages(
+  propertyId: string,
+  opts?: { force?: boolean; limit?: number }
+): Promise<{ described: number; pending: number; total: number }> {
+  const { getAdminDb } = await import('@/lib/firebaseAdminSafe');
+  const db = await getAdminDb();
+  const ref = db.collection('properties').doc(propertyId);
+  const snap = await ref.get();
+  if (!snap.exists) return { described: 0, pending: 0, total: 0 };
+  const images = (snap.data()?.images ?? []) as Array<{ url?: string; storagePath?: string; aiDescription?: unknown }>;
+
+  const todo = images
+    .map((img, idx) => ({ img, idx }))
+    .filter(({ img }) => img.storagePath && (opts?.force || !img.aiDescription))
+    .slice(0, opts?.limit ?? Infinity);
+
+  let described = 0;
+  for (const { img, idx } of todo) {
+    if (!img.url) continue;
+    try {
+      const res = await fetch(img.url);
+      if (!res.ok) continue;
+      const bytes = Buffer.from(await res.arrayBuffer());
+      const desc = await describeImage(bytes.toString('base64'), mediaTypeFromUrl(img.url));
+      if (!desc) continue;
+      images[idx] = { ...img, aiDescription: desc };
+      await ref.update({ images }); // write-after-each → resumable
+      described += 1;
+    } catch (error) {
+      loggers.ads.warn('captionUndescribedImages: failed for one image (continuing)', { propertyId, idx, error: String(error) });
+    }
+  }
+  return { described, pending: todo.length, total: images.length };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -608,6 +608,22 @@ export interface AdLearnings {
   note: string;                     // the statistical contract, shipped verbatim to the LLM
 }
 
+/**
+ * A photo the copywriter WANTED for a theme the brief needs but the gallery can't supply (Fable §2.1).
+ * It always anchors to the nearest REAL photo (never "invent a scene"), and carries a ready-to-paste
+ * generation prompt so the operator can produce it in their own image-AI and upload the result (which
+ * then gets auto-described). The manual-generation v1 — the honest "the system tells you what's
+ * missing and how to make it" flow, before any paid generation gateway exists.
+ */
+export interface AdAssetGap {
+  need: string;                    // what's missing, e.g. "a family at the fire pit at winter dusk"
+  nearestAssetPath: string;        // a REAL offered gallery storagePath — the base to edit
+  nearestAssetUrl?: string;        // for the review preview
+  whyInsufficient: string;         // why the nearest real photo falls short
+  transform: 'relight' | 'populate_people' | 'seasonal';
+  generationPrompt: string;        // guarded, ready to paste into an image-AI (built server-side)
+}
+
 export interface AdCampaign {
   id: string;
   propertyId: string;
@@ -658,6 +674,8 @@ export interface AdCampaign {
     cities: Array<{ name: string; radius: number }>;
     creativeBrief: string;
     rationale: string;
+    /** Photos the AI wanted but the gallery lacks — each with a ready generation prompt (manual-gen v1). */
+    assetGaps?: AdAssetGap[];
   };
   lastSyncedAt?: SerializableTimestamp;
   createdAt?: SerializableTimestamp;


### PR DESCRIPTION
Closes two operational gaps so the photo intelligence stays current and actionable from the console.

- **Auto-caption**: `captionUndescribedImages` + `/api/cron/caption-gallery` (daily) — a newly uploaded photo gets a vision `aiDescription` automatically, so the selectors always see a fully-described catalog. (Owner: schedule the cron.)
- **Missing-shot guidance**: the copywriter declares `assetGaps` (what's missing + nearest real photo + why + transform); the proposal persists each with a guarded, ready-to-paste **generation prompt**, shown in `/admin/ads` review with a Copy button + the base photo. Manual-generation v1 — the system tells you what to make and how; you generate + upload; it self-describes. Every gap is validated to anchor to a real photo (never invent a scene).

Proven live (winter framing): picked the one true winter photo, avoided summer/couples shots, declared 2 gaps (chalet-under-snow, family-at-fireplace) anchored to the nearest real photos.

213 growth tests pass; build clean. Ships dark (no auto-spend/publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)