### PR TITLE
Get back on track — Move 0 (docs truth) + Move 1 (signals lib)

### DIFF
--- a/docs/growth-ad-engine-plan.md
+++ b/docs/growth-ad-engine-plan.md
@@ -241,25 +241,27 @@ Don't build 2b/2c before 2a proves photos → bookings.
 
 ---
 
-## 15. Current state (26 Jul 2026) — what actually shipped and where it sits
+## 15. Current state — what actually shipped and where it sits (updated 2026-08-03)
 
-The **execution engine is built and proven at zero spend; it has never run live.** Verified against code + live account (see `docs/meta-ads-infrastructure-2026.md` §11):
+> **Update 2026-08-03:** the ads **intelligence** (§16) has since shipped — the arm is now built end to end (planner + creative + validators + review-before-push console + learning loop + reconcile cron). What remains is upstream (an in-app analyst/router to feed it automatically) + the deliberate go-live. The 26-Jul snapshot below is kept for history with corrections inline.
+
+The **whole arm is built and proven at zero spend; it has never run live.** Verified against code + live account (see `docs/meta-ads-infrastructure-2026.md` §11):
 - **Enabled but dry-run:** `GROWTH_ADS_ENABLED="true"` in `apphosting.yaml` (switch 1 ON → `/admin/ads` composes drafts + dry-run activates). `GROWTH_ADS_MODE=live` deliberately absent → **zero spend possible.**
 - **Config wired:** Prahova `analytics.{metaAdAccountId,metaPageId,metaTokenRef,metaInstagramActorId,metaPixelId}` all present; `META_ADS_TOKENS` secret live; pixel firing.
-- **2 leftover draft `adCampaigns`** from July machinery validation — confirmed PAUSED/inert in Meta, stale end-times, harmless.
-- **Never activated:** no campaign approved, none carries `spendCapMinor`, the only `adAuditLog` entry is one `dry-run`.
-- **Open gaps:** (a) **no reconciliation cron** — insights/effective-status refresh is manual (`refreshAdInsightsAction` only); (b) **no `/api/growth/ad-proposals`** brain seam; (c) 🔴 account `spend_cap = 0` (owner must set it before live).
+- **Draft `adCampaigns` come and go** via the console/CLI (all PAUSED, zero spend); e.g. the Oct autumn-break draft was created, then pulled back to a Firestore-only draft when review-before-push landed.
+- **Never activated:** no campaign approved for live, none carries a live-spend `spendCapMinor` beyond dry-run, the only real `adAuditLog` activation entry is `dry-run`.
+- **Corrected open gaps (was a/b/c):** (a) ~~no reconciliation cron~~ → **BUILT** (`api/cron/ad-reconcile` → `reconcileAdCampaigns`, incl. drift/escape detection + outcome finalize); (b) **no `/api/growth/ad-proposals` route** — *by design the console calls the intelligence in-process* (`generateAdProposalAction → planAndCreative`); the HTTP seam is only needed if an out-of-app brain is ever added; (c) account `spend_cap` — owner set it (300 RON); confirm before live.
 
-## 16. The ads INTELLIGENCE build — the missing brain (mirrors the WhatsApp arm)
+## 16. The ads INTELLIGENCE build — ✅ SHIPPED (2026-08-03; mirrors the WhatsApp arm)
 
-The engine is a safe *console where a human does 100% of the thinking*. The WhatsApp arm proves the intelligent shape end-to-end (`analyst → planner → copywriter → Gate-1 review → send`); the ads arm reuses it. See `docs/promotion-system-architecture.md` §4.2 for the cross-channel framing. Concretely:
+The engine *was* a safe console where a human did 100% of the thinking; the intelligence below has since been built, so the arm now generates its own plan + creative and the human reviews. Status per sub-item (verified against code):
 
-- **16.1 Generalize the Opportunity contract** — `contracts.ts` `Opportunity.instrument` is the literal `'whatsapp'` today; widen to `'whatsapp' | 'ads' | 'page'` so the analyst can route an opportunity to ads and a planner can consume it.
-- **16.2 Ad planner** (twin of `.claude/skills/whatsapp-planner` + `planner-pack.ts`): an ad-planner-pack (geo/interest candidates, budget ceiling `MAX_DAILY_BUDGET_MINOR`, opportunity nights/value, past-ad performance, page-best content) → LLM sizes targeting + budget + angle + creative brief → an ad-brief validator (spend-cap math via `validateApprovalCap`, geo sanity — "narrows-never-widens" against the candidate set) → a **PAUSED `adCampaigns` draft** via the existing `composeAndCreateAd`.
-- **16.3 Ad creative/copy intelligence** (twin of `copywriter.ts`): grounded in real gallery photos + best-performing past ad copy + the page's best posts; writes primary-text/headline/CTA + picks photos; validated for truth (no invented amenities) and the **public brand voice** (distinct from the private WhatsApp voice — architecture §5.1). Feeds the composer.
-- **16.4 The hand-off** — `POST /api/growth/ad-proposals` (the §7 brain seam), mirroring `land-campaign.ts → /admin/campaigns`: lands a proposal as a PAUSED draft in `/admin/ads`.
-- **16.5 Admin symmetry** — reshape `/admin/ads` from a blank compose form into the campaigns-workspace pattern: **framing → "Generate ad" → Gate-1 review → guarded activate.**
-- **16.6 Reconciliation cron** — the durability backstop the plan always intended (§13 C2/M2): a cron that syncs `effective_status` + insights and flags any non-paused campaign not in the approved set. Build before ongoing (vs one-shot) ads.
+- **16.1 Generalize the Opportunity contract** — ✅ **Done.** `contracts.ts:22` ships `OpportunityInstrument = 'whatsapp' | 'ads' | 'page'` + narrowed subtypes (`:44-46`).
+- **16.2 Ad planner** — ✅ **Built.** `adPlannerPack.ts` (geo candidates, `MAX_DAILY_BUDGET_MINOR`, opportunity value, past-ad performance + `buildAdLearnings`) → `adPlanner.ts:123` (`generateAdPlan`, forced-tool LLM) → `validateAdPlan.ts` (spend-cap + geo "narrows-never-widens") → PAUSED draft via `composeAndCreateAd`.
+- **16.3 Ad creative/copy intelligence** — ✅ **Built.** `adCopywriter.ts` grounded in real gallery photos (+ `aiDescription`) + asset-gap declarations; `validateAdCreative.ts` (truth + public brand voice).
+- **16.4 The hand-off** — ◐ **In-process, not an HTTP route.** `generateAdProposalAction → planAndCreative` lands the draft directly; `POST /api/growth/ad-proposals` was never built and is only needed if an out-of-app brain is added. (The real remaining hand-off is upstream: an in-app **analyst/router** that *produces* the routed `AdOpportunity` — see `promotion-system-architecture.md` §0.5 / §7 M2–M3.)
+- **16.5 Admin symmetry** — ✅ **Built + improved.** `/admin/ads` is framing → generate → **review-before-push** (edit copy/budget, nothing on Meta until Push) → approve → activate.
+- **16.6 Reconciliation cron** — ✅ **Built.** `api/cron/ad-reconcile` → `reconcileAdCampaigns` (`adReconciliation.ts`), incl. drift/escape detection + `finalizeAdOutcome`. A **learning loop** (`adOutcomes.ts` + `adLearnings.ts`) feeds outcomes back into the planner pack.
 
 ## 17. Go-live runbook (when the brain is trusted — a deliberate act, not a default)
 

--- a/docs/promotion-system-architecture.md
+++ b/docs/promotion-system-architecture.md
@@ -18,9 +18,28 @@
 
 **One detector, many responses.** A property has *one* situation each week — the gaps, the pace, the RevPAR trend, the dormant page. That situation is diagnosed *once* by a shared analyst, which then routes each opportunity to the instrument that fits: a WhatsApp message to warm past guests, a Meta ad to strangers, an organic page post, a price change — or, explicitly, *nothing*.
 
-**Build the intelligence before running the spend.** The execution machinery on every channel is already built and guarded. What is missing is the *brain* that decides and composes. We build that first; live ad spend is a deliberate act taken only once the brain is trusted, not a default.
+**Build the intelligence before running the spend.** The execution machinery *and* the per-arm intelligence (the ads planner + creative, the WhatsApp copywriter) are now built and guarded (see §0.5). What is still missing is the *shared brain's runtime* — an in-app analyst + router that detects the situation and emits routed opportunities into those arms, rather than a human running a skill and hand-typing windows. We build that; live ad spend is a deliberate act taken only once the brain is trusted, not a default.
 
 **The principle that governs every LLM stage:** *feed the model facts + method + constraints, never conclusions.* Guardrails constrain only **truth and margin**; relevance, presentation, voice, and per-target adaptation are the model's job. (Plan §2 principles 1 & 5.)
+
+---
+
+## 0.5 Current state — verified as-built (2026-08-03)
+
+> Verified against the code (`file:line`) + a live Meta read. **This section is the single source of truth for what EXISTS vs what is still INTENT;** the design sections below (§2–§7) describe the *target*. Where an older claim in §2–§7 conflicts with this, this wins — those conflicts are corrected in place.
+
+**Two arms are genuinely built, in-app, and coherent** (this is real, working code, not scaffolding):
+- **Ads arm — end to end.** Deterministic pack → in-app LLM planner (`adPlanner.ts:123`) → in-app creative (`adCopywriter.ts`) → truth/money validators (`validateAdPlan.ts`, `validateAdCreative.ts`) → PAUSED Meta compose (`adComposer.ts`) → a real **generate → review-before-push → approve → activate** console (`src/app/admin/ads/actions.ts:492,665,277,348`) → a reconciliation cron that freezes outcomes and feeds `buildAdLearnings` back into the planner pack (`adReconciliation.ts:163` → `adPlannerPack.ts:111`). Two-switch spend gate + spend-cap math. Never run live.
+- **WhatsApp arm.** In-app audience selection (`warmupAudience.ts`), in-app copywriter (`src/services/growth/copywriter.ts`), the full execution gateway (consent/suppression/dedup/frequency/active-booking gates, `executionGateway.ts:259`), the warmup cron, and the campaigns admin (Gate-1 review → Gate-2 wa.me).
+- Plus: the vision/caption layer (`galleryVision.ts` + `caption-gallery` cron), a **manual** page-post drafting tool (`src/app/admin/page-posts`), in-app brand-health sensors (`brandHealth.ts`), and real two-switch config.
+
+**The shared BRAIN is intent-only — it exists as a Claude skill + a CLI script + this doc, not as running code:**
+- **No in-app analyst** — analysis happens only in the `.claude/skills/situation-analyst` skill, run by a human.
+- **No in-app detector/router** — every `Opportunity.instrument` is a hardcoded literal set by its entry point (`src/app/admin/ads/actions.ts:526` for ads; `warmupAudience.ts:89` for WhatsApp). The residency predicate (`audience.ts:52`) exists but nothing calls it to route. `PageOpportunity` has zero producers.
+- **The fact pack is a CLI** (`scripts/situation-pack.ts`), not a service — nothing in `src/` imports it. The two routing signals it computes (`inventory.recentCancellations`, `outreachHistory.pastCampaigns.bookedWithin120d`) live **inline in that script**.
+- **No `POST /api/growth/ad-proposals` seam** — the console calls the ads intelligence in-process (`generateAdProposalAction` → `planAndCreative`) instead.
+
+**So:** the arms the brain would drive are built and operator-triggered; the *"one shared brain that routes across arms"* is the remaining build. It is short because the `Opportunity` contract and the arm-side seams (e.g. `planAndCreative(opportunity)`) were built ahead of it. The build order in §7 is therefore now: **give the brain a runtime** — sensors-as-a-lib → an in-app analyst service that emits routed opportunities → a `/admin` surface where the owner approves → hand-off to these already-built arms.
 
 ---
 
@@ -43,42 +62,43 @@ Acquisition is the constraint, and acquisition is ads + a live brand page. That 
   SENSORS ─────────────────────────────► ANALYST ──► ROUTER ──►  ARM (per instrument)
   (deterministic facts, no conclusions)   (LLM over    (audience-
                                            the facts)   math)
-  ┌─ inventory / pace / calendar ─┐                          ┌─ WhatsApp: planner → copywriter → wa.me   [BUILT]
-  ├─ audience segments / dueNow ──┤                          ├─ Ads: ad planner → creative/copy → activate [TO BUILD]
-  ├─ acquisition / market  [new] ─┤                          ├─ Page: post planner → composer → publish   [TO BUILD]
-  └─ Facebook page health  [new] ─┘                          └─ price / min-stay / OTA / do-nothing (human)
+  ┌─ inventory / pace / calendar ─┐                          ┌─ WhatsApp: planner → copywriter → wa.me   [BUILT*]
+  ├─ audience segments / dueNow ──┤                          ├─ Ads: ad planner → creative/copy → activate [BUILT]
+  ├─ acquisition / market ────────┤                          ├─ Page: post → manual publish [BUILT (manual); auto-publish TO BUILD]
+  └─ Facebook page health ────────┘                          └─ price / min-stay / OTA / do-nothing (human)
 ```
+`SENSORS → ANALYST → ROUTER` is the intended **spine**; today it is **not yet in-app** — the analyst + router live in the `situation-analyst` skill over a CLI pack (see §0.5), and each arm's `instrument` is hardcoded by its entry point. `[BUILT*]` = the WhatsApp *copywriter* is in-app but its *gap-planner* is still skill+CLI. Each **arm** is a per-instrument planner → generator → guarded execution gateway; the WhatsApp arm is the reference the ads/page arms copy.
 
-The **spine** (sensors → analyst → router) is shared and channel-agnostic. Each **arm** is a per-instrument planner → generator → guarded execution gateway. The WhatsApp arm is the fully-built reference implementation; the ads and page arms reuse its exact shape.
-
-| Layer | Shared? | Status |
+| Layer | Shared? | Status (verified — §0.5) |
 |---|---|---|
-| Sensors (`situation-pack.ts`) | shared | Built (inventory/pace/audience); **new: acquisition + page-health sensors** |
-| Analyst (`situation-analyst` skill) | shared | Built — LLM over facts; **already routes to ads** as a menu item |
-| Router / instrument choice | shared | Built into the analyst's reasoning (a menu, not a rules table) |
-| Opportunity contract (`contracts.ts`) | shared | Built — **but `instrument` is WhatsApp-only today; generalize to `whatsapp\|ads\|page`** |
-| WhatsApp planner + copywriter + validators | arm | **Built, live in prod** |
-| Ads planner + creative/copy intelligence | arm | **Missing** (execution console exists; no brain) |
-| Page post planner + composer | arm | **Missing** (+ needs token scopes) |
-| Execution gateways (message / ads / page) | arm | Message + ads gateways built; page gateway new |
+| Sensors (`situation-pack.ts`) | shared | Built, incl. acquisition + page-health sensors — but as a **CLI script**, not an in-app service |
+| Analyst (`situation-analyst` skill) | shared | Built as a **Claude skill only**; no in-app analyst service |
+| Router / instrument choice | shared | **Intent-only** — lives in the analyst skill's reasoning; no in-app router (every `instrument` is a hardcoded literal) |
+| Opportunity contract (`contracts.ts`) | shared | Built — the `whatsapp\|ads\|page` union **already shipped** (`contracts.ts:22`); it just has no automated producer |
+| WhatsApp planner + copywriter + validators | arm | Copywriter + validators **built in-app**; gap-**planner** is still skill + `planner-pack.ts` |
+| Ads planner + creative/copy intelligence | arm | **Built in-app** (`adPlanner.ts`, `adCopywriter.ts`, validators, review-before-push, learning loop, reconcile cron) |
+| Page post planner + composer | arm | Manual **draft** tool built (`admin/page-posts`); opportunity-routed planner + auto-publish **to build** (+ token scopes) |
+| Execution gateways (message / ads / page) | arm | Message + ads gateways built; page = manual wa.me-style hand-post (no gateway) |
 
 ---
 
 ## 3. The shared brain
 
-### 3.1 Sensors — what the system watches (`scripts/situation-pack.ts`)
-Pure functions over Firestore + the clock. Today: `performance` (occupancy/ADR/RevPAR, like-for-like YTD), month baselines, channel/origin mix, `inventory` (gaps, **orphan nights**, unsellable-under-min-stay, named periods), `audience` (segments, `dueNow`, return clock), `dataQuality` (provenance + caveats). **To add:**
+### 3.1 Sensors — what the system watches (`scripts/situation-pack.ts` — today a CLI, to become a lib)
+Pure functions over Firestore + the clock. Built: `performance` (occupancy/ADR/RevPAR, like-for-like YTD), month baselines, channel/origin mix, `inventory` (gaps, **orphan nights**, unsellable-under-min-stay, named periods, **`recentCancellations`**), `audience` (segments, `dueNow`, return clock), **`outreachHistory` (per-run reply + `bookedWithin120d` conversion)**, `dataQuality` (provenance + caveats). Both sensors below are now **built and wired** (`brandHealth.ts`, consumed by `situation-pack.ts` + `adPlannerPack.ts`):
 - **Acquisition/market sensor** — past ad performance (from the ad account: CTR/CPC/spend history), pixel pool size, seasonal demand signals. Tells the analyst whether an acquisition play is warranted and what has worked.
 - **Facebook page-health sensor** — is the page alive (last post date, engagement trend), profile correctness (e.g. the website-link-to-Airbnb leak), audience. A dormant page is itself a flagged opportunity.
+
+> Note: this whole pack is a **CLI script** today, not an in-app service. Extracting it (and its two routing signals) into `src/lib/growth/` is the first move toward the in-app brain (§7).
 
 ### 3.2 The analyst — an LLM over the facts (`.claude/skills/situation-analyst`)
 Not a rules engine. It reads the pack and produces a **Situation Report** (headline → flags ranked by money at risk → opportunities with instrument + why → an explicit NORMAL section → questions → confidence). It **never computes** (every number is cited from the pack) and **never sends or spends**. Crucially, its instrument list is *"a menu, not a mapping"* — it already includes **Ads** (*"reaches strangers; scales with budget; hand over as a dated, sized proposal"*). So detection and the WhatsApp-vs-ads decision already live in this one shared reasoner. **This is why we extend it, never fork a second ads analyst** — a fork would duplicate the identical sensors and diagnosis and could disagree with itself.
 
 ### 3.3 The Opportunity — the one shape everything shares (`src/lib/growth/contracts.ts`)
-`Opportunity` = `{ id, propertyId, source, window{start,end,nights}, daysOut, occasion?, valueAtRisk?, instrument, rationale }`. **Today `instrument` is the literal `'whatsapp'`** — the typed pipeline is WhatsApp-only by construction. **The core generalization this architecture requires: `instrument: 'whatsapp' | 'ads' | 'page'`** (or a discriminated union), so the analyst can route an opportunity to ads or the page and a matching planner can consume it — exactly as the WhatsApp planner consumes a whatsapp-routed one.
+`Opportunity` = `{ id, propertyId, source, window{start,end,nights}, daysOut, occasion?, valueAtRisk?, instrument, rationale }`. **The `instrument: 'whatsapp' | 'ads' | 'page'` union is already shipped** (`contracts.ts:22`), with narrowed `WhatsAppOpportunity`/`AdOpportunity`/`PageOpportunity` subtypes (`:44-46`), so a matching planner can consume a routed opportunity — the ads seam already does (`planAndCreative(opportunity: AdOpportunity)`). **What's still missing is the *producer*:** nothing emits a *routed* opportunity yet — every `instrument` is hardcoded by its entry point, and `PageOpportunity` has no producer at all. Building that producer (the in-app router) is the point of §7.
 
 ### 3.4 Routing — audience-math-driven, "both" allowed
-The split is already encoded: the analyst's standing constraint (*"WhatsApp targets Romanian guests; foreign demand is an ads or OTA matter"*) plus `src/lib/growth/audience.ts` (`isRomaniaBased` / `classifyResidency` → **domestic / diaspora / foreign**). For a detected gap the router reasons: the **warm RO/diaspora/repeat** slice → WhatsApp; the **residual/strangers/foreign** slice → ads; a **silent brand page** → an organic post. *Often the answer is several arms for the same gap, to different people* — that is the cohesion, and only one shared analyst keeps it coherent.
+This is the intended routing *logic* — today it lives in the analyst **skill's reasoning**, not in an in-app router (§0.5); building the in-app router that applies it is §7. The split draws on the analyst's standing constraint (*"WhatsApp targets Romanian guests; foreign demand is an ads or OTA matter"*) plus `src/lib/growth/audience.ts` (`isRomaniaBased` / `classifyResidency` → **domestic / diaspora / foreign**) — a predicate that exists in code but is **not yet called to route**. For a detected gap the router reasons: the **warm RO/diaspora/repeat** slice → WhatsApp; the **residual/strangers/foreign** slice → ads; a **silent brand page** → an organic post. *Often the answer is several arms for the same gap, to different people* — that is the cohesion, and only one shared analyst keeps it coherent.
 
 **A window's character is a prior, not a verdict.** Detection and routing are deliberately separate: one detector surfaces the window; the router chooses the instrument, and it treats the window's character (warmth, occasion, nearness) as a prior only. Before selecting, the router reads two outcome streams — recent outreach results (a lever recently fired that produced ≈zero *new bookings* — `outreachHistory.pastCampaigns.bookedWithin120d`, which counts only bookings made after the run, not pre-existing reservations — is *spent* for that window: escalate, don't repeat) and forward cancellations (sold-then-cancelled inventory is simultaneously re-opened supply and fresh demand-softness evidence, raising urgency and shifting selection toward broader instruments — `inventory.recentCancellations`). The same gap can therefore route to different levers in different weeks: eligibility is a function of recorded history under current conditions, not of the window's character alone.
 
@@ -89,12 +109,12 @@ The split is already encoded: the analyst's standing constraint (*"WhatsApp targ
 ### 4.1 WhatsApp — the reference implementation (BUILT, live in prod)
 `analyst → planner (`whatsapp-planner` skill + `planner-pack.ts`) → copywriter (`copywriter.ts`, Opus, in-app) → land (`createProposedCampaign`) → /admin/campaigns Gate-1 review → outbox → Gate-2 wa.me`. Guardrails: `validatePlan` (narrows-never-widens · run cap · offer ceiling) and `validateDrafts` (grounding · voice · self-ID · opt-out · sentiment). Ban-safe: the server never touches WhatsApp; the owner one-taps `wa.me`. This arm is the template the other two copy.
 
-### 4.2 Ads — execution built, intelligence missing (THE main build)
-**Built** (`src/services/growth/metaAds/*`, `adComposer`, `adExecutionGateway`, `/admin/ads`): the whole PAUSED create→approve→activate→pause→insights chain, two-switch spend gate, ownership asserts, spend-cap math, audit log — see `docs/growth-ad-engine-plan.md`. **Missing** — the *brain*, which is the twin of the WhatsApp arm:
-- **Ad planner** (twin of `whatsapp-planner`): an ad-planner-pack (geo/interest candidates, budget ceiling `MAX_DAILY_BUDGET_MINOR`, the opportunity's nights/value, past-ad performance, page-best content) → LLM sizes targeting + budget + angle + creative brief → an ad-brief validator (spend-cap math, geo sanity) → a **PAUSED `adCampaigns` draft** landed into `/admin/ads` for Gate-1 review. `narrows-never-widens` becomes "narrows targeting/budget against candidates"; the offer-ceiling guard becomes the spend-cap guard.
-- **Ad creative/copy intelligence** (twin of the copywriter): grounded in real gallery photos + best-performing past ad copy + the page's best posts; writes ad primary-text/headline/CTA and picks photos; validated for truth (no invented amenities) and the **public brand voice** (see §5.1). Feeds the existing composer.
-- **The hand-off**: `POST /api/growth/ad-proposals` — the analyst→ads seam that lands a proposal into the console (mirrors `land-campaign.ts` → `/admin/campaigns`).
-- **Admin symmetry**: reshape `/admin/ads` from a blank compose form into the campaigns-workspace pattern — **framing → "Generate ad" → Gate-1 review → guarded activate**.
+### 4.2 Ads — arm fully built (intelligence + review-before-push + learning); only the *automated* hand-off is missing
+As of 2026-08-03 the ads arm is the **most complete** part of the system — both execution and intelligence:
+- **Built — execution** (`src/services/growth/metaAds/*`, `adComposer`, `adExecutionGateway`, `/admin/ads`): the whole PAUSED create→approve→activate→pause→insights chain, two-switch spend gate, ownership asserts, spend-cap math, audit log — see `docs/growth-ad-engine-plan.md`.
+- **Built — the intelligence** (the twin of the WhatsApp arm, now real): the **ad planner** (`adPlanner.ts`) over an ad-planner-pack (`adPlannerPack.ts` — geo candidates, budget ceiling, opportunity value, past-ad performance + `buildAdLearnings`) → an ad-brief validator (`validateAdPlan.ts`, spend-cap + geo "narrows-never-widens"); the **ad creative** (`adCopywriter.ts`) grounded in real gallery photos (+ `aiDescription`) + asset-gap declarations, validated for truth + public brand voice (`validateAdCreative.ts`); the composer produces a PAUSED draft.
+- **Built — the console**: `/admin/ads` is the framing → generate → **review-before-push** → approve → activate workspace (`generateAdProposalAction` lands a Firestore-only draft; `pushAdToMetaAction` is the first Meta touch; go-live is gated). A **learning loop** freezes per-campaign outcomes (`adOutcomes.ts`) and feeds them back into the pack; the `ad-reconcile` cron is the durability backstop.
+- **Still missing — the *automated* hand-off only.** The console is operator-initiated (a human types the window/framing). The `POST /api/growth/ad-proposals` seam does **not** exist; the console calls `planAndCreative` in-process. The real remaining ads work is upstream: an **in-app analyst/router** that emits a routed `AdOpportunity` into this arm automatically (§0.5, §7) — plus the deliberate go-live.
 
 ### 4.3 The Facebook page — sensor AND instrument (NEW; needs a token grant)
 The page (`ComarnicChalet`, 552 followers) is a real, **dormant** asset the system should both understand and keep alive.
@@ -128,8 +148,8 @@ The governing principle for every pack and prompt (§0). Validate via the strip 
 
 ## 6. Locked design decisions (26 Jul 2026)
 
-1. **One shared analyst — extend, never fork.** Confirmed in code: the analyst already routes to ads over a menu; the RO/stranger split predicate exists.
-2. **Ad planner + creative intelligence run in-app** (like the copywriter's "Generate"), landing PAUSED drafts into `/admin/ads`.
+1. **One shared analyst — extend, never fork.** (Decision.) The analyst reasons over a menu and the RO/stranger split predicate exists (`audience.ts:52`) — but note per §0.5 this routing lives in the *skill*, not in code; the in-app router is the thing §7 builds. The decision stands: one analyst, extended — not a second ads analyst.
+2. **Ad planner + creative intelligence run in-app** (like the copywriter's "Generate"), landing PAUSED drafts into `/admin/ads`. ✅ **Done** (§4.2).
 3. **Facebook page = sensor + instrument.** Read now (profile + aggregate health); posts/IG/publishing after a one-time token grant.
 4. **Creative: real photos first** (asset_feed_spec crops); external generation (people/relight) is a later phase.
 5. **Admin symmetry:** `/admin/ads` becomes framing → generate → Gate-1 review → guarded activate.
@@ -139,14 +159,22 @@ The governing principle for every pack and prompt (§0). Validate via the strip 
 
 ## 7. Build order (value-first, lowest-risk first)
 
-1. **Page understanding + the two free fixes** — ingest readable page data (profile + aggregate insights) + the ad-history sensor; surface "page dormant" and fix the Airbnb link. No provisioning.
-2. **Generalize the Opportunity contract** (`instrument: 'whatsapp' | 'ads' | 'page'`) + make the analyst's ads/page routing emit typed opportunities.
-3. **Ad planner** — routed opportunity → PAUSED ad draft into the console (twin of the WhatsApp planner).
-4. **Ad creative/copy intelligence** — grounded in photos + best past-ad copy + page best posts; the `/admin/ads` framing→generate→review redesign.
-5. **Organic page instrument** (after the token grant) — draft → approve → publish.
-6. **Reconciliation cron + go-live** — the durability backstop (see ads plan), set the account spend limit, then run the first real ad as a deliberate act.
+Original order (26 Jul), now annotated with verified status (§0.5):
+1. **Page understanding + the two free fixes** — page/ad-history sensors + "page dormant" flag. ✅ **Sensors built** (`brandHealth.ts`); Airbnb-link fix = owner action (§8).
+2. **Generalize the Opportunity contract** + make the analyst emit typed opportunities. ◐ **Contract done** (`contracts.ts:22`); **the analyst emitting routed opportunities is NOT built** — this is the core of the remaining work.
+3. **Ad planner** — routed opportunity → PAUSED ad draft. ✅ **Built** (`adPlanner.ts`), currently fed by the operator console rather than an automated router.
+4. **Ad creative/copy intelligence + the `/admin/ads` redesign.** ✅ **Built** (`adCopywriter.ts` + review-before-push console).
+5. **Organic page instrument** (after token grant) — draft → approve → publish. ◐ **Manual draft built**; auto-publish pending a token grant (§8).
+6. **Reconciliation cron + go-live.** ✅ **Reconcile cron built** (`ad-reconcile`); go-live = a deliberate owner act (still off).
 
-Do not build a later step before an earlier one proves out. Each arm reuses the WhatsApp arm's shape, so none is a from-scratch build.
+**Remaining build — "give the brain a runtime"** (the value-first sequence, replacing what's left of steps 2/5/6):
+- **M1.** Extract the fact pack + its two routing signals from `scripts/situation-pack.ts` into `src/lib/growth/` (pure refactor; makes them importable by any arm).
+- **M2.** An **in-app analyst service** (shape of `adPlanner.ts`): pack → LLM → typed `SituationReport` + routed `Opportunity[]` → a report validator (enforces in code what the skill enforces in prose) → land into Firestore + a minimal `/admin` surface (report + opportunities + approve/dismiss). *This is the move that makes "the analyst routes in code" true.*
+- **M3.** Wire **Approve → the existing arm** (ads: the routed `AdOpportunity` flows into `planAndCreative`; WhatsApp: framing lands in the campaigns flow).
+- **M4.** Feed the two ledgers into the **arm** packs (`adPlannerPack`, the WhatsApp planner pack) so the routing doctrine fires even when no human runs the ritual.
+- **M5.** A weekly cron + owner notification. **M6.** Migrate the WhatsApp gap-planner in-app (same pattern), retiring the CLI from the production path.
+
+The **skills** (`situation-analyst`, `whatsapp-planner`) do not get thrown away — after M2 they become the *interactive console* (backtests, deep-dives) over the same lib-built pack. Do not build a later move before an earlier one proves out.
 
 ---
 

--- a/scripts/situation-pack.ts
+++ b/scripts/situation-pack.ts
@@ -21,6 +21,7 @@ dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 import { execSync } from 'child_process';
 import { getAdminDb } from '../src/lib/firebaseAdminSafe';
 import { getPageHealth, getAdAccountHealth } from '@/services/growth/metaAds/brandHealth';
+import { computeRecentCancellations, computeOutreachLedger } from '@/lib/growth/signals';
 
 const arg = (n: string, d?: string) => {
   const i = process.argv.indexOf(`--${n}`);
@@ -514,35 +515,8 @@ async function main() {
     .map(h => ({ name: h.name, type: h.type, startDate: h.startDate, endDate: h.endDate, source: h.source ?? null }));
 
   // ---------- recent cancellations (re-opened inventory + a demand signal) ----------
-  // A cancelled FUTURE stay is BOTH an open gap that returned to inventory AND fresh evidence that
-  // demand for that window is soft — someone who had committed backed out. It is surfaced here (not
-  // silently dropped with the other cancelled rows in `live`) so the analyst can weight it. Facts
-  // only; the method (how to route on it) lives in the analyst skill. "Forward" = the stay had not
-  // yet started as of the pack date. Names are never included — window + value + timing only.
-  const forwardCancellations = allBookings
-    .filter(b => b.status === 'cancelled' && b.ci && b.ci >= AS_OF)
-    .map(b => {
-      const cancelledAt = toD(b.cancelledAt);
-      return {
-        window: `${ymd(b.ci!)}→${ymd(b.co!)}`,
-        month: `${b.ci!.getUTCFullYear()}-${String(b.ci!.getUTCMonth() + 1).padStart(2, '0')}`,
-        nights: nightsBetween(b.ci!, b.co!),
-        valueLost: round(price(b)),
-        channel: b.source ?? null,
-        cancelledDaysAgo: cancelledAt ? nightsBetween(cancelledAt, AS_OF) : null,
-      };
-    })
-    .sort((a, b) => (a.window < b.window ? -1 : 1));
-  const recentCancellations = {
-    note:
-      'Cancelled bookings whose stay is still in the FUTURE as of the pack date. Each one both re-opened ' +
-      'that window to inventory (it now sits inside a freeRun) AND is a signal demand there was soft — a ' +
-      'guest who had committed backed out. `cancelledDaysAgo` shows how fresh the signal is (null if the ' +
-      'cancellation timestamp was not recorded). valueLost is net-to-owner (dataQuality.amountsNote).',
-    forwardCount: forwardCancellations.length,
-    nightsReopened: forwardCancellations.reduce((s, c) => s + c.nights, 0),
-    items: forwardCancellations.slice(0, 12),
-  };
+  // Logic lives in src/lib/growth/signals.ts so any in-app arm can read the same signal (arch §7 M1).
+  const recentCancellations = computeRecentCancellations(allBookings, AS_OF);
 
   const inventory = isHistorical
     ? {
@@ -625,35 +599,9 @@ async function main() {
       };
 
   // ---------- outreach history ----------
-  const outboundDays = new Map<string, Set<string>>();
-  tSnap.docs.forEach(d => {
-    const t: any = d.data();
-    (t.messages || []).forEach((m: any) => {
-      if (m.direction !== 'out' || m.ts >= ymd(AS_OF)) return;
-      const day = String(m.ts).slice(0, 10);
-      if (!outboundDays.has(day)) outboundDays.set(day, new Set());
-      outboundDays.get(day)!.add(d.id);
-    });
-  });
-  const campaigns = [...outboundDays.entries()].filter(([, s]) => s.size >= 8).sort()
-    .map(([day, gset]) => {
-      const dayD = new Date(`${day}T00:00:00Z`);
-      let replied = 0, booked = 0;
-      gset.forEach(gid => {
-        const msgs = ((threads.get(gid)?.messages || []) as any[]);
-        if (msgs.some(m => m.direction === 'in' && new Date(m.ts) > dayD && nightsBetween(dayD, new Date(m.ts)) <= 14)) replied++;
-        const g = guests.find(x => x.id === gid);
-        // ATTRIBUTABLE conversion: a booking MADE (createdAt) AFTER the outreach, within 120d — NOT
-        // merely a stay whose check-in falls after it (that would count pre-existing reservations a
-        // recipient already held). Gated to imported===false because imported rows carry the import
-        // timestamp, not the real booking date (dataQuality.bookingDate) — they can't support
-        // attribution.
-        const after = (g?.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
-          .some((b: any) => b.imported === false && b.created && b.created > dayD && nightsBetween(dayD, b.created) <= 120);
-        if (after) booked++;
-      });
-      return { date: day, daysAgo: nightsBetween(dayD, AS_OF), recipients: gset.size, repliedWithin14d: replied, replyRatePct: round(replied / gset.size * 100), bookedWithin120d: booked };
-    });
+  // Logic lives in src/lib/growth/signals.ts (arch §7 M1). `threads` (:292) + property-filtered
+  // `guests` (:289) + `bookingById` (:291) are the same inputs the inline version used.
+  const campaigns = computeOutreachLedger(threads, guests, bookingById, AS_OF);
 
   // ---------- current brand + acquisition signals (LIVE Meta state — NOT as-of reproducible) ----------
   // Fetched DIRECTLY from Meta at pack-build (promotion-system-architecture.md §3.1). Unlike every

--- a/src/lib/growth/signals.ts
+++ b/src/lib/growth/signals.ts
@@ -1,0 +1,202 @@
+/**
+ * growth/signals — the two ROUTING signals the promotion analyst reads before choosing an instrument,
+ * lifted out of `scripts/situation-pack.ts` so they are importable by any arm (not trapped in a CLI).
+ * See `docs/promotion-system-architecture.md` §0.5 / §7 (Move 1) and the analyst doctrine in
+ * `.claude/skills/situation-analyst/SKILL.md` ("Choosing the instrument — a prior is not a verdict").
+ *
+ *   1. recentCancellations — forward (still-future) cancelled stays: re-opened inventory AND a
+ *      demand-softness signal for that window.
+ *   2. outreachLedger      — past WhatsApp runs with their ATTRIBUTABLE conversion (bookedWithin120d):
+ *      a recent run that converted ≈0 means the warm channel is spent for what it was aimed at.
+ *
+ * Two layers:
+ *   - `compute*` — PURE functions over already-shaped data. `situation-pack.ts` calls these with the
+ *     data it already fetched, so its output is byte-identical to the old inline code.
+ *   - `get*`     — convenience fetchers (`propertyId` → result) that read Firestore + shape + compute,
+ *     for in-app arms (Move 4). Server-only (Admin SDK).
+ *
+ * Facts only — these NEVER decide routing; the analyst/router does. Names are never included.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+
+// ── local helpers (kept identical to scripts/situation-pack.ts to guarantee zero behaviour change) ──
+const toDate = (v: unknown): Date | null => {
+  const x = v as { _seconds?: number; toDate?: () => Date } | string | Date | null | undefined;
+  return (x as { _seconds?: number })?._seconds
+    ? new Date((x as { _seconds: number })._seconds * 1000)
+    : (x as { toDate?: () => Date })?.toDate
+      ? (x as { toDate: () => Date }).toDate()
+      : typeof x === 'string'
+        ? new Date(x)
+        : x instanceof Date
+          ? x
+          : null;
+};
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const nights = (a: Date, b: Date) => Math.round((+b - +a) / 86400000);
+const round = (n: number, d = 0) => Number(n.toFixed(d));
+const priceOf = (b: SignalBooking) => b.pricing?.total ?? b.pricing?.totalPrice ?? 0;
+
+// ── input shapes (what the compute functions need — a subset of a Firestore booking / thread / guest) ──
+export interface SignalBooking {
+  id?: string;
+  status?: string;
+  /** check-in / check-out / created, already parsed to Date (null if absent). */
+  ci?: Date | null;
+  co?: Date | null;
+  created?: Date | null;
+  cancelledAt?: unknown;
+  source?: string | null;
+  imported?: boolean;
+  pricing?: { total?: number; totalPrice?: number } | null;
+}
+export interface SignalThread { messages?: Array<{ direction?: string; ts?: string }> }
+export interface SignalGuest { id: string; bookingIds?: string[] }
+
+// ── output shapes ──
+export interface CancellationItem {
+  window: string;
+  month: string;
+  nights: number;
+  valueLost: number;
+  channel: string | null;
+  cancelledDaysAgo: number | null;
+}
+export interface RecentCancellations {
+  note: string;
+  forwardCount: number;
+  nightsReopened: number;
+  items: CancellationItem[];
+}
+export interface OutreachRun {
+  date: string;
+  daysAgo: number;
+  recipients: number;
+  repliedWithin14d: number;
+  replyRatePct: number;
+  bookedWithin120d: number;
+}
+
+const RECENT_CANCELLATIONS_NOTE =
+  'Cancelled bookings whose stay is still in the FUTURE as of the pack date. Each one both re-opened ' +
+  'that window to inventory (it now sits inside a freeRun) AND is a signal demand there was soft — a ' +
+  'guest who had committed backed out. `cancelledDaysAgo` shows how fresh the signal is (null if the ' +
+  'cancellation timestamp was not recorded). valueLost is net-to-owner (dataQuality.amountsNote).';
+
+/**
+ * Forward (still-future) cancellations, newest-window-first. `allBookings` must already be shaped with
+ * `ci`/`co` as Date (and filtered to those present, as the pack does) — the fetcher below does this.
+ */
+export function computeRecentCancellations(allBookings: SignalBooking[], asOf: Date): RecentCancellations {
+  const forwardCancellations = allBookings
+    .filter(b => b.status === 'cancelled' && b.ci && b.ci >= asOf)
+    .map(b => {
+      const cancelledAt = toDate(b.cancelledAt);
+      return {
+        window: `${ymd(b.ci!)}→${ymd(b.co!)}`,
+        month: `${b.ci!.getUTCFullYear()}-${String(b.ci!.getUTCMonth() + 1).padStart(2, '0')}`,
+        nights: nights(b.ci!, b.co!),
+        valueLost: round(priceOf(b)),
+        channel: b.source ?? null,
+        cancelledDaysAgo: cancelledAt ? nights(cancelledAt, asOf) : null,
+      };
+    })
+    .sort((a, b) => (a.window < b.window ? -1 : 1));
+  return {
+    note: RECENT_CANCELLATIONS_NOTE,
+    forwardCount: forwardCancellations.length,
+    nightsReopened: forwardCancellations.reduce((s, c) => s + c.nights, 0),
+    items: forwardCancellations.slice(0, 12),
+  };
+}
+
+/**
+ * Past manual WhatsApp runs (outbound-day clusters of ≥8 recipients), oldest→newest, each with its
+ * reply rate and ATTRIBUTABLE conversion: `bookedWithin120d` counts recipients who MADE a booking
+ * (createdAt) after the run within 120d — NOT a pre-existing reservation whose stay merely falls after
+ * it (gated to `imported === false`, which carries a real booking date). Evidence, not proof of cause.
+ */
+export function computeOutreachLedger(
+  threads: Map<string, SignalThread>,
+  guests: SignalGuest[],
+  bookingById: Map<string, SignalBooking>,
+  asOf: Date,
+): OutreachRun[] {
+  const outboundDays = new Map<string, Set<string>>();
+  threads.forEach((t, id) => {
+    (t.messages || []).forEach((m) => {
+      // NB: intentionally the same loose comparison as the original inline code (an outbound message
+      // always carries a ts in real data) so the pack output stays byte-identical.
+      if (m.direction !== 'out' || (m.ts as unknown as string) >= ymd(asOf)) return;
+      const day = String(m.ts).slice(0, 10);
+      if (!outboundDays.has(day)) outboundDays.set(day, new Set());
+      outboundDays.get(day)!.add(id);
+    });
+  });
+  return [...outboundDays.entries()].filter(([, s]) => s.size >= 8).sort()
+    .map(([day, gset]) => {
+      const dayD = new Date(`${day}T00:00:00Z`);
+      let replied = 0;
+      let booked = 0;
+      gset.forEach(gid => {
+        const msgs = (threads.get(gid)?.messages || []);
+        if (msgs.some(m => m.direction === 'in' && !!m.ts && new Date(m.ts) > dayD && nights(dayD, new Date(m.ts)) <= 14)) replied++;
+        const g = guests.find(x => x.id === gid);
+        const after = (g?.bookingIds || []).map((bid) => bookingById.get(bid)).filter(Boolean)
+          .some((b) => b!.imported === false && b!.created && b!.created > dayD && nights(dayD, b!.created) <= 120);
+        if (after) booked++;
+      });
+      return {
+        date: day,
+        daysAgo: nights(dayD, asOf),
+        recipients: gset.size,
+        repliedWithin14d: replied,
+        replyRatePct: round(replied / gset.size * 100),
+        bookedWithin120d: booked,
+      };
+    });
+}
+
+// ── convenience fetchers (propertyId → result) for in-app arms (Move 4). Server-only. ──
+
+function shapeBooking(id: string, x: Record<string, unknown>): SignalBooking {
+  return {
+    id,
+    status: x.status as string | undefined,
+    ci: toDate(x.checkInDate),
+    co: toDate(x.checkOutDate),
+    created: toDate(x.createdAt),
+    cancelledAt: x.cancelledAt,
+    source: (x.source as string | undefined) ?? null,
+    imported: x.imported as boolean | undefined,
+    pricing: x.pricing as SignalBooking['pricing'],
+  };
+}
+
+/** Forward cancellations for a property (re-opened inventory + demand-softness). */
+export async function getRecentCancellations(propertyId: string, asOf: Date = new Date()): Promise<RecentCancellations> {
+  const db = await getAdminDb();
+  const snap = await db.collection('bookings').where('propertyId', '==', propertyId).get();
+  const bookings = snap.docs
+    .map(d => shapeBooking(d.id, d.data() as Record<string, unknown>))
+    .filter(b => b.ci && b.co);
+  return computeRecentCancellations(bookings, asOf);
+}
+
+/** Past-outreach ledger for a property (recency + attributable conversion). */
+export async function getOutreachLedger(propertyId: string, asOf: Date = new Date()): Promise<OutreachRun[]> {
+  const db = await getAdminDb();
+  const [bSnap, gSnap, tSnap] = await Promise.all([
+    db.collection('bookings').where('propertyId', '==', propertyId).get(),
+    db.collection('guests').where('propertyIds', 'array-contains', propertyId).get(),
+    db.collection('whatsappThreads').get(),
+  ]);
+  const bookingById = new Map<string, SignalBooking>();
+  bSnap.docs.forEach(d => {
+    const b = shapeBooking(d.id, d.data() as Record<string, unknown>);
+    if (b.ci && b.co) bookingById.set(d.id, b);
+  });
+  const guests: SignalGuest[] = gSnap.docs.map(d => ({ id: d.id, bookingIds: (d.data() as { bookingIds?: string[] }).bookingIds }));
+  const threads = new Map<string, SignalThread>(tSnap.docs.map(d => [d.id, d.data() as SignalThread]));
+  return computeOutreachLedger(threads, guests, bookingById, asOf);
+}

--- a/src/services/growth/adProposal.ts
+++ b/src/services/growth/adProposal.ts
@@ -1,10 +1,14 @@
 /**
- * adProposal — the orchestrator that turns ONE ads-routed opportunity into a PAUSED, reviewable ad
- * DRAFT, end to end (promotion-system-architecture.md §4.2). It is the single seam the brain / the
- * `/admin/ads` "Generate" action / the `/api/growth/ad-proposals` endpoint all call:
+ * adProposal — the orchestrator that turns ONE ads-routed opportunity into an ad DRAFT, end to end
+ * (promotion-system-architecture.md §4.2). Two entry points:
+ *   - `planAndCreative(opportunity)` — plan + creative only, ZERO Meta footprint (what the `/admin/ads`
+ *     "Generate" action calls; it lands a Firestore-only draft, and `pushAdToMetaAction` composes later).
+ *   - `proposeAd(opportunity)` — planAndCreative + `composeAndCreateAd` in one shot (the CLI harness).
+ * NB: there is NO `/api/growth/ad-proposals` HTTP route today — the console calls these functions
+ * in-process. Such a seam is only needed if an out-of-app "brain" is ever added.
  *
  *   opportunity → buildAdPlannerPack → generateAdPlan (AdBrief) → generateAdCreative (copy+photos)
- *              → composeAndCreateAd (PAUSED Meta chain + adCampaigns draft)
+ *              → [proposeAd only] composeAndCreateAd (PAUSED Meta chain + adCampaigns draft)
  *
  * The pack is built ONCE and fed to both LLM stages. Every money/geo/creative guard already lives in
  * the stages it belongs to (`validateAdPlan`, `validateAdCreative`, `adComposer`'s budget policy) —


### PR DESCRIPTION
First two moves of the "give the brain a runtime" sequence (arch §7 M1–M6), from the verified as-built audit + Fable senior assessment. Non-breaking groundwork; nothing in the app's runtime behavior changes.

## Move 0 — docs truth pass
The docs misreported built/missing **in both directions**, which would mislead future planning sessions. Corrected against code:
- **`promotion-system-architecture.md`**: new **§0.5 "Current state — verified as-built (2026-08-03)"** (cited); fixed §2 table + diagram, §3.1/§3.3/§3.4, §4.2 (ads intelligence **built**, not "missing"), §6.1 ("routes in code" → in the skill); rewrote §7 into the **M1–M6** brain-runtime sequence.
- **`growth-ad-engine-plan.md`** §15/§16: intelligence **shipped**; reconcile cron **built**; the `/api/growth/ad-proposals` route was never built (in-process by design).
- **`adProposal.ts`** header: removed the phantom endpoint reference; documented the real two entry points.
- (`plans/engagement-system.md` "Current status" corrected locally — gitignored.)

## Move 1 — extract the two routing signals into a lib
The forward-cancellation + outreach-conversion signals were trapped inline in `scripts/situation-pack.ts`; no arm could import them.
- **`src/lib/growth/signals.ts`** (new): pure `computeRecentCancellations` / `computeOutreachLedger` + `propertyId` fetchers (`getRecentCancellations` / `getOutreachLedger`) for the arms (Move 4).
- `situation-pack.ts` now calls the pure functions with the same data.

**Verification:** the full pack JSON is **byte-identical** before vs after (`diff` clean), and `next build` **compiles successfully**. No app runtime path imports `signals.ts` yet.

## Next (held for explicit go)
Move 2 — the in-app analyst **service** (the brain's body): pack → LLM → typed `SituationReport` + routed `Opportunity[]` → validator → `/admin` surface → approve → existing arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)