### PR TITLE
feat: page-posts admin (manual organic posting) + ad-propose --keep review

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -124,6 +124,14 @@
         { "fieldPath": "propertyId", "order": "ASCENDING" },
         { "fieldPath": "capturedAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "pagePosts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -267,6 +267,12 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only (written by finalizeAdOutcome)
     }
 
+    match /pagePosts/{postId} {
+      // Drafted organic page posts (manual-post flow) — super-admin/owner read.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (page-posts server actions)
+    }
+
     match /adImageCache/{cacheId} {
       // Per-(platform, ad account, content hash) image-hash dedup cache
       // (Phase 2a Build A) — no user-facing write path exists.

--- a/scripts/ad-propose.ts
+++ b/scripts/ad-propose.ts
@@ -68,7 +68,33 @@ const opportunity: AdOpportunity = {
     console.log(`draft ids: adCampaign=${res.draft.adCampaignId} campaign=${res.draft.metaCampaignId} adset=${res.draft.metaAdSetId} ad=${res.draft.metaAdId} creative=${res.draft.creativeId}`);
 
     if (keep) {
-      console.log('\n--keep: PAUSED draft left in place for inspection (remember to delete it in Ads Manager / Firestore).');
+      // Persist the proposal blob so /admin/ads/[id] shows the full review (mirrors generateAdProposalAction).
+      const { getAdminDb, FieldValue } = await import('@/lib/firebaseAdminSafe');
+      const { buildGenerationPrompt } = await import('@/lib/growth/generationPrompt');
+      const db = await getAdminDb();
+      const propDoc = await db.collection('properties').doc(property).get();
+      const imgs = (propDoc.data()?.images ?? []) as Array<{ storagePath?: string; url?: string; thumbnailUrl?: string; aiDescription?: { summary?: string } }>;
+      const urlBy = new Map(imgs.filter((i) => i.storagePath).map((i) => [i.storagePath!, i.thumbnailUrl || i.url || '']));
+      const descBy = new Map(imgs.filter((i) => i.storagePath).map((i) => [i.storagePath!, i.aiDescription?.summary ?? '']));
+      const b = res.brief!;
+      const c = res.creative!;
+      const photos = c.assetPaths.map((sp) => ({ storagePath: sp, url: urlBy.get(sp) ?? '' }));
+      const assetGaps = (c.assetGaps ?? []).map((g) => ({
+        need: g.need, nearestAssetPath: g.nearestAssetPath, nearestAssetUrl: urlBy.get(g.nearestAssetPath) ?? '',
+        whyInsufficient: g.whyInsufficient, transform: g.transform,
+        generationPrompt: buildGenerationPrompt(g.transform, g.need, descBy.get(g.nearestAssetPath) ?? ''),
+      }));
+      await db.collection('adCampaigns').doc(res.draft.adCampaignId).update({
+        proposal: {
+          source: 'opportunity-engine',
+          occasion: { name: b.opportunity.occasion?.name ?? null, start: b.opportunity.window.start, end: b.opportunity.window.end, nights: b.opportunity.window.nights },
+          goal: framing.goal ?? null, audience: framing.audience ?? null,
+          copy: c.copy, photos, cities: b.targeting.cities.map((city) => ({ name: city.name, radius: city.radius })),
+          creativeBrief: b.creativeBrief, rationale: b.rationale, assetGaps,
+        },
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      console.log(`\n--keep: PAUSED draft + proposal persisted (zero spend). Review at /admin/ads/${res.draft.adCampaignId}`);
     } else {
       console.log('\nself-cleaning (zero spend was possible — everything was PAUSED)…');
       const ctx = await resolveAdContext(property);

--- a/src/app/admin/page-posts/_components/page-post-console.tsx
+++ b/src/app/admin/page-posts/_components/page-post-console.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+/**
+ * Page-post console — generate a warm organic post, review it, and post it BY HAND (copy the caption,
+ * open the photo, post from your own account, mark it done). Ban-safe, no page-scope needed. Mirrors
+ * the ads generate flow + the wa.me manual-send philosophy.
+ */
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Sparkles, Copy, ExternalLink, Check, Trash2 } from 'lucide-react';
+import { generatePagePostAction, markPagePostedAction, discardPagePostAction } from '../actions';
+
+interface PagePost {
+  id: string;
+  message: string;
+  assetPath: string;
+  assetUrl: string;
+  status: string;
+  goal?: string | null;
+  audience?: string | null;
+}
+
+export function PagePostConsole({ propertyId, initialPosts }: { propertyId: string; initialPosts: PagePost[] }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [generating, startGenerate] = useTransition();
+
+  const [prompt, setPrompt] = useState('');
+  const [goal, setGoal] = useState('');
+  const [audience, setAudience] = useState('');
+  const [edited, setEdited] = useState<Record<string, string>>({});
+  const [pending, setPending] = useState<Set<string>>(new Set());
+
+  const generate = () => {
+    if (!prompt.trim()) {
+      toast({ title: 'Add a prompt', description: 'What should the post be about?', variant: 'destructive' });
+      return;
+    }
+    startGenerate(async () => {
+      const res = await generatePagePostAction({ propertyId, prompt: prompt.trim(), goal: goal.trim() || undefined, audience: audience.trim() || undefined });
+      if (res.ok) {
+        toast({ title: 'Post drafted', description: 'Review it below, then post it by hand.' });
+        setPrompt('');
+        router.refresh();
+      } else {
+        toast({ title: 'Could not generate', description: res.error, variant: 'destructive' });
+      }
+    });
+  };
+
+  const withPending = async (id: string, fn: () => Promise<void>) => {
+    setPending((p) => new Set(p).add(id));
+    await fn();
+    setPending((p) => {
+      const n = new Set(p);
+      n.delete(id);
+      return n;
+    });
+  };
+
+  const markPosted = (post: PagePost) =>
+    withPending(post.id, async () => {
+      const res = await markPagePostedAction(post.id, edited[post.id] ?? post.message);
+      if (res.ok) {
+        toast({ title: 'Marked posted' });
+        router.refresh();
+      } else {
+        toast({ title: 'Could not update', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  const discard = (id: string) =>
+    withPending(id, async () => {
+      const res = await discardPagePostAction(id);
+      if (res.ok) router.refresh();
+      else toast({ title: 'Could not discard', description: res.error, variant: 'destructive' });
+    });
+
+  const drafts = initialPosts.filter((p) => p.status !== 'posted');
+  const posted = initialPosts.filter((p) => p.status === 'posted');
+
+  return (
+    <div className="space-y-6">
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-muted-foreground" /> New page post
+          </CardTitle>
+          <CardDescription>Say what the post is about; the engine writes a warm caption in your voice and picks a fitting real photo.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="prompt">What&apos;s the post about?</Label>
+            <Textarea id="prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={2} placeholder="e.g. Early-autumn hello — golden leaves, quiet mornings, the fire pit ready for cool evenings" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <Label htmlFor="goal">Goal (optional)</Label>
+              <Input id="goal" value={goal} onChange={(e) => setGoal(e.target.value)} placeholder="e.g. keep the page warm" />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="audience">Audience (optional)</Label>
+              <Input id="audience" value={audience} onChange={(e) => setAudience(e.target.value)} placeholder="e.g. couples who love the outdoors" />
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button onClick={generate} disabled={generating}>
+            {generating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Sparkles className="mr-2 h-4 w-4" />}
+            Generate post
+          </Button>
+        </CardFooter>
+      </Card>
+
+      {drafts.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-medium">Drafts — post these by hand</h3>
+          {drafts.map((post) => {
+            const busy = pending.has(post.id);
+            const text = edited[post.id] ?? post.message;
+            return (
+              <Card key={post.id}>
+                <CardContent className="grid gap-4 pt-6 sm:grid-cols-[160px_1fr]">
+                  {post.assetUrl ? (
+                    <div className="relative aspect-square overflow-hidden rounded-md border">
+                      <Image src={post.assetUrl} alt="" fill className="object-cover" sizes="160px" />
+                    </div>
+                  ) : (
+                    <div className="flex aspect-square items-center justify-center rounded-md border text-xs text-muted-foreground">no preview</div>
+                  )}
+                  <div className="space-y-2">
+                    <Textarea value={text} onChange={(e) => setEdited((prev) => ({ ...prev, [post.id]: e.target.value }))} rows={5} className="text-sm" />
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button size="sm" variant="outline" onClick={() => { void navigator.clipboard?.writeText(text); toast({ title: 'Caption copied' }); }}>
+                        <Copy className="mr-1 h-3.5 w-3.5" /> Copy caption
+                      </Button>
+                      {post.assetUrl && (
+                        <a href={post.assetUrl} target="_blank" rel="noopener noreferrer">
+                          <Button size="sm" variant="outline">
+                            <ExternalLink className="mr-1 h-3.5 w-3.5" /> Open photo
+                          </Button>
+                        </a>
+                      )}
+                      <Button size="sm" onClick={() => markPosted(post)} disabled={busy}>
+                        {busy ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Check className="mr-1 h-3.5 w-3.5" />} Mark posted
+                      </Button>
+                      <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => discard(post.id)} disabled={busy}>
+                        <Trash2 className="mr-1 h-3.5 w-3.5" /> Discard
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {posted.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-muted-foreground">Posted</h3>
+          {posted.map((post) => (
+            <div key={post.id} className="flex items-center gap-3 rounded-md border bg-muted/30 p-2 text-sm">
+              {post.assetUrl && (
+                <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded border">
+                  <Image src={post.assetUrl} alt="" fill className="object-cover" sizes="40px" />
+                </div>
+              )}
+              <p className="line-clamp-2 flex-1 text-muted-foreground">{post.message}</p>
+              <Badge variant="outline" className="text-emerald-700">
+                <Check className="mr-1 h-3 w-3" /> posted
+              </Badge>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/page-posts/actions.ts
+++ b/src/app/admin/page-posts/actions.ts
@@ -1,0 +1,132 @@
+'use server';
+
+/**
+ * Page-posts operator surface (promotion-system-architecture.md §4.3). The organic-page arm's
+ * console: generate a warm, grounded page post (caption + a real photo), then post it BY HAND (copy
+ * the caption, open the photo) — the same ban-safe manual philosophy as the wa.me WhatsApp flow. The
+ * server drafts; it never publishes (API auto-publish needs the owner's page-scope grant — deferred).
+ *
+ * `'use server'` files may only export async functions — return shapes are inline.
+ */
+import { revalidatePath } from 'next/cache';
+import { loggers } from '@/lib/logger';
+import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { convertTimestampsToISOStrings } from '@/lib/utils';
+import { serverTranslateContent } from '@/lib/server-language-utils';
+import { generatePagePost } from '@/services/growth/pagePostWriter';
+import type { PropertyImage } from '@/types';
+
+const logger = loggers.ads;
+
+/** Generate a draft organic page post for review + manual posting. */
+export async function generatePagePostAction(input: {
+  propertyId: string;
+  prompt: string;
+  goal?: string;
+  audience?: string;
+}): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+  if (!input.prompt.trim()) return { ok: false, error: 'a prompt is required' };
+  try {
+    const db = await getAdminDb();
+    const propDoc = await db.collection('properties').doc(input.propertyId).get();
+    if (!propDoc.exists) return { ok: false, error: 'property-not-found' };
+    const images = (propDoc.data()?.images ?? []) as PropertyImage[];
+    const ownPrefix = `properties/${input.propertyId}/`;
+    const assets = images
+      .filter((i): i is PropertyImage & { storagePath: string } => Boolean(i.storagePath?.startsWith(ownPrefix)))
+      .map((i) => ({ storagePath: i.storagePath, alt: serverTranslateContent(i.alt, 'en'), tags: i.tags ?? [], aiDescription: i.aiDescription }));
+    if (!assets.length) return { ok: false, error: 'no gallery photos for this property' };
+
+    const framing = { goal: input.goal?.trim() || undefined, audience: input.audience?.trim() || undefined };
+    const res = await generatePagePost({ propertyId: input.propertyId, prompt: input.prompt.trim(), assets, framing });
+    if (!res.ok || !res.post) return { ok: false, error: res.errors.join('; ') || 'generation-failed' };
+
+    const urlByPath = new Map(images.filter((i) => i.storagePath).map((i) => [i.storagePath!, i.url]));
+    const ref = db.collection('pagePosts').doc();
+    await ref.set({
+      propertyId: input.propertyId,
+      prompt: input.prompt.trim(),
+      goal: framing.goal ?? null,
+      audience: framing.audience ?? null,
+      message: res.post.message,
+      assetPath: res.post.assetPath,
+      assetUrl: urlByPath.get(res.post.assetPath) ?? '',
+      status: 'draft',
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    revalidatePath('/admin/page-posts');
+    return { ok: true, id: ref.id };
+  } catch (error) {
+    logger.error('generatePagePostAction failed', error as Error, { propertyId: input.propertyId });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+/** List a property's page posts (drafts + posted), newest first. */
+export async function fetchPagePostsAction(propertyId: string): Promise<
+  Array<{ id: string; message: string; assetPath: string; assetUrl: string; status: string; prompt?: string; goal?: string | null; audience?: string | null; createdAt?: string }>
+> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return [];
+    throw error;
+  }
+  try {
+    const db = await getAdminDb();
+    const snap = await db.collection('pagePosts').where('propertyId', '==', propertyId).orderBy('createdAt', 'desc').limit(50).get();
+    return snap.docs.map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as never);
+  } catch (error) {
+    logger.error('fetchPagePostsAction failed', error as Error, { propertyId });
+    return [];
+  }
+}
+
+/** Mark a post as posted (the operator posted it by hand). Optionally records the final edited text. */
+export async function markPagePostedAction(id: string, finalText?: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+  try {
+    const db = await getAdminDb();
+    await db.collection('pagePosts').doc(id).update({
+      status: 'posted',
+      postedAt: FieldValue.serverTimestamp(),
+      ...(finalText ? { message: finalText } : {}),
+    });
+    revalidatePath('/admin/page-posts');
+    return { ok: true };
+  } catch (error) {
+    logger.error('markPagePostedAction failed', error as Error, { id });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+/** Delete a draft page post. */
+export async function discardPagePostAction(id: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+  try {
+    const db = await getAdminDb();
+    await db.collection('pagePosts').doc(id).delete();
+    revalidatePath('/admin/page-posts');
+    return { ok: true };
+  } catch (error) {
+    logger.error('discardPagePostAction failed', error as Error, { id });
+    return { ok: false, error: 'internal-error' };
+  }
+}

--- a/src/app/admin/page-posts/page.tsx
+++ b/src/app/admin/page-posts/page.tsx
@@ -1,0 +1,28 @@
+import { AdminPage } from '@/components/admin';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { fetchPagePostsAction } from './actions';
+import { PagePostConsole } from './_components/page-post-console';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function PagePostsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const posts = await fetchPagePostsAction(property);
+
+  return (
+    <AdminPage
+      title="Page posts"
+      description="Draft warm organic Facebook posts to keep the page alive — the engine writes one grounded in a real photo; you post it from your own account, one tap. (Auto-publish needs a page-scope grant.)"
+    >
+      <PropertyUrlSync />
+      <PagePostConsole propertyId={property} initialPosts={posts} />
+    </AdminPage>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -13,6 +13,7 @@ import {
   Ticket,
   Megaphone,
   Target,
+  Newspaper,
   MessageSquare,
   Sliders,
   RefreshCw,
@@ -94,6 +95,7 @@ const navigationGroups = [
     items: [
       { title: 'Campaigns', href: '/admin/campaigns', icon: Megaphone },
       { title: 'Ads', href: '/admin/ads', icon: Target },
+      { title: 'Page posts', href: '/admin/page-posts', icon: Newspaper },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
Ships the **page-posts admin screen** (step 5 of the promotion system) and a small ads-tooling improvement.

### Page posts — `/admin/page-posts`
Ban-safe manual organic-posting flow, mirroring the ads generate + wa.me manual-send philosophy:
- **Generate** a warm caption (LLM, in the owner's voice) + a fitting real photo from a plain-language prompt (+ optional goal/audience).
- **Review** the draft, edit the caption inline.
- **Post by hand**: Copy caption / Open photo / Mark posted / Discard. No page-scope token needed, no auto-publish.
- New Growth nav item (`Newspaper` icon). Writes to `pagePosts` (Admin-SDK-only; super-admin/owner read).
- `firestore.rules` + `firestore.indexes.json` entries for `pagePosts`.

### Ads tooling — `scripts/ad-propose.ts --keep`
`--keep` now persists the full proposal blob (copy variants, photos, cities, creative brief, rationale, asset gaps + generation prompts) onto the `adCampaigns` doc — mirroring `generateAdProposalAction` — so a CLI-created PAUSED draft is **fully reviewable** at `/admin/ads/[id]`, not just a bare Meta object.

## Safety
- Page posts never auto-publish — human copies + posts from their own account.
- `ad-propose` creates only PAUSED, zero-spend drafts; activation + `GROWTH_ADS_MODE=live` remain separate gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)