### PR TITLE
feat: analyst routing doctrine — read the ledger before routing a window

### DIFF
--- a/.claude/skills/situation-analyst/SKILL.md
+++ b/.claude/skills/situation-analyst/SKILL.md
@@ -94,9 +94,44 @@ truth, and do not invent a "corrected" one — if the yardstick is ambiguous, re
 month as ambiguous and say why.
 
 **3. What to do?** Pick the smallest instrument that fits the thing you found, and say
-why the others don't. Match the instrument to the *size and cause* of the problem —
-a structural shortfall and a single dated gap call for different tools. "Do nothing,
-because this is normal / outside our control" is a valid and sometimes correct answer.
+why the others don't. Before you pick, read the window's history:
+`outreachHistory.pastCampaigns` (has a lever just been fired at this audience, and did
+anyone stay?) and `inventory.recentCancellations` (was this "empty" window sold and
+handed back?). Either can overrule the instrument the window's character suggests — see
+*Choosing the instrument* below. Match the instrument to the *size and cause* of the
+problem — a structural shortfall and a single dated gap call for different tools. "Do
+nothing, because this is normal / outside our control" is a valid and sometimes correct
+answer.
+
+## Choosing the instrument (a prior is not a verdict)
+
+A window's character — a warm audience, an occasion to borrow, nearness — *suggests*
+an instrument. It never selects one. Character is a prior; the window's history is
+evidence, and evidence outranks the prior. Two ledgers to read before you route:
+
+- **The outreach ledger.** Check `outreachHistory.pastCampaigns` before proposing any
+  past-guest outreach. A recent run whose `stayedWithin120d` is ≈nothing against its
+  `recipients` means the warm pool has just been pitched and did not book — that lever
+  is **spent for now** for whatever it was aimed at. Proposing it again is not the
+  smallest instrument; it is the same instrument failing twice. Escalate to a different
+  lever and cite the ledger as the reason. What counts as "recent" and "≈nothing" is
+  your judgment from `daysAgo` and the run's size — read the magnitudes as stated; do
+  not invent a cutoff, and do not compute a rate the pack doesn't carry. Scope the
+  verdict: one run is strong evidence about this audience *under current conditions*,
+  thin evidence about the channel in general.
+- **The cancellation ledger.** A forward cancellation (`inventory.recentCancellations`)
+  is two signals, not one: the window returned to inventory, AND someone who had
+  committed backed out — fresh evidence demand there is soft. A free run that was
+  sold-then-cancelled is not the same as one that never sold: it is more urgent, and
+  the softness argues for broader or stronger tools than a warm nudge. Read
+  `forwardCount`, `nightsReopened` and each item's `cancelledDaysAgo` before treating
+  an empty window as merely unsold. Respect n here as everywhere: one cancellation is
+  an episode; several into the same window is a pattern.
+
+So the rule in step 3, stated precisely: the smallest fitting instrument is the
+smallest one **not already tried and failed on this window under current conditions**.
+Warm, cheap channels remain first-resort — but first-resort means first *considered*,
+not exempt from the ledger.
 
 ## Operating constraints (owner's standing decisions — obey; do not re-derive or re-litigate)
 
@@ -118,9 +153,12 @@ does not tell you which to use for any given situation.
   `inventory.unsellableUnderMinStay` (the latter cannot be booked as-is).
 - **Outreach to past guests** (WhatsApp) — a warm, no-commission channel; targets
   Romanian guests (see the operating constraint above). Judge the fit from
-  `audience.segments` and the occasion each week.
-- **Ads** (Meta, built separately) — reaches strangers; scales with budget. Hand over
-  as a dated, sized proposal.
+  `audience.segments` and the occasion each week — and from
+  `outreachHistory.pastCampaigns`: a recent run that converted ≈no stays leaves this
+  channel spent for now (see *Choosing the instrument*).
+- **Ads** (Meta, built separately) — reaches strangers; scales with budget; the natural
+  escalation when the warm channel is spent or the buyer you need isn't in the
+  past-guest pool. Hand over as a dated, sized proposal.
 - **Brand / page fixes** (from `currentSignals`, owner actions — not guest campaigns) — some
   health flags are prerequisites or one-off fixes, not something to route to a campaign: a page
   `websiteIsOtaLink` (the page sends clicks to an OTA → leaks direct-booking margin), a `dormant`

--- a/docs/promotion-system-architecture.md
+++ b/docs/promotion-system-architecture.md
@@ -80,6 +80,8 @@ Not a rules engine. It reads the pack and produces a **Situation Report** (headl
 ### 3.4 Routing — audience-math-driven, "both" allowed
 The split is already encoded: the analyst's standing constraint (*"WhatsApp targets Romanian guests; foreign demand is an ads or OTA matter"*) plus `src/lib/growth/audience.ts` (`isRomaniaBased` / `classifyResidency` → **domestic / diaspora / foreign**). For a detected gap the router reasons: the **warm RO/diaspora/repeat** slice → WhatsApp; the **residual/strangers/foreign** slice → ads; a **silent brand page** → an organic post. *Often the answer is several arms for the same gap, to different people* — that is the cohesion, and only one shared analyst keeps it coherent.
 
+**A window's character is a prior, not a verdict.** Detection and routing are deliberately separate: one detector surfaces the window; the router chooses the instrument, and it treats the window's character (warmth, occasion, nearness) as a prior only. Before selecting, the router reads two outcome streams — recent outreach results (a lever recently fired that converted ≈zero stays is *spent* for that window: escalate, don't repeat — `outreachHistory.pastCampaigns`) and forward cancellations (sold-then-cancelled inventory is simultaneously re-opened supply and fresh demand-softness evidence, raising urgency and shifting selection toward broader instruments — `inventory.recentCancellations`). The same gap can therefore route to different levers in different weeks: eligibility is a function of recorded history under current conditions, not of the window's character alone.
+
 ---
 
 ## 4. The channel arms

--- a/scripts/situation-pack.ts
+++ b/scripts/situation-pack.ts
@@ -513,6 +513,37 @@ async function main() {
     .slice(0, 20)
     .map(h => ({ name: h.name, type: h.type, startDate: h.startDate, endDate: h.endDate, source: h.source ?? null }));
 
+  // ---------- recent cancellations (re-opened inventory + a demand signal) ----------
+  // A cancelled FUTURE stay is BOTH an open gap that returned to inventory AND fresh evidence that
+  // demand for that window is soft — someone who had committed backed out. It is surfaced here (not
+  // silently dropped with the other cancelled rows in `live`) so the analyst can weight it. Facts
+  // only; the method (how to route on it) lives in the analyst skill. "Forward" = the stay had not
+  // yet started as of the pack date. Names are never included — window + value + timing only.
+  const forwardCancellations = allBookings
+    .filter(b => b.status === 'cancelled' && b.ci && b.ci >= AS_OF)
+    .map(b => {
+      const cancelledAt = toD(b.cancelledAt);
+      return {
+        window: `${ymd(b.ci!)}→${ymd(b.co!)}`,
+        month: `${b.ci!.getUTCFullYear()}-${String(b.ci!.getUTCMonth() + 1).padStart(2, '0')}`,
+        nights: nightsBetween(b.ci!, b.co!),
+        valueLost: round(price(b)),
+        channel: b.source ?? null,
+        cancelledDaysAgo: cancelledAt ? nightsBetween(cancelledAt, AS_OF) : null,
+      };
+    })
+    .sort((a, b) => (a.window < b.window ? -1 : 1));
+  const recentCancellations = {
+    note:
+      'Cancelled bookings whose stay is still in the FUTURE as of the pack date. Each one both re-opened ' +
+      'that window to inventory (it now sits inside a freeRun) AND is a signal demand there was soft — a ' +
+      'guest who had committed backed out. `cancelledDaysAgo` shows how fresh the signal is (null if the ' +
+      'cancellation timestamp was not recorded). valueLost is net-to-owner (dataQuality.amountsNote).',
+    forwardCount: forwardCancellations.length,
+    nightsReopened: forwardCancellations.reduce((s, c) => s + c.nights, 0),
+    items: forwardCancellations.slice(0, 12),
+  };
+
   const inventory = isHistorical
     ? {
         valid: false,
@@ -526,6 +557,7 @@ async function main() {
         valid: true,
         horizonDays: 240,
         freeRuns: runs.slice(0, 25).map(priceRun),
+        recentCancellations,
         orphanNights: {
           definition: `free runs of exactly ${MIN_STAY} nights (equal to the min-stay minimum in dataQuality.constraints)`,
           count: orphanRuns.length,
@@ -615,7 +647,7 @@ async function main() {
           .some((b: any) => b.ci && b.ci > dayD && nightsBetween(dayD, b.ci) <= 120);
         if (after) booked++;
       });
-      return { date: day, recipients: gset.size, repliedWithin14d: replied, replyRatePct: round(replied / gset.size * 100), stayedWithin120d: booked };
+      return { date: day, daysAgo: nightsBetween(dayD, AS_OF), recipients: gset.size, repliedWithin14d: replied, replyRatePct: round(replied / gset.size * 100), stayedWithin120d: booked };
     });
 
   // ---------- current brand + acquisition signals (LIVE Meta state — NOT as-of reproducible) ----------
@@ -672,7 +704,14 @@ async function main() {
     product,
     audience,
     inventory,
-    outreachHistory: { pastCampaigns: campaigns, note: 'past manual outreach runs, with reply and subsequent-stay counts per run' },
+    outreachHistory: {
+      pastCampaigns: campaigns,
+      note:
+        'Past manual outreach runs (WhatsApp), newest-last. Per run: `daysAgo` (recency), `recipients`, ' +
+        '`repliedWithin14d`/`replyRatePct`, and `stayedWithin120d` = how many recipients actually booked a ' +
+        'stay afterwards (the conversion outcome). A recent run with stayedWithin120d ≈ 0 means the warm ' +
+        'channel was already fired and did NOT convert — the method reads this before routing a window to it.',
+    },
   };
 
   const json = JSON.stringify(pack, null, 2);


### PR DESCRIPTION
## Problem
The analyst recommended a warm channel (WhatsApp) for a near-term gap while ignoring that (a) WhatsApp had just been fired at that audience ~10 days earlier and converted ~1 stay, and (b) much of the "empty" window was **sold-then-cancelled**. Both facts were invisible or unused, so warmth/occasion was treated as a **verdict** when it is only a **prior**.

## Two root causes — fixed generally (not particularized to this case)

**Pack dropped cancellations** (`situation-pack.ts` `live` filter). Added `inventory.recentCancellations` — forward-looking cancellations (`window`, `nights`, `valueLost`, `cancelledDaysAgo`, `forwardCount`, `nightsReopened`): re-opened inventory **and** a demand-softness signal.

**Outreach outcome was present but illegible for routing.** Added `daysAgo` to each `outreachHistory.pastCampaigns` run and sharpened the note (`stayedWithin120d` = conversion outcome; a recent run that converted ~0 = warm channel spent for now).

## Skill doctrine (`situation-analyst/SKILL.md`) — generalized
- **"How to think" step 3**: read the window's history before picking an instrument.
- **New section — "Choosing the instrument (a prior is not a verdict)"**: the outreach ledger + the cancellation ledger; *smallest fitting instrument = smallest one NOT already tried-and-failed on this window under current conditions*. Respects "you read, you never compute" and "respect n" (one run/one cancellation = n=1, scoped accordingly).
- **Menu**: outreach eligibility conditional on not-recently-exhausted; ads framed as the natural escalation.

## Architecture doc §3.4
Window character is a prior, not a verdict; the router reads recent-outcome + cancellation evidence; the same gap can route to different levers in different weeks.

## Notes
- Doctrine drafted with a top-reasoning (Fable) pass, then integrated.
- No Cloud Run code changed (pack is a script; skill + docs are not deployed) — no production deploy needed.
- **Scope**: this teaches the human-in-the-loop weekly analyst (the situation-analyst skill). Wiring the same two signals into the automated arm packs (`adPlannerPack`, the WhatsApp planner) is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)