### PR TITLE
feat: review-before-push for ads (nothing on Meta until you press Push)

### DIFF
--- a/scripts/check-ad-status.ts
+++ b/scripts/check-ad-status.ts
@@ -1,0 +1,31 @@
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+process.env.META_ADS_TOKENS = execSync('gcloud secrets versions access latest --secret=META_ADS_TOKENS --project=rentalspot-fzwom', { encoding: 'utf8' }).trim();
+import { resolveAdContext } from '@/services/growth/metaAds/adContext';
+
+const CAMPAIGN = '120251505692310114';
+const ADSET = '120251505692830114';
+const AD = '120251505695810114';
+
+(async () => {
+  const ctx = await resolveAdContext('prahova-mountain-chalet');
+  if (!ctx) { console.log('no ad context'); process.exit(1); }
+  const t = ctx.token;
+  const g = async (id: string, fields: string) => {
+    const r = await fetch(`https://graph.facebook.com/v25.0/${id}?fields=${fields}&access_token=${encodeURIComponent(t)}`);
+    return r.json();
+  };
+  console.log('=== CAMPAIGN ===');
+  console.log(JSON.stringify(await g(CAMPAIGN, 'name,status,effective_status,daily_budget,lifetime_budget,start_time,stop_time'), null, 1));
+  console.log('=== ADSET ===');
+  console.log(JSON.stringify(await g(ADSET, 'name,status,effective_status,daily_budget,lifetime_budget,start_time,end_time'), null, 1));
+  console.log('=== AD ===');
+  console.log(JSON.stringify(await g(AD, 'name,status,effective_status'), null, 1));
+  console.log('=== SPEND (campaign insights, lifetime) ===');
+  const ins = await g(CAMPAIGN + '/insights', 'spend,impressions,clicks,reach');
+  console.log(JSON.stringify(ins, null, 1));
+  console.log('=== ACCOUNT ===');
+  console.log(JSON.stringify(await g(ctx.adAccountId, 'name,account_status,spend_cap,amount_spent,disable_reason'), null, 1));
+})().catch(e => { console.error(e); process.exit(1); });

--- a/src/app/admin/ads/_components/ad-detail-panel.tsx
+++ b/src/app/admin/ads/_components/ad-detail-panel.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Dialog,
   DialogContent,
@@ -29,13 +30,61 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
 import Image from 'next/image';
-import { Loader2, ExternalLink, RefreshCw, Ban, ShieldCheck, Rocket, Sparkles, Trash2, MapPin } from 'lucide-react';
-import type { AdCampaign } from '@/types';
-import { approveAdAction, activateAdAction, pauseAdAction, refreshAdInsightsAction, discardAdDraftAction } from '../actions';
+import { Loader2, ExternalLink, RefreshCw, Ban, Rocket, Sparkles, Trash2, MapPin, Send, Save } from 'lucide-react';
+import type { AdCampaign, CopyVariant } from '@/types';
+import {
+  approveAdAction,
+  activateAdAction,
+  pauseAdAction,
+  refreshAdInsightsAction,
+  discardAdDraftAction,
+  pushAdToMetaAction,
+  updateAdDraftAction,
+} from '../actions';
 
-/** The AI proposal (copy + photos + geo + rationale) shown for in-console review when a draft was drafted by the Opportunity Engine. */
-function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal']> }) {
+/**
+ * The AI proposal (copy + photos + geo + rationale) shown for in-console review. While the campaign is
+ * a Firestore-only `draft` (nothing on Meta yet) the copy + daily budget are EDITABLE — what you save
+ * here is exactly what Push sends to Meta. Once pushed, it renders read-only.
+ */
+function ProposalCard({
+  proposal,
+  editable,
+  adCampaignId,
+  dailyBudgetMinor,
+}: {
+  proposal: NonNullable<AdCampaign['proposal']>;
+  editable: boolean;
+  adCampaignId: string;
+  dailyBudgetMinor?: number;
+}) {
   const { toast } = useToast();
+  const router = useRouter();
+  const [saving, startSave] = useTransition();
+  const [copy, setCopy] = useState<CopyVariant[]>(proposal.copy);
+  const [budgetRon, setBudgetRon] = useState(((dailyBudgetMinor ?? 0) / 100).toFixed(0));
+
+  const dirty =
+    editable &&
+    (JSON.stringify(copy) !== JSON.stringify(proposal.copy) ||
+      Math.round(Number(budgetRon) * 100) !== (dailyBudgetMinor ?? 0));
+
+  const patchVariant = (i: number, field: 'headline' | 'primary', value: string) =>
+    setCopy((prev) => prev.map((v, idx) => (idx === i ? { ...v, [field]: value } : v)));
+  const removeVariant = (i: number) => setCopy((prev) => prev.filter((_, idx) => idx !== i));
+
+  const save = () =>
+    startSave(async () => {
+      const dailyMinor = Math.round(Number(budgetRon) * 100);
+      const res = await updateAdDraftAction(adCampaignId, { copy, dailyBudgetMinor: dailyMinor });
+      if (res.ok) {
+        toast({ title: 'Draft updated', description: 'Your edits are what Push will send to Meta.' });
+        router.refresh();
+      } else {
+        toast({ title: 'Could not save', description: res.error, variant: 'destructive' });
+      }
+    });
+
   return (
     <Card>
       <CardHeader>
@@ -43,6 +92,7 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
           <Sparkles className="h-4 w-4 text-muted-foreground" />
           Proposal
           <Badge variant="secondary" className="text-[10px]">Opportunity Engine</Badge>
+          {editable && <Badge variant="outline" className="text-[10px] text-emerald-700">editable</Badge>}
         </CardTitle>
         {proposal.occasion && (
           <CardDescription>
@@ -68,6 +118,22 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
             )}
           </div>
         )}
+
+        {editable && (
+          <div className="flex items-center gap-2">
+            <Label htmlFor="daily-budget" className="text-xs text-muted-foreground">Daily budget (RON)</Label>
+            <Input
+              id="daily-budget"
+              type="number"
+              min={1}
+              step="1"
+              value={budgetRon}
+              onChange={(e) => setBudgetRon(e.target.value)}
+              className="h-8 w-24"
+            />
+          </div>
+        )}
+
         {proposal.cities.length > 0 && (
           <div className="flex flex-wrap items-center gap-1.5">
             <MapPin className="h-3.5 w-3.5 text-muted-foreground" />
@@ -76,6 +142,7 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
                 {c.name} · {c.radius}km
               </Badge>
             ))}
+            {editable && <span className="text-[10px] text-muted-foreground">(geo edits: discard &amp; regenerate for now)</span>}
           </div>
         )}
         {proposal.photos.length > 0 && (
@@ -91,16 +158,49 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
             ))}
           </div>
         )}
+
         <div className="space-y-2">
-          <p className="text-xs font-medium text-muted-foreground">Copy variants ({proposal.copy.length})</p>
-          {proposal.copy.map((v, i) => (
-            <div key={i} className="rounded-md border p-2">
-              {v.headline && <p className="text-xs font-medium">{v.headline}</p>}
-              <p className="text-sm">{v.primary}</p>
-              <p className="mt-1 text-[10px] uppercase text-muted-foreground">{v.cta}</p>
-            </div>
-          ))}
+          <p className="text-xs font-medium text-muted-foreground">Copy variants ({copy.length})</p>
+          {copy.map((v, i) =>
+            editable ? (
+              <div key={i} className="space-y-1 rounded-md border p-2">
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={v.headline ?? ''}
+                    onChange={(e) => patchVariant(i, 'headline', e.target.value)}
+                    placeholder="Headline"
+                    className="h-8 text-xs font-medium"
+                  />
+                  {copy.length > 1 && (
+                    <Button size="sm" variant="ghost" className="h-8 shrink-0 px-2 text-destructive" onClick={() => removeVariant(i)}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </div>
+                <Textarea
+                  value={v.primary}
+                  onChange={(e) => patchVariant(i, 'primary', e.target.value)}
+                  rows={3}
+                  className="text-sm"
+                />
+                <p className="text-[10px] uppercase text-muted-foreground">{v.cta}</p>
+              </div>
+            ) : (
+              <div key={i} className="rounded-md border p-2">
+                {v.headline && <p className="text-xs font-medium">{v.headline}</p>}
+                <p className="text-sm">{v.primary}</p>
+                <p className="mt-1 text-[10px] uppercase text-muted-foreground">{v.cta}</p>
+              </div>
+            )
+          )}
+          {editable && (
+            <Button size="sm" onClick={save} disabled={saving || !dirty}>
+              {saving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
+              Save changes
+            </Button>
+          )}
         </div>
+
         {proposal.creativeBrief && (
           <details className="rounded-md border bg-muted/30 p-2">
             <summary className="cursor-pointer text-xs font-medium text-muted-foreground">Creative brief &amp; rationale</summary>
@@ -115,7 +215,7 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
         {(proposal.assetGaps?.length ?? 0) > 0 && (
           <div className="space-y-2">
             <p className="text-xs font-medium text-amber-700">
-              Missing shots the AI wanted ({proposal.assetGaps!.length}) — generate these & upload, and they self-describe
+              Missing shots the AI wanted ({proposal.assetGaps!.length}) — generate these &amp; upload, and they self-describe
             </p>
             {proposal.assetGaps!.map((g, i) => (
               <div key={i} className="rounded-md border border-amber-200 bg-amber-50/40 p-2 text-xs">
@@ -157,6 +257,7 @@ function ProposalCard({ proposal }: { proposal: NonNullable<AdCampaign['proposal
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   draft: 'outline',
+  pushed: 'secondary',
   pending_approval: 'secondary',
   approved: 'secondary',
   active: 'default',
@@ -165,6 +266,15 @@ const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | '
 };
 
 const PROBLEM_EFFECTIVE_STATUSES = new Set(['DISAPPROVED', 'REJECTED', 'WITH_ISSUES', 'CAMPAIGN_PAUSED', 'ADSET_PAUSED']);
+
+const STATUS_HELP: Record<string, string> = {
+  draft: 'Nothing is on Meta yet. Review and adjust the copy/budget, then Push to Meta.',
+  pushed: 'On Meta as PAUSED (zero spend) — Meta is reviewing the creative. Go live is the only step that spends.',
+  approved: 'Spend cap set. Activate to start delivery (spends only when the engine is in live mode).',
+  active: 'Delivering on Meta. Pause to stop spend immediately.',
+  paused: 'Paused on Meta — no spend.',
+  failed: 'Something went wrong creating this on Meta. Discard and regenerate.',
+};
 
 function formatMinor(minor: number | undefined): string {
   if (minor === undefined || minor === null) return '—';
@@ -183,12 +293,13 @@ function daysToEndTime(endTime: string | undefined): number | null {
 export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManagerUrl?: string } }) {
   const { toast } = useToast();
   const router = useRouter();
-  const [approving, startApprove] = useTransition();
+  const [pushing, startPush] = useTransition();
+  const [goingLive, startGoLive] = useTransition();
   const [activating, startActivate] = useTransition();
   const [pausing, startPause] = useTransition();
   const [refreshing, startRefresh] = useTransition();
   const [discarding, startDiscard] = useTransition();
-  const [approveOpen, setApproveOpen] = useState(false);
+  const [goLiveOpen, setGoLiveOpen] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const [spendCapRon, setSpendCapRon] = useState('50');
 
@@ -196,21 +307,42 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
   const projectedSpendMinor =
     days && campaign.dailyBudgetMinor ? Math.round(campaign.dailyBudgetMinor * days * 1.25) : undefined;
 
-  const approve = () => {
+  const pushToMeta = () => {
+    startPush(async () => {
+      const res = await pushAdToMetaAction(campaign.id);
+      if (res.ok) {
+        toast({ title: 'Pushed to Meta (PAUSED)', description: 'Zero spend. Meta will review the creative and email you — that email is expected now.' });
+        router.push(`/admin/ads/${res.adCampaignId}`);
+      } else {
+        toast({ title: 'Push failed', description: `${res.error}${res.stage ? ` (${res.stage})` : ''}`, variant: 'destructive' });
+      }
+    });
+  };
+
+  // Go live = approve (set spend cap) then activate, in one operator step. Activation only spends when
+  // both engine switches are on; otherwise it reports a dry-run and the cap is still saved.
+  const goLive = () => {
     const spendCapMinor = Math.round(Number(spendCapRon) * 100);
     if (!Number.isFinite(spendCapMinor) || spendCapMinor <= 0) {
       toast({ title: 'Invalid spend cap', variant: 'destructive' });
       return;
     }
-    startApprove(async () => {
-      const res = await approveAdAction(campaign.id, spendCapMinor);
-      if (res.ok) {
-        toast({ title: 'Approved', description: `Spend cap set to ${spendCapRon} RON.` });
-        setApproveOpen(false);
-        router.refresh();
-      } else {
-        toast({ title: 'Approve failed', description: res.error, variant: 'destructive' });
+    startGoLive(async () => {
+      const ap = await approveAdAction(campaign.id, spendCapMinor);
+      if (!ap.ok) {
+        toast({ title: 'Go live blocked at approval', description: ap.error, variant: 'destructive' });
+        return;
       }
+      const res = await activateAdAction(campaign.id);
+      if (res.status === 'activated') {
+        toast({ title: 'Live', description: `Meta is serving this ad, capped at ${spendCapRon} RON.` });
+      } else if (res.status === 'dry-run') {
+        toast({ title: 'Approved · dry-run', description: 'Spend cap saved, but GROWTH_ADS_MODE is not live yet — nothing spends until the engine is switched to live.' });
+      } else {
+        toast({ title: 'Approved, activation rejected', description: res.reason, variant: 'destructive' });
+      }
+      setGoLiveOpen(false);
+      router.refresh();
     });
   };
 
@@ -244,7 +376,7 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
     startDiscard(async () => {
       const res = await discardAdDraftAction(campaign.id);
       if (res.ok) {
-        toast({ title: 'Draft discarded' });
+        toast({ title: 'Discarded' });
         router.push('/admin/ads');
       } else {
         toast({ title: 'Could not discard', description: res.error, variant: 'destructive' });
@@ -269,152 +401,208 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
     });
   };
 
+  const canDiscard = campaign.status === 'draft' || campaign.status === 'pushed' || campaign.status === 'failed';
+
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
       <div className="space-y-6">
-      {campaign.proposal && <ProposalCard proposal={campaign.proposal} />}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            Campaign
-            <Badge variant={STATUS_VARIANT[campaign.status] || 'outline'}>{campaign.status}</Badge>
-            {campaign.effectiveStatus && PROBLEM_EFFECTIVE_STATUSES.has(campaign.effectiveStatus) && (
-              <Badge variant="destructive">{campaign.effectiveStatus}</Badge>
+        {campaign.proposal && (
+          <ProposalCard
+            proposal={campaign.proposal}
+            editable={campaign.status === 'draft'}
+            adCampaignId={campaign.id}
+            dailyBudgetMinor={campaign.dailyBudgetMinor}
+          />
+        )}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              Campaign
+              <Badge variant={STATUS_VARIANT[campaign.status] || 'outline'}>{campaign.status}</Badge>
+              {campaign.effectiveStatus && PROBLEM_EFFECTIVE_STATUSES.has(campaign.effectiveStatus) && (
+                <Badge variant="destructive">{campaign.effectiveStatus}</Badge>
+              )}
+            </CardTitle>
+            <CardDescription>
+              {campaign.status === 'draft'
+                ? 'Firestore draft — no Meta campaign exists yet'
+                : campaign.metaCampaignId ?? 'No Meta campaign id recorded'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <dl className="grid grid-cols-2 gap-y-2">
+              <dt className="text-muted-foreground">Objective</dt>
+              <dd>{campaign.objective ?? '—'}</dd>
+              <dt className="text-muted-foreground">Daily budget</dt>
+              <dd>{formatMinor(campaign.dailyBudgetMinor)}</dd>
+              <dt className="text-muted-foreground">Spend cap</dt>
+              <dd>{formatMinor(campaign.spendCapMinor)}</dd>
+              <dt className="text-muted-foreground">End time</dt>
+              <dd>{campaign.endTime ? new Date(campaign.endTime).toLocaleString() : '—'}</dd>
+              <dt className="text-muted-foreground">Approved by</dt>
+              <dd>{campaign.approvedBy ?? '—'}</dd>
+              <dt className="text-muted-foreground">Effective status</dt>
+              <dd>{campaign.effectiveStatus ?? 'not synced yet'}</dd>
+            </dl>
+
+            {campaign.insights && (
+              <div className="rounded-md border bg-muted/40 p-3">
+                <p className="font-medium mb-1">Insights</p>
+                <dl className="grid grid-cols-2 gap-y-1">
+                  <dt className="text-muted-foreground">Spend</dt>
+                  <dd>{campaign.insights.spend.toFixed(2)} RON</dd>
+                  <dt className="text-muted-foreground">Impressions</dt>
+                  <dd>{campaign.insights.impressions}</dd>
+                  <dt className="text-muted-foreground">Clicks</dt>
+                  <dd>{campaign.insights.clicks}</dd>
+                  <dt className="text-muted-foreground">Bookings</dt>
+                  <dd>{campaign.insights.bookings ?? 0}</dd>
+                  <dt className="text-muted-foreground">ROAS</dt>
+                  <dd>{campaign.insights.roas?.toFixed(2) ?? '—'}</dd>
+                </dl>
+              </div>
             )}
-          </CardTitle>
-          <CardDescription>{campaign.metaCampaignId ?? 'No Meta campaign id recorded'}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 text-sm">
-          <dl className="grid grid-cols-2 gap-y-2">
-            <dt className="text-muted-foreground">Objective</dt>
-            <dd>{campaign.objective ?? '—'}</dd>
-            <dt className="text-muted-foreground">Daily budget</dt>
-            <dd>{formatMinor(campaign.dailyBudgetMinor)}</dd>
-            <dt className="text-muted-foreground">Spend cap</dt>
-            <dd>{formatMinor(campaign.spendCapMinor)}</dd>
-            <dt className="text-muted-foreground">End time</dt>
-            <dd>{campaign.endTime ? new Date(campaign.endTime).toLocaleString() : '—'}</dd>
-            <dt className="text-muted-foreground">Approved by</dt>
-            <dd>{campaign.approvedBy ?? '—'}</dd>
-            <dt className="text-muted-foreground">Effective status</dt>
-            <dd>{campaign.effectiveStatus ?? 'not synced yet'}</dd>
-          </dl>
 
-          {campaign.insights && (
-            <div className="rounded-md border bg-muted/40 p-3">
-              <p className="font-medium mb-1">Insights</p>
-              <dl className="grid grid-cols-2 gap-y-1">
-                <dt className="text-muted-foreground">Spend</dt>
-                <dd>{campaign.insights.spend.toFixed(2)} RON</dd>
-                <dt className="text-muted-foreground">Impressions</dt>
-                <dd>{campaign.insights.impressions}</dd>
-                <dt className="text-muted-foreground">Clicks</dt>
-                <dd>{campaign.insights.clicks}</dd>
-                <dt className="text-muted-foreground">Bookings</dt>
-                <dd>{campaign.insights.bookings ?? 0}</dd>
-                <dt className="text-muted-foreground">ROAS</dt>
-                <dd>{campaign.insights.roas?.toFixed(2) ?? '—'}</dd>
-              </dl>
-            </div>
+            {campaign.adsManagerUrl && (
+              <a
+                href={campaign.adsManagerUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                Open in Ads Manager <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </CardContent>
+          {campaign.status !== 'draft' && (
+            <CardFooter>
+              <Button variant="outline" size="sm" onClick={refresh} disabled={refreshing}>
+                {refreshing ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-1 h-3.5 w-3.5" />}
+                Refresh insights
+              </Button>
+            </CardFooter>
           )}
-
-          {campaign.adsManagerUrl && (
-            <a
-              href={campaign.adsManagerUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-            >
-              Open in Ads Manager <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          )}
-        </CardContent>
-        <CardFooter>
-          <Button variant="outline" size="sm" onClick={refresh} disabled={refreshing}>
-            {refreshing ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-1 h-3.5 w-3.5" />}
-            Refresh insights
-          </Button>
-        </CardFooter>
-      </Card>
+        </Card>
       </div>
 
       <Card className="h-fit">
         <CardHeader>
           <CardTitle>Actions</CardTitle>
-          <CardDescription>Approve sets a spend cap. Activate spends real money once both engine switches are on.</CardDescription>
+          <CardDescription>{STATUS_HELP[campaign.status] ?? ''}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
-          <Dialog open={approveOpen} onOpenChange={setApproveOpen}>
-            <DialogTrigger asChild>
-              <Button className="w-full" variant="secondary" disabled={campaign.status !== 'draft'}>
-                <ShieldCheck className="mr-1 h-4 w-4" />
-                Approve
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Approve this ad</DialogTitle>
-                <DialogDescription>
-                  Set a spend cap. The server rejects the cap unless{' '}
-                  <code>dailyBudget × days-to-end-time × 1.25 ≤ spendCap</code>.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-2">
-                <Label htmlFor="spend-cap">Spend cap (RON)</Label>
-                <Input id="spend-cap" type="number" min={1} step="0.01" value={spendCapRon} onChange={(e) => setSpendCapRon(e.target.value)} />
-                {days !== null && projectedSpendMinor !== undefined && (
-                  <p className="text-xs text-muted-foreground">
-                    Projected: {formatMinor(campaign.dailyBudgetMinor)}/day × {days} day{days === 1 ? '' : 's'} × 1.25 ={' '}
-                    <strong>{formatMinor(projectedSpendMinor)}</strong> — your cap must be at least this.
-                  </p>
-                )}
-              </div>
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setApproveOpen(false)} disabled={approving}>
-                  Cancel
+          {/* DRAFT (Firestore only) → Push to Meta */}
+          {campaign.status === 'draft' && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button className="w-full" disabled={pushing}>
+                  {pushing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Send className="mr-1 h-4 w-4" />}
+                  Push to Meta
                 </Button>
-                <Button onClick={approve} disabled={approving}>
-                  {approving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Confirm approval
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Push this draft to Meta?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This creates the campaign on Meta as <strong>PAUSED (zero spend)</strong>. Meta will review the creative
+                    and send you a &ldquo;your ad was approved&rdquo; email — that email is expected at this step and does not
+                    mean anything is spending. Nothing spends until you press <strong>Go live</strong>.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={pushing}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={pushToMeta} disabled={pushing}>
+                    {pushing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Push to Meta
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+
+          {/* PUSHED (PAUSED on Meta) → Go live (approve cap + activate) */}
+          {campaign.status === 'pushed' && (
+            <Dialog open={goLiveOpen} onOpenChange={setGoLiveOpen}>
+              <DialogTrigger asChild>
+                <Button className="w-full" disabled={goingLive}>
+                  {goingLive ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Rocket className="mr-1 h-4 w-4" />}
+                  Go live
                 </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Go live</DialogTitle>
+                  <DialogDescription>
+                    Sets a spend cap and un-pauses the campaign on Meta. The cap is rejected unless{' '}
+                    <code>dailyBudget × days-to-end-time × 1.25 ≤ spendCap</code>. Real spend happens only when the engine is
+                    in live mode; otherwise the cap is saved and delivery stays a dry-run.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2">
+                  <Label htmlFor="spend-cap">Spend cap (RON)</Label>
+                  <Input id="spend-cap" type="number" min={1} step="0.01" value={spendCapRon} onChange={(e) => setSpendCapRon(e.target.value)} />
+                  {days !== null && projectedSpendMinor !== undefined && (
+                    <p className="text-xs text-muted-foreground">
+                      Projected: {formatMinor(campaign.dailyBudgetMinor)}/day × {days} day{days === 1 ? '' : 's'} × 1.25 ={' '}
+                      <strong>{formatMinor(projectedSpendMinor)}</strong> — your cap must be at least this.
+                    </p>
+                  )}
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setGoLiveOpen(false)} disabled={goingLive}>
+                    Cancel
+                  </Button>
+                  <Button onClick={goLive} disabled={goingLive}>
+                    {goingLive && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Go live
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          )}
 
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button className="w-full" disabled={campaign.status !== 'approved' || activating}>
-                {activating ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Rocket className="mr-1 h-4 w-4" />}
-                Activate
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Activate this ad?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This un-pauses the campaign, every ad set, and every ad on Meta. If the engine is live, this starts real
-                  spend up to the approved cap. If it&apos;s still in dry-run mode, nothing spends.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={activating}>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={activate} disabled={activating}>
-                  {activating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Yes, activate
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          {/* APPROVED → Activate (e.g. retry after the engine switch is turned on) */}
+          {campaign.status === 'approved' && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button className="w-full" disabled={activating}>
+                  {activating ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Rocket className="mr-1 h-4 w-4" />}
+                  Activate
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Activate this ad?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This un-pauses the campaign, every ad set, and every ad on Meta. If the engine is live, this starts real
+                    spend up to the approved cap. If it&apos;s still in dry-run mode, nothing spends.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={activating}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={activate} disabled={activating}>
+                    {activating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Yes, activate
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
 
-          <Button className="w-full" variant="destructive" onClick={pause} disabled={pausing}>
-            {pausing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Ban className="mr-1 h-4 w-4" />}
-            Pause
-          </Button>
+          {/* Pause is available whenever there is something on Meta that could deliver */}
+          {(campaign.status === 'active' || campaign.status === 'approved' || campaign.status === 'pushed') && (
+            <Button className="w-full" variant="destructive" onClick={pause} disabled={pausing}>
+              {pausing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Ban className="mr-1 h-4 w-4" />}
+              Pause
+            </Button>
+          )}
 
-          {campaign.status === 'draft' &&
+          {canDiscard &&
             (confirmDiscard ? (
               <div className="flex items-center justify-center gap-2 text-xs">
-                <span className="text-muted-foreground">Delete this draft?</span>
+                <span className="text-muted-foreground">
+                  {campaign.status === 'draft' ? 'Delete this draft?' : 'Delete on Meta + here?'}
+                </span>
                 <Button size="sm" variant="destructive" className="h-7" onClick={discard} disabled={discarding}>
                   {discarding ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Yes, discard'}
                 </Button>
@@ -424,7 +612,7 @@ export function AdDetailPanel({ campaign }: { campaign: AdCampaign & { adsManage
               </div>
             ) : (
               <Button className="w-full" variant="ghost" size="sm" onClick={() => setConfirmDiscard(true)}>
-                <Trash2 className="mr-1 h-4 w-4" /> Discard draft
+                <Trash2 className="mr-1 h-4 w-4" /> {campaign.status === 'draft' ? 'Discard draft' : 'Discard'}
               </Button>
             ))}
         </CardContent>

--- a/src/app/admin/ads/_components/ad-table.tsx
+++ b/src/app/admin/ads/_components/ad-table.tsx
@@ -7,6 +7,7 @@ import type { AdCampaign } from '@/types';
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   draft: 'outline',
+  pushed: 'secondary',
   pending_approval: 'secondary',
   approved: 'secondary',
   active: 'default',

--- a/src/app/admin/ads/actions.ts
+++ b/src/app/admin/ads/actions.ts
@@ -36,15 +36,15 @@ import { convertTimestampsToISOStrings } from '@/lib/utils';
 import { serverTranslateContent } from '@/lib/server-language-utils';
 import { getBaseUrl } from '@/lib/structured-data';
 import { getMaxDailyBudgetMinor } from '@/config/growth-ads';
-import type { AdCampaign, AdCampaignStatus, ComposeAndCreateAdInput, PropertyImage } from '@/types';
-import { composeAndCreateAd, validateApprovalCap, type ComposeAndCreateAdResult } from '@/services/growth/adComposer';
+import type { AdCampaign, AdCampaignStatus, ComposeAndCreateAdInput, CopyVariant, PropertyImage } from '@/types';
+import { composeAndCreateAd, validateApprovalCap, validateDailyBudget, type ComposeAndCreateAdResult } from '@/services/growth/adComposer';
 import { activateCampaign, type ActivateResult } from '@/services/growth/adExecutionGateway';
 import { pauseCampaign, type PauseResult } from '@/services/growth/metaAds/lifecycle';
 import { getInsights, getEffectiveStatus } from '@/services/growth/metaAds/insights';
 import { resolveAdContext } from '@/services/growth/metaAds/adContext';
 import { searchCities, type CityMatch } from '@/services/growth/metaAds/geo';
 import { deleteResource } from '@/services/growth/metaAds/client';
-import { proposeAd } from '@/services/growth/adProposal';
+import { planAndCreative } from '@/services/growth/adProposal';
 import { buildGenerationPrompt } from '@/lib/growth/generationPrompt';
 import type { AdOpportunity } from '@/lib/growth/contracts';
 
@@ -244,7 +244,15 @@ export async function composeAdAction(input: ComposeAndCreateAdInput): Promise<C
   logger.info('composeAdAction: composing', { actor, propertyId: input.propertyId });
   const result = await composeAndCreateAd(input);
   if (result.ok) {
-    logger.info('composeAdAction: composed draft', { actor, adCampaignId: result.adCampaignId });
+    // The manual form creates the Meta chain directly (no Firestore-only draft stage), so the doc is
+    // already ON Meta (PAUSED) — mark it 'pushed' so it enters the same approve/Go-live gates.
+    try {
+      const db = await getAdminDb();
+      await db.collection('adCampaigns').doc(result.adCampaignId).update({ status: 'pushed', pushedBy: actor, updatedAt: FieldValue.serverTimestamp() });
+    } catch (e) {
+      logger.warn('composeAdAction: could not mark pushed (non-fatal)', { adCampaignId: result.adCampaignId, error: (e as Error).message });
+    }
+    logger.info('composeAdAction: composed draft (on Meta, PAUSED)', { actor, adCampaignId: result.adCampaignId });
     revalidatePath('/admin/ads');
   } else {
     logger.warn('composeAdAction: compose failed', { actor, propertyId: input.propertyId, stage: result.stage, error: result.error });
@@ -256,8 +264,9 @@ export async function composeAdAction(input: ComposeAndCreateAdInput): Promise<C
  * Approve a draft ad campaign — the state machine + spend-bound gate (plan
  * REVISIONS S3/B2). Super-admin gate; actor from session (S4).
  *
- *  1. Require `status === 'draft'` — approving anything else (already
- *     approved/active/paused) is rejected with `not-draft:<status>`.
+ *  1. Require `status === 'pushed'` — the ad must already exist on Meta (PAUSED)
+ *     before a spend cap can be approved; anything else is rejected with
+ *     `not-pushed:<status>`. (A Firestore-only `draft` must be Pushed first.)
  *  2. `validateApprovalCap` — the ONLY place spend-cap arithmetic runs; this
  *     action never re-derives or duplicates that math, it only surfaces the
  *     policy's verdict.
@@ -286,8 +295,8 @@ export async function approveAdAction(
     }
     const doc = snap.data() as AdCampaignDocData;
 
-    if (doc.status !== 'draft') {
-      return { ok: false, error: `not-draft:${doc.status ?? 'unknown'}` };
+    if (doc.status !== 'pushed') {
+      return { ok: false, error: `not-pushed:${doc.status ?? 'unknown'} (push the draft to Meta before approving)` };
     }
 
     const dailyBudgetMinor = doc.dailyBudgetMinor ?? 0;
@@ -520,14 +529,16 @@ export async function generateAdProposalAction(input: {
 
     const framing = { goal: input.goal?.trim() || undefined, audience: input.audience?.trim() || undefined };
     logger.info('generateAdProposalAction: generating', { actor, propertyId: input.propertyId, window: `${input.start}..${input.end}` });
-    const res = await proposeAd(opportunity, { framing });
+
+    // Intelligence only — plan + creative, ZERO Meta footprint. Nothing reaches Meta until Push.
+    const res = await planAndCreative(opportunity, { framing });
 
     if (!res.ok) return { ok: false, error: res.errors.join('; ') || 'proposal-failed', stage: res.stage };
-    if (res.declined || !res.draft || !res.brief || !res.creative) {
+    if (res.declined || !res.brief || !res.creative || !res.composeInput) {
       return { ok: true, declined: true, rationale: res.brief?.rationale ?? 'The planner declined to run an ad for this window.' };
     }
 
-    // Persist the reviewable proposal blob (resolve photo URLs from the property gallery).
+    // Resolve photo URLs from the property gallery for the reviewable proposal blob.
     const db = await getAdminDb();
     const propDoc = await db.collection('properties').doc(input.propertyId).get();
     const images = (propDoc.data()?.images ?? []) as PropertyImage[];
@@ -544,7 +555,18 @@ export async function generateAdProposalAction(input: {
       generationPrompt: buildGenerationPrompt(g.transform, g.need, descByPath.get(g.nearestAssetPath) ?? ''),
     }));
 
-    await db.collection('adCampaigns').doc(res.draft.adCampaignId).update({
+    // Create a Firestore-ONLY draft (status 'draft', no metaCampaignId). `composeInput` is the neutral
+    // request that `pushAdToMetaAction` will replay verbatim (with any operator edits) to build the
+    // real PAUSED Meta chain. Top-level dailyBudgetMinor/endTime/objective mirror it for display + the
+    // later approve cap-check.
+    const ref = db.collection('adCampaigns').doc();
+    await ref.set({
+      propertyId: input.propertyId,
+      status: 'draft',
+      objective: res.composeInput.objective,
+      dailyBudgetMinor: res.composeInput.dailyBudgetMinor,
+      endTime: res.composeInput.endTime,
+      composeInput: res.composeInput,
       proposal: {
         source: 'opportunity-engine',
         occasion: {
@@ -562,12 +584,14 @@ export async function generateAdProposalAction(input: {
         rationale: res.brief.rationale,
         assetGaps,
       },
+      createdBy: actor,
+      createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
     });
 
-    logger.info('generateAdProposalAction: draft created', { actor, adCampaignId: res.draft.adCampaignId });
+    logger.info('generateAdProposalAction: Firestore-only draft created (no Meta)', { actor, adCampaignId: ref.id });
     revalidatePath('/admin/ads');
-    return { ok: true, adCampaignId: res.draft.adCampaignId };
+    return { ok: true, adCampaignId: ref.id };
   } catch (error) {
     logger.error('generateAdProposalAction failed', error as Error, { propertyId: input.propertyId });
     return { ok: false, error: 'internal-error' };
@@ -575,11 +599,125 @@ export async function generateAdProposalAction(input: {
 }
 
 /**
+ * Edit a Firestore draft before it is pushed to Meta (operator review + adjust). v1 covers copy text
+ * + daily budget; photo/geo edits are a follow-up. Keeps `proposal` (what the console shows) and
+ * `composeInput` (what push replays) in sync, so the ad that reaches Meta is exactly what was reviewed.
+ * Super-admin gate; only a `draft` (no Meta objects yet) can be edited.
+ */
+export async function updateAdDraftAction(
+  adCampaignId: string,
+  patch: { copy?: CopyVariant[]; dailyBudgetMinor?: number }
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('adCampaigns').doc(adCampaignId);
+    const snap = await ref.get();
+    if (!snap.exists) return { ok: false, error: 'not-found' };
+    const doc = snap.data() as AdCampaignDocData & { composeInput?: ComposeAndCreateAdInput };
+    if (doc.status !== 'draft') return { ok: false, error: `not-draft:${doc.status ?? 'unknown'}` };
+    const composeInput = doc.composeInput;
+    if (!composeInput) return { ok: false, error: 'draft-missing-composeInput' };
+
+    const update: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
+    let nextComposeInput = composeInput;
+
+    if (patch.copy) {
+      const clean = patch.copy.filter((c) => c && (c.headline?.trim() || c.primary?.trim()));
+      if (clean.length === 0) return { ok: false, error: 'copy-empty' };
+      nextComposeInput = { ...nextComposeInput, copy: clean };
+      update['proposal.copy'] = clean;
+    }
+    if (typeof patch.dailyBudgetMinor === 'number') {
+      const budgetCheck = validateDailyBudget(patch.dailyBudgetMinor);
+      if (!budgetCheck.ok) return { ok: false, error: budgetCheck.reason };
+      nextComposeInput = { ...nextComposeInput, dailyBudgetMinor: patch.dailyBudgetMinor };
+      update['dailyBudgetMinor'] = patch.dailyBudgetMinor;
+    }
+
+    update['composeInput'] = nextComposeInput;
+    await ref.update(update);
+    logger.info('updateAdDraftAction: draft edited', { actor, adCampaignId, fields: Object.keys(patch) });
+    revalidatePath('/admin/ads');
+    revalidatePath(`/admin/ads/${adCampaignId}`);
+    return { ok: true };
+  } catch (error) {
+    logger.error('updateAdDraftAction failed', error as Error, { adCampaignId });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+/**
+ * Push a reviewed Firestore draft to Meta — the FIRST moment anything is created on Meta. Builds the
+ * real PAUSED Meta chain (zero spend) from the draft's `composeInput` (carrying any operator edits),
+ * carries the reviewed proposal onto the composed doc, and removes the Firestore-only draft. Meta runs
+ * its policy review at THIS point (the "your ad was approved" email is expected here, by the operator's
+ * choice — never at generate). Spend stays gated behind the separate Go-live (approve + activate).
+ * Super-admin gate; requires status 'draft'. The composed doc gets a NEW id (returned to the caller).
+ */
+export async function pushAdToMetaAction(
+  adCampaignId: string
+): Promise<{ ok: true; adCampaignId: string } | { ok: false; error: string; stage?: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    throw error;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('adCampaigns').doc(adCampaignId);
+    const snap = await ref.get();
+    if (!snap.exists) return { ok: false, error: 'not-found' };
+    const doc = snap.data() as AdCampaignDocData & { composeInput?: ComposeAndCreateAdInput; proposal?: unknown };
+    if (doc.status !== 'draft') return { ok: false, error: `not-draft:${doc.status ?? 'unknown'}` };
+    if (!doc.composeInput) return { ok: false, error: 'draft-missing-composeInput' };
+
+    // Create the real (PAUSED) Meta chain — this is what makes Meta policy-review the creative.
+    const compose = await composeAndCreateAd(doc.composeInput);
+    if (!compose.ok) {
+      logger.warn('pushAdToMetaAction: compose failed', { actor, adCampaignId, stage: compose.stage, error: compose.error });
+      // Leave the draft intact so the operator can fix + retry; surface the last error in the console.
+      await ref.update({ lastPushError: `${compose.stage}:${compose.error}`, updatedAt: FieldValue.serverTimestamp() });
+      return { ok: false, error: compose.error, stage: compose.stage };
+    }
+
+    // Carry the reviewed proposal onto the freshly composed doc, mark 'pushed', then remove the
+    // Firestore-only draft (its content now lives on the composed doc under a new id).
+    await db.collection('adCampaigns').doc(compose.adCampaignId).update({
+      proposal: doc.proposal ?? null,
+      status: 'pushed',
+      pushedBy: actor,
+      pushedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    await ref.delete();
+
+    logger.info('pushAdToMetaAction: pushed to Meta (PAUSED, zero spend)', { actor, from: adCampaignId, adCampaignId: compose.adCampaignId });
+    revalidatePath('/admin/ads');
+    revalidatePath(`/admin/ads/${compose.adCampaignId}`);
+    return { ok: true, adCampaignId: compose.adCampaignId };
+  } catch (error) {
+    logger.error('pushAdToMetaAction failed', error as Error, { adCampaignId });
+    return { ok: false, error: 'internal-error' };
+  }
+}
+
+/**
  * Discard a draft ad — delete its Meta chain (ad set + campaign cascade the ad; creative is
- * account-level) and the Firestore doc. Only a `draft` or `failed` campaign may be discarded (never
- * an approved/active one — pause that first). Super-admin gate. A Dynamic-Creative ad can't be
- * deleted directly (Meta err 100/1340029), so we delete the ad set + campaign (which cascade the ad)
- * + the creative.
+ * account-level) and the Firestore doc. Only a `draft` (Firestore-only, nothing on Meta to delete),
+ * `pushed` (PAUSED on Meta), or `failed` campaign may be discarded (never an approved/active one —
+ * pause that first). Super-admin gate. A Dynamic-Creative ad can't be deleted directly (Meta err
+ * 100/1340029), so we delete the ad set + campaign (which cascade the ad) + the creative.
  */
 export async function discardAdDraftAction(adCampaignId: string): Promise<{ ok: true } | { ok: false; error: string }> {
   let actor: string;
@@ -596,7 +734,7 @@ export async function discardAdDraftAction(adCampaignId: string): Promise<{ ok: 
     const snap = await ref.get();
     if (!snap.exists) return { ok: false, error: 'not-found' };
     const doc = snap.data() as AdCampaignDocData;
-    if (doc.status !== 'draft' && doc.status !== 'failed') {
+    if (doc.status !== 'draft' && doc.status !== 'pushed' && doc.status !== 'failed') {
       return { ok: false, error: `cannot-discard:${doc.status ?? 'unknown'} (pause an active/approved ad first)` };
     }
 

--- a/src/services/growth/adProposal.ts
+++ b/src/services/growth/adProposal.ts
@@ -39,35 +39,51 @@ export interface AdProposalResult {
   errors: string[];
 }
 
+/** The intelligence half of a proposal: plan + creative, with NO Meta footprint. */
+export interface PlanAndCreativeResult {
+  ok: boolean;
+  stage: AdProposalStage;
+  declined: boolean;
+  brief?: AdBrief;
+  creative?: { copy: CopyVariant[]; assetPaths: string[]; notes?: string; assetGaps?: RawAssetGap[] };
+  /** The neutral compose input to replay LATER at push time (present on ok, non-declined). */
+  composeInput?: ComposeAndCreateAdInput;
+  landingBaseUrl?: string;
+  errors: string[];
+}
+
 /**
- * Produce a PAUSED ad draft for an opportunity. Returns at the first stage that fails (with its
- * errors), or `declined:true` if the planner chose not to act, or the created draft ids on success.
+ * Run ONLY the intelligence chain — buildAdPlannerPack → generateAdPlan → generateAdCreative — and
+ * return the brief + creative + the neutral `ComposeAndCreateAdInput` that a later push can replay.
+ * This creates NOTHING on Meta (no policy review, no email): it is what the `/admin/ads` "Generate"
+ * action calls so a proposal can be reviewed + edited as a Firestore-only draft first. The separate
+ * `pushAdToMetaAction` is the only step that turns this into a real (PAUSED) Meta chain.
  */
-export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date; framing?: AdFraming }): Promise<AdProposalResult> {
+export async function planAndCreative(opportunity: AdOpportunity, opts?: { asOf?: Date; framing?: AdFraming }): Promise<PlanAndCreativeResult> {
   const pack = await buildAdPlannerPack(opportunity, { asOf: opts?.asOf, framing: opts?.framing });
 
   // 1. Plan (geo + budget + timing + creative brief) — the pack carries the framing (goal + audience).
   const plan = await generateAdPlan(opportunity, { pack });
   if (!plan.ok || !plan.brief) {
-    logger.warn('proposeAd: planning failed', { opportunityId: opportunity.id, errors: plan.errors });
+    logger.warn('planAndCreative: planning failed', { opportunityId: opportunity.id, errors: plan.errors });
     return { ok: false, stage: 'plan', declined: false, errors: plan.errors };
   }
   const brief = plan.brief;
   if (!brief.act) {
-    logger.info('proposeAd: planner declined', { opportunityId: opportunity.id, rationale: brief.rationale });
+    logger.info('planAndCreative: planner declined', { opportunityId: opportunity.id, rationale: brief.rationale });
     return { ok: true, stage: 'plan', declined: true, brief, errors: [] };
   }
 
   // 2. Creative (grounded copy + real photos) — reinforce the same goal + audience shaping.
   const creativeRes = await generateAdCreative(brief, pack.assets, { framing: opts?.framing });
   if (!creativeRes.ok || !creativeRes.creative) {
-    logger.warn('proposeAd: creative failed', { opportunityId: opportunity.id, errors: creativeRes.errors });
+    logger.warn('planAndCreative: creative failed', { opportunityId: opportunity.id, errors: creativeRes.errors });
     return { ok: false, stage: 'creative', declined: false, brief, errors: creativeRes.errors };
   }
   const creative = creativeRes.creative;
 
-  // 3. Compose into a PAUSED Meta chain + adCampaigns draft (zero spend).
-  const input: ComposeAndCreateAdInput = {
+  // Assemble the neutral compose input now, so push can replay it verbatim (with any operator edits).
+  const composeInput: ComposeAndCreateAdInput = {
     propertyId: brief.propertyId,
     assetRefs: creative.assetPaths.map((storagePath) => ({ kind: 'gallery' as const, storagePath })),
     copy: creative.copy,
@@ -77,7 +93,25 @@ export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date
     targeting: { cities: brief.targeting.cities },
     endTime: brief.endTime,
   };
-  const compose = await composeAndCreateAd(input);
+  return { ok: true, stage: 'creative', declined: false, brief, creative, composeInput, landingBaseUrl: pack.landing.baseUrl, errors: [] };
+}
+
+/**
+ * Produce a PAUSED ad draft for an opportunity, INCLUDING the Meta chain — the all-in-one path used
+ * by the CLI harness (`ad-propose`) and any caller that wants a real draft in one shot. The admin
+ * console does NOT use this anymore (it splits generate/push); it calls `planAndCreative` then
+ * `pushAdToMetaAction`. Returns at the first failing stage, `declined:true`, or the created ids.
+ */
+export async function proposeAd(opportunity: AdOpportunity, opts?: { asOf?: Date; framing?: AdFraming }): Promise<AdProposalResult> {
+  const pc = await planAndCreative(opportunity, opts);
+  if (!pc.ok || pc.declined || !pc.brief || !pc.creative || !pc.composeInput) {
+    return { ok: pc.ok, stage: pc.stage, declined: pc.declined, brief: pc.brief, creative: pc.creative, errors: pc.errors };
+  }
+  const brief = pc.brief;
+  const creative = pc.creative;
+
+  // 3. Compose the (already-assembled) neutral input into a PAUSED Meta chain + adCampaigns draft.
+  const compose = await composeAndCreateAd(pc.composeInput);
   if (!compose.ok) {
     logger.warn('proposeAd: compose failed', { opportunityId: opportunity.id, stage: compose.stage, error: compose.error });
     return { ok: false, stage: 'compose', declined: false, brief, creative, errors: [`${compose.stage}:${compose.error}`] };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -529,7 +529,8 @@ export interface Campaign {
  * ever un-pause the Meta campaign (plan §13 H5).
  */
 export type AdCampaignStatus =
-  | 'draft'
+  | 'draft'          // Firestore-only proposal, editable, NO Meta objects exist yet (nothing on Meta)
+  | 'pushed'         // pushed to Meta (PAUSED, zero spend, Meta policy-reviewing) — awaiting Go-live
   | 'pending_approval'
   | 'approved'
   | 'active'


### PR DESCRIPTION
## Problem
Generating an ad proposal created the real Meta campaign/ad-set/ad objects **immediately** (`proposeAd` → `composeAndCreateAd` at generate time). So Meta policy-reviewed the creative and emailed the operator a *"your ad was approved"* notice **before** any in-console review — which reasonably looked like something had gone live. Nothing had spent (everything was PAUSED), but the flow put things on Meta too early.

## Fix — split generate from push
- **`planAndCreative`** (new, in `adProposal.ts`): runs plan + creative only, **zero Meta footprint**. `proposeAd` is now `planAndCreative` + compose (kept for the CLI harness).
- **`generateAdProposalAction`**: lands a **Firestore-only draft** (`status: 'draft'`, no `metaCampaignId`) carrying a replayable `composeInput` + the reviewable `proposal`. Nothing on Meta.
- **`pushAdToMetaAction`** (new): the first + only step that builds the PAUSED Meta chain, carries the reviewed proposal onto the composed doc, and deletes the Firestore draft. Meta's review email is expected **here**, by the operator's choice.
- **`updateAdDraftAction`** (new): edit copy variants + daily budget on a draft before push (keeps `proposal` display and `composeInput` replay in sync).
- **Money gates re-sequenced**: `approve` now requires `status: 'pushed'` (was `'draft'`); the manual `composeAdAction` marks its doc `'pushed'`; `discard` allows `draft | pushed | failed`.
- **UI**: draft → **Push to Meta** (warns the review email is expected) + inline editable copy/budget; pushed → **Go live** (approve cap + activate in one) + Discard.
- Added `'pushed'` to `AdCampaignStatus`; status badges + help text.
- `scripts/check-ad-status.ts`: reusable "is any ad actually spending?" verifier (pulls effective_status + spend straight from Meta).

## State machine now
`draft` (Firestore only) → **Push** → `pushed` (PAUSED on Meta, 0 spend, Meta reviews) → **Go live** → `approved`/`active` (spends, capped, gated by the engine switches).

## Notes
- The October draft that was created on Meta earlier has been pulled back to a clean Firestore-only draft (Meta objects deleted; reviewed copy preserved).
- Photo/geo editing on a draft is deferred (UI note: discard & regenerate for now).
- Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)