### PR TITLE
Move 2 · P2 — in-app situation analyst service (the brain's runtime)

### DIFF
--- a/.claude/skills/situation-analyst/SKILL.md
+++ b/.claude/skills/situation-analyst/SKILL.md
@@ -10,6 +10,13 @@ description: >-
 
 # Situation Analyst
 
+> **In-app mirror (keep aligned).** The *production* analyst now runs in-app —
+> `src/services/growth/situationAnalyst.ts`, using `src/lib/growth/situationAnalystMethod.ts`
+> (this same METHOD) as its system prompt, over the same pack (`src/lib/growth/situationPack.ts`).
+> When you change the METHOD or the instrument doctrine here, mirror it in that module.
+> This skill is the **interactive console** (backtests, deep-dives, "why did you say that");
+> the service is the **production loop** (arch §0.5 / §7).
+
 You are the revenue analyst for a small mountain-chalet rental business.
 Your job each week: **read the facts, work out what is actually happening, and
 propose the smallest action that addresses it.**

--- a/scripts/run-situation-analyst.ts
+++ b/scripts/run-situation-analyst.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env npx tsx
+/**
+ * run-situation-analyst — exercise the IN-APP analyst service (situationAnalyst.runSituationAnalysis)
+ * on live data and print its typed output, so we can compare the in-app brain's reasoning against the
+ * situation-analyst skill before wiring it to anything (Move 2 · P2 test). Nothing is persisted or sent.
+ *
+ *   npx tsx scripts/run-situation-analyst.ts
+ *   npx tsx scripts/run-situation-analyst.ts --steer "September is fine, do not flag it"
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+const secret = (n: string) => execSync(`gcloud secrets versions access latest --secret=${n} --project=rentalspot-fzwom`, { encoding: 'utf8' }).trim();
+if (!process.env.ANTHROPIC_API_KEY) process.env.ANTHROPIC_API_KEY = secret('ANTHROPIC_API_KEY');
+if (!process.env.META_ADS_TOKENS) process.env.META_ADS_TOKENS = secret('META_ADS_TOKENS');
+
+import { runSituationAnalysis } from '@/services/growth/situationAnalyst';
+
+const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
+const steer = arg('steer');
+
+(async () => {
+  const res = await runSituationAnalysis(PROPERTY, { steer });
+  console.log(`\n=== ok:${res.ok} · attempts:${res.attempts} · flags:${res.report?.flags?.length ?? 0} · opps:${res.opportunities.length} ===`);
+  if (res.errors.length) console.log('ERRORS:\n  -', res.errors.join('\n  - '));
+  if (res.warnings.length) console.log('WARNINGS (soft grounding):\n  -', res.warnings.join('\n  - '));
+
+  const r = res.report;
+  if (r) {
+    console.log('\nHEADLINE\n  ' + r.headline);
+    console.log('\nFLAGS');
+    r.flags.forEach(f => console.log(`  [${f.severity}] ${f.what}\n      → ${f.evidence.path} = ${f.evidence.value}  (${f.whoActs})`));
+    console.log('\nNORMAL'); r.normal.forEach(n => console.log('  - ' + n));
+    console.log('\nQUESTIONS'); r.questions.forEach(q => console.log('  - ' + q));
+    console.log(`\nCONFIDENCE  sure:${r.confidence.sure.length} · thin:${r.confidence.thin.length} · guessing:${r.confidence.guessing.length}`);
+    r.confidence.thin.forEach(t => console.log('  thin: ' + t));
+    if (r.packGaps?.length) { console.log('\nPACK GAPS'); r.packGaps.forEach(g => console.log('  - ' + g)); }
+  }
+  console.log('\nOPPORTUNITIES');
+  res.opportunities.forEach((o, i) => {
+    const w = o.window ? ` · ${o.window.start}→${o.window.end} (${o.window.nights}n)` : '';
+    const v = o.valueAtRisk ? ` · ~${o.valueAtRisk} RON` : '';
+    console.log(`  [${i}] ${o.action.toUpperCase()}${w}${v}`);
+    if (o.audience) console.log(`       audience: ${o.audience}`);
+    console.log(`       why: ${o.rationale}`);
+    if (o.rejected) console.log(`       rejected: ${o.rejected}`);
+  });
+  process.exit(res.ok ? 0 : 1);
+})().catch(e => { console.error(e); process.exit(1); });

--- a/src/lib/growth/contracts.ts
+++ b/src/lib/growth/contracts.ts
@@ -45,6 +45,63 @@ export type WhatsAppOpportunity = Opportunity & { instrument: 'whatsapp' };
 export type AdOpportunity = Opportunity & { instrument: 'ads' };
 export type PageOpportunity = Opportunity & { instrument: 'page' };
 
+// ── analyst output: the Situation Report + its recommendations (Move 2, arch §7 M2) ──────────────
+/**
+ * The analyst's FULL instrument menu — deliberately broader than `OpportunityInstrument` (which is
+ * only the three campaign arms). The analyst may recommend a price/min-stay/LOS/OTA change or, most
+ * importantly, `none` (do nothing). Only `CAMPAIGN_ACTIONS` have a downstream arm; the rest are owner
+ * actions surfaced for the human to act on. A routable recommendation converts to a narrow
+ * `Opportunity` at hand-off (P5).
+ */
+export type RecommendedAction = OpportunityInstrument | 'price' | 'minstay' | 'los' | 'ota' | 'none';
+export const CAMPAIGN_ACTIONS = ['whatsapp', 'ads', 'page'] as const;
+export function isRoutable(o: Pick<AnalystOpportunity, 'action'>): boolean {
+  return (CAMPAIGN_ACTIONS as readonly string[]).includes(o.action);
+}
+
+/** One ranked flag in the Situation Report. `evidence` is the grounding contract: a pack path + the value there. */
+export interface Flag {
+  severity: 'red' | 'amber' | 'yellow';
+  what: string;
+  evidence: { path: string; value: string };
+  whoActs: 'owner' | 'system';
+}
+
+/**
+ * The analyst's diagnosis — the typed twin of the `situation-analyst` skill's text Situation Report.
+ * Every number must trace to the pack (the validator checks flag evidence paths). "Nothing is wrong"
+ * is a valid, important output — that is what `normal` + an empty/low-severity `flags` express.
+ */
+export interface SituationReport {
+  headline: string;
+  flags: Flag[];                                   // ranked by money at risk
+  normal: string[];                                // what looks alarming but isn't, and why
+  questions: string[];                             // what the data cannot explain (a human answer would change the call)
+  confidence: { sure: string[]; thin: string[]; guessing: string[] };
+  packGaps?: string[];                             // facts it needed and could not get
+}
+
+/**
+ * One recommendation the analyst routed to an action. If `action ∈ CAMPAIGN_ACTIONS` it has an arm
+ * (P5 hand-off → a PAUSED draft); otherwise it is an owner action (price/min-stay/OTA) or `none`.
+ * The analyst EMITS this shape; the service adds id/propertyId/source when persisting (P3).
+ */
+export interface AnalystOpportunity {
+  window?: { start: string; end: string; nights: number } | null;   // the dated window (absent for price/ota/none)
+  occasion?: string | null;
+  valueAtRisk?: number | null;                     // money at stake, cited from the pack, if known
+  action: RecommendedAction;
+  audience?: string | null;                        // for campaign actions: who to reach
+  rationale: string;                               // why this action fits the size + cause
+  rejected?: string | null;                        // the instrument(s) it considered and rejected, and why
+}
+
+/** The analyst's complete output: the diagnosis + the routed recommendations. */
+export interface AnalystOutput {
+  report: SituationReport;
+  opportunities: AnalystOpportunity[];
+}
+
 // ── planner → copywriter / validator / createManualCampaign ──────────────────
 export type CampaignIntent = 'gap_fill' | 'share';
 

--- a/src/lib/growth/situationAnalystMethod.ts
+++ b/src/lib/growth/situationAnalystMethod.ts
@@ -1,0 +1,70 @@
+/**
+ * situationAnalystMethod — the CANONICAL method text for the in-app analyst service, used as the
+ * system prompt for the LLM stage (src/services/growth/situationAnalyst.ts). It is the same method
+ * the .claude/skills/situation-analyst skill applies, adapted for a forced tool call instead of a
+ * text report.
+ *
+ * SINGLE-SOURCE NOTE: perfect single-sourcing between a Markdown skill and a TS service is not
+ * achievable (one is read by Claude Code, one is compiled). THIS module is canonical for the in-app
+ * analyst; .claude/skills/situation-analyst/SKILL.md is canonical for the interactive console. When
+ * you change the METHOD in one, mirror it in the other (both carry a pointer to this fact).
+ *
+ * No backticks inside the template literal (it terminates the string) — pack fields are named in
+ * plain text.
+ */
+export const SITUATION_ANALYST_METHOD = `You are the revenue analyst for a small Romanian mountain-chalet rental business. Each run: read the deterministic fact PACK, work out what is actually happening, and propose the smallest action that addresses it. You are a partner, not a dashboard — you explain what the numbers mean, say which you do not trust, and ask when the data cannot tell you.
+
+THE ONE RULE — you read, you never compute.
+Every number you state must ALREADY exist in the pack, addressable by a path (e.g. performance.ytdComparable.rows[3].revpar). Never do arithmetic — not percentages, not differences, not projections. If a number you want is not in the pack, say the pack does not contain it and move on. A single invented figure destroys the owner's trust in everything else. Each flag you raise must carry an evidence path + the value found there — cite, do not calculate.
+
+READ dataQuality FIRST, every run.
+The pack's dataQuality block states the provenance and limits of the data — what is and is not reconstructable, which comparisons are valid, how large the sample is. Respect it. Do not work around a limit it declares. In particular:
+- Compare like-for-like only. Use the ytdComparable blocks (every year windowed identically). Never compare a partial current period against a prior complete one; rows flagged isPartialYear / isPartialMonth are not comparable to complete ones.
+- Respect n. Check yearsOfData / n before drawing a conclusion. State the n. Do not assert a trend from a single month or a handful of observations.
+
+currentSignals — live brand & acquisition state.
+pack.currentSignals carries LIVE Facebook page + ad-account health, read at pack-build. It is CURRENT state — no history, not tied to the as-of date, withheld on a backtest (available:false). Never put a currentSignals number into a trend or a like-for-like comparison. Use it only to answer "how do the page and ad account stand right now", and surface each block's warnings as flags — several are owner/brand prerequisites (a page website-is-OTA-link leak, a dormant page, no-account-spend-limit, an unpublished page), not guest campaigns. If available is false, say the signal was unavailable; do not infer all-is-well from its absence.
+
+HOW TO THINK — work in this order; do not jump to step 3.
+1. What changed? Look at occupancy, ADR and RevPAR together, never occupancy alone — the three can move in different directions and only the combination tells you what happened. Read the multi-year series, not an average.
+2. Why? Look for the mechanism across signals — channel mix, origin mix, new-vs-repeat, rate. The informative findings live in the interaction between signals. Classify what you find: structural (a channel, a price, a market shift — outreach cannot fix these), episodic (a cancellation, a specific gap, a holiday window — actionable now), or one-off (an unusual month, a non-recurring source — do not extrapolate). "Behind baseline" is a HYPOTHESIS, not a hole: month baselines blend demand regimes that may no longer hold (see dataQuality.baselineCaveat). Before flagging a month as underperforming, read its perYear series against origin.byYear and judge whether the baseline leans on years/demand that will not recur. If the yardstick is ambiguous, report the month as ambiguous and say why.
+3. What to do? Pick the smallest instrument that fits the thing you found, and say why the others do not. Match the instrument to the size AND cause of the problem. But first read the window's history (next section). "Do nothing, because this is normal / outside our control" is a valid and often correct answer.
+
+CHOOSING THE INSTRUMENT — a prior is not a verdict.
+A window's character (a warm audience, an occasion, nearness) SUGGESTS an instrument; it never selects one. Character is a prior; the window's history is evidence, and evidence outranks the prior. Read two ledgers before you route:
+- The outreach ledger (outreachHistory.pastCampaigns). A recent run whose bookedWithin120d is ~nothing against its recipients means the warm pool was just pitched and did not book — that lever is SPENT for now for whatever it was aimed at. Proposing it again is the same instrument failing twice; escalate to a different lever and cite the ledger. What counts as "recent" and "~nothing" is your judgment from daysAgo and the run's size — read the magnitudes; do not invent a cutoff. Scope it: one run is strong evidence about this audience now, thin evidence about the channel in general.
+- The cancellation ledger (inventory.recentCancellations). A forward cancellation is two signals: the window returned to inventory AND someone who had committed backed out — fresh evidence demand there is soft. A sold-then-cancelled run is more urgent than one that never sold, and the softness argues for broader/stronger tools than a warm nudge. Respect n: one cancellation is an episode; several into one window a pattern.
+So the smallest fitting instrument is the smallest one NOT already tried-and-failed on this window under current conditions. Warm, cheap channels stay first-resort — first-resort means first CONSIDERED, not exempt from the ledger.
+
+OPERATING CONSTRAINTS (owner's standing decisions — obey; do not re-derive or re-litigate).
+- WhatsApp / past-guest outreach targets ROMANIAN guests. Foreign demand is an ads or OTA matter — never propose a past-guest message to bring foreigners back. (The pack carries guest data by origin; the rule stands regardless.)
+
+THE INSTRUMENTS (a menu, not a mapping — decide which fits from the pack each run):
+- whatsapp — outreach to past guests: a warm, no-commission channel; targets Romanian guests. Judge fit from audience.segments + the occasion + the outreach ledger (a recently-spent pool disqualifies it for now).
+- ads — Meta paid, reaches STRANGERS; scales with budget; the natural escalation when the warm channel is spent or the buyer you need is not in the past-guest pool. Hand over as a dated, sized proposal.
+- page — an organic brand post (keeping the page alive). A dormant page is itself a flag (owner action).
+- price — the largest lever; never a message. Check dataQuality.pricing for whether in-system pricing is even the live rate before reasoning about it.
+- minstay — a minimum-stay change; see inventory for the current min-stay and any gaps it makes unsellable.
+- los — a length-of-stay discount, when one long booking beats several short ones.
+- ota — an OTA action: ranking, parity, listing quality.
+- none — do nothing, when a month is at its own baseline or the cause is outside our control. A system that never says "this is normal" cannot be trusted when it says "this is not."
+Brand/page health flags from currentSignals (OTA website link, dormant page, no spend limit) are owner FLAGS, not guest campaigns.
+
+METHOD REMINDERS (how to be wrong less):
+- Compare a partial period only to the same partial window in other years.
+- Read the multi-year series, not an average — an average can hide a trend.
+- Occupancy alone is not a verdict. Read it with ADR and RevPAR.
+- Rank flags by money at risk, not by how precisely a thing can be measured. Do not colour something red because it is easy to measure.
+- Do not reach for the same instrument every time; most problems have a cheaper-fitting tool.
+- Cite the n on anything thin; do not diagnose from a single month.
+- Headline first — do not bury the answer.
+
+GUARDRAILS:
+- You PROPOSE. You never send, spend, or change anything.
+- Report audience sizes and segments as information. Whether and whom the owner contacts is the owner's decision, not yours to police.
+- Never name individual guests — segment counts only.
+
+OUTPUT — call emit_situation once, with:
+- report: the diagnosis. headline (one or two sentences: what is actually going on; if nothing changed, say so). flags (ranked by money at risk; each with severity, what, an evidence {path, value} that exists in the pack, and whoActs). normal (what looks alarming but is not, and why — this is what makes the rest credible). questions (what the data cannot explain and a human answer would change). confidence (sure / thin / guessing). packGaps (facts you needed and could not get).
+- opportunities: zero or more recommendations. Each: the action (from the menu above), the window {start,end,nights} when it is a dated window (omit for price/ota/none), occasion, valueAtRisk (cited from the pack, if known), audience (for campaign actions: who), rationale (why THIS action, matched to size + cause + the ledgers), and rejected (which instruments you considered and rejected, and why). If nothing is worth acting on, return an empty opportunities array and say so in the report's normal section. A window-targeting action (whatsapp/ads/page) MUST have a window that sits inside a real inventory.freeRuns entry — never invent a window.
+Nothing else — just the tool call.`;

--- a/src/lib/growth/validateSituationReport.ts
+++ b/src/lib/growth/validateSituationReport.ts
@@ -1,0 +1,105 @@
+/**
+ * validateSituationReport — enforces IN CODE what the analyst skill enforces in prose (arch §7 M2).
+ * The LLM owns the judgement; this is the guard that its output cannot lie about structure:
+ *
+ *   HARD (reject → bounded repair):
+ *     - every opportunity.action is on the menu;
+ *     - a window-targeting action (whatsapp/ads/page) carries a window that sits INSIDE a real
+ *       inventory.freeRuns entry — narrows-never-widens (the analyst cannot invent a free window).
+ *   SOFT (surfaced as warnings, not blocking — grounding review during calibration):
+ *     - each flag cites a pack path that resolves, and the cited value matches the pack.
+ *
+ * Value-match is soft on purpose: citation formats vary, and one mismatched digit should flag for
+ * review, not block the whole report. The structural guarantees are the hard gate. Pure — no I/O.
+ */
+import type { AnalystOutput, AnalystOpportunity, Flag, RecommendedAction } from '@/lib/growth/contracts';
+
+const MENU: RecommendedAction[] = ['whatsapp', 'ads', 'page', 'price', 'minstay', 'los', 'ota', 'none'];
+const WINDOW_ACTIONS = new Set<RecommendedAction>(['whatsapp', 'ads', 'page']);
+
+export interface SituationValidation {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/** Resolve a dot/bracket path (e.g. "performance.byYear[0].revpar") into a value; undefined if absent. */
+export function resolvePath(root: unknown, path: string): unknown {
+  const parts = path.replace(/\[(\d+)\]/g, '.$1').split('.').filter(Boolean);
+  let cur: unknown = root;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+/** Whole days from a→b for two YYYY-MM-DD dates (UTC). */
+const dayspan = (a: string, b: string) => Math.round((Date.parse(b) - Date.parse(a)) / 86400000);
+
+export function validateSituationReport(pack: unknown, out: AnalystOutput): SituationValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Free runs are present only when inventory is valid (withheld on a backtest). Each: {start,end,nights}.
+  const inv = (pack as { inventory?: { valid?: boolean; freeRuns?: Array<{ start: string; end: string; nights: number }> } })?.inventory;
+  const freeRuns = inv && inv.valid !== false && Array.isArray(inv.freeRuns) ? inv.freeRuns : [];
+
+  // ── report shape ──
+  const report = out?.report;
+  if (!report || typeof report.headline !== 'string' || !report.headline.trim()) {
+    errors.push('report.headline is missing or empty');
+  }
+  if (report && !Array.isArray(report.flags)) {
+    errors.push('report.flags must be an array');
+  }
+
+  // ── flag grounding (SOFT) — every flag should cite a pack path that resolves to the value shown ──
+  (report?.flags ?? []).forEach((f: Flag, i: number) => {
+    if (!f?.evidence || typeof f.evidence.path !== 'string' || !f.evidence.path.trim()) {
+      warnings.push(`flag[${i}] has no evidence.path (grounding)`);
+      return;
+    }
+    const resolved = resolvePath(pack, f.evidence.path);
+    if (resolved === undefined) {
+      warnings.push(`flag[${i}] evidence.path "${f.evidence.path}" does not resolve in the pack`);
+    } else if (f.evidence.value != null && String(resolved) !== String(f.evidence.value)) {
+      warnings.push(`flag[${i}] evidence.value "${f.evidence.value}" != pack value "${String(resolved)}" at ${f.evidence.path}`);
+    }
+  });
+
+  // ── opportunities (HARD) — on-menu + window ⊆ a real free run ──
+  (out?.opportunities ?? []).forEach((o: AnalystOpportunity, i: number) => {
+    if (!MENU.includes(o.action)) {
+      errors.push(`opportunity[${i}] action "${o.action}" is off-menu (allowed: ${MENU.join(', ')})`);
+      return;
+    }
+    if (WINDOW_ACTIONS.has(o.action)) {
+      const w = o.window;
+      if (!w || !w.start || !w.end) {
+        errors.push(`opportunity[${i}] action "${o.action}" needs a window {start,end,nights} — a campaign targets a dated window`);
+        return;
+      }
+      if (w.start > w.end) {
+        errors.push(`opportunity[${i}] window start ${w.start} is after end ${w.end}`);
+      }
+      if (freeRuns.length) {
+        // Nights-based fit: the window must sit inside ONE free run. Using nights (not the raw end
+        // date) is robust to the checkout-vs-last-night convention: a run of N free nights from
+        // r.start covers a booking of up to N nights starting on any date within [r.start, r.end].
+        const nights = w.nights ?? Math.max(1, dayspan(w.start, w.end));
+        const fits = freeRuns.some(r => w.start >= r.start && w.start <= r.end && dayspan(w.start, r.end) + 1 >= nights);
+        if (!fits) {
+          errors.push(`opportunity[${i}] window ${w.start}..${w.end} (${nights}n) is not inside any inventory.freeRuns entry — narrows-never-widens`);
+        }
+      } else {
+        warnings.push(`opportunity[${i}] window not checked against free runs (inventory withheld — e.g. a backtest)`);
+      }
+    }
+    if (!o.rationale || !o.rationale.trim()) {
+      warnings.push(`opportunity[${i}] has no rationale`);
+    }
+  });
+
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/src/services/growth/situationAnalyst.ts
+++ b/src/services/growth/situationAnalyst.ts
@@ -1,0 +1,191 @@
+/**
+ * situationAnalyst (in-app) — the shared BRAIN's runtime (arch §7 M2). Builds the deterministic
+ * situation pack, calls Claude with the analyst METHOD as its system prompt (forced tool call), and
+ * returns a typed SituationReport + routed AnalystOpportunity[]. The twin of adPlanner/copywriter:
+ * same shape (build pack → forced tool call → validate → bounded repair). It PROPOSES only — it never
+ * sends, spends, or writes anything (persistence + hand-off to the arms are P3/P5).
+ *
+ * The analyst's judgement is the LLM's; the guardrails (menu, window ⊆ a real free run) are enforced
+ * in CODE (validateSituationReport). Grounding (every flag cites a pack path) is checked and surfaced
+ * as warnings for the calibration phase. Server-only; throws a clear error if ANTHROPIC_API_KEY absent.
+ */
+import { getAnthropicClient, COPYWRITER_MODEL } from '@/lib/growth/anthropic';
+import { buildSituationPack, type SituationPack } from '@/lib/growth/situationPack';
+import { SITUATION_ANALYST_METHOD } from '@/lib/growth/situationAnalystMethod';
+import { validateSituationReport } from '@/lib/growth/validateSituationReport';
+import type { AnalystOutput, AnalystOpportunity, SituationReport } from '@/lib/growth/contracts';
+import { loggers } from '@/lib/logger';
+
+const logger = loggers.campaign;
+
+const SITUATION_TOOL = {
+  name: 'emit_situation',
+  description: 'Emit the Situation Report (the diagnosis) and the routed opportunities.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      report: {
+        type: 'object',
+        description: 'The diagnosis. Every number must exist in the pack (cite it in a flag evidence path).',
+        properties: {
+          headline: { type: 'string', description: 'One or two sentences: what is actually going on. If nothing changed, say so.' },
+          flags: {
+            type: 'array',
+            description: 'Ranked by MONEY AT RISK (not by how precisely a thing can be measured). Empty is fine if nothing is wrong.',
+            items: {
+              type: 'object',
+              properties: {
+                severity: { type: 'string', enum: ['red', 'amber', 'yellow'] },
+                what: { type: 'string', description: 'what is going on, in one line' },
+                evidence: {
+                  type: 'object',
+                  description: 'the grounding: a pack path that resolves + the value there',
+                  properties: {
+                    path: { type: 'string', description: 'a resolvable pack path, e.g. inventory.recentCancellations.nightsReopened or performance.ytdComparable.rows[3].revpar' },
+                    value: { type: 'string', description: 'the value found at that path, as text' },
+                  },
+                  required: ['path', 'value'],
+                },
+                whoActs: { type: 'string', enum: ['owner', 'system'] },
+              },
+              required: ['severity', 'what', 'evidence', 'whoActs'],
+            },
+          },
+          normal: { type: 'array', items: { type: 'string' }, description: 'What looks alarming but is not, and why — this is what makes the rest credible.' },
+          questions: { type: 'array', items: { type: 'string' }, description: 'What the data cannot explain and a human answer would change.' },
+          confidence: {
+            type: 'object',
+            properties: {
+              sure: { type: 'array', items: { type: 'string' } },
+              thin: { type: 'array', items: { type: 'string' }, description: 'with the n' },
+              guessing: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['sure', 'thin', 'guessing'],
+          },
+          packGaps: { type: 'array', items: { type: 'string' }, description: 'facts you needed and could not get' },
+        },
+        required: ['headline', 'flags', 'normal', 'questions', 'confidence'],
+      },
+      opportunities: {
+        type: 'array',
+        description: 'Zero or more recommendations. Empty if nothing is worth acting on (say so in report.normal).',
+        items: {
+          type: 'object',
+          properties: {
+            action: { type: 'string', enum: ['whatsapp', 'ads', 'page', 'price', 'minstay', 'los', 'ota', 'none'], description: 'the instrument from the menu' },
+            window: {
+              type: 'object',
+              description: 'the dated window; REQUIRED for whatsapp/ads/page and MUST sit inside a real inventory.freeRuns entry; omit for price/ota/none',
+              properties: {
+                start: { type: 'string', description: 'YYYY-MM-DD' },
+                end: { type: 'string', description: 'YYYY-MM-DD (checkout)' },
+                nights: { type: 'number' },
+              },
+              required: ['start', 'end', 'nights'],
+            },
+            occasion: { type: 'string' },
+            valueAtRisk: { type: 'number', description: 'money at stake, cited from the pack if known' },
+            audience: { type: 'string', description: 'for campaign actions: who to reach (e.g. a segment description)' },
+            rationale: { type: 'string', description: 'why THIS action, matched to the size + cause + the outreach/cancellation ledgers' },
+            rejected: { type: 'string', description: 'which instruments you considered and rejected, and why' },
+          },
+          required: ['action', 'rationale'],
+        },
+      },
+    },
+    required: ['report', 'opportunities'],
+  },
+};
+
+interface EmitSituationInput {
+  report: SituationReport;
+  opportunities: AnalystOpportunity[];
+}
+
+export interface RunSituationAnalysisResult {
+  ok: boolean;
+  report: SituationReport | null;
+  opportunities: AnalystOpportunity[];
+  errors: string[];
+  warnings: string[];
+  attempts: number;
+  /** The pack the analysis ran over — returned so P3 can persist it (evidence links + "why did you say that"). */
+  pack: SituationPack;
+}
+
+/**
+ * Run the situation analysis for a property. Builds the pack, runs the LLM, validates, and on failure
+ * feeds the validator errors back for a bounded repair before returning. `steer` is the owner's
+ * challenge note (P4) folded into the prompt. Never sends/spends/writes.
+ */
+export async function runSituationAnalysis(
+  propertyId: string,
+  opts?: { asOf?: Date; steer?: string; maxRepairs?: number; pack?: SituationPack },
+): Promise<RunSituationAnalysisResult> {
+  const client = getAnthropicClient();
+  if (!client) throw new Error('ANTHROPIC_API_KEY not configured — the in-app situation analyst is unavailable');
+
+  const asOf = opts?.asOf ?? new Date();
+  const pack = opts?.pack ?? (await buildSituationPack(propertyId, asOf));
+  const maxRepairs = opts?.maxRepairs ?? 1;
+
+  const steer = opts?.steer?.trim();
+  const steerBlock = steer
+    ? `\n\nThe owner has left a note that MUST shape your analysis (a challenge/steer):\n"${steer}"\n` +
+      `Take it seriously and adjust your findings/recommendations accordingly — but NEVER invent facts to satisfy it; ` +
+      `if the pack contradicts it, say so plainly in the report.`
+    : '';
+
+  const packJson = JSON.stringify(pack);
+  const messages: Array<{ role: 'user' | 'assistant'; content: unknown }> = [
+    { role: 'user', content: `Here is the situation pack. Analyse it and call emit_situation.${steerBlock}\n\n${packJson}` },
+  ];
+
+  let report: SituationReport | null = null;
+  let opportunities: AnalystOpportunity[] = [];
+  let lastValidation = { ok: false, errors: [] as string[], warnings: [] as string[] };
+
+  for (let attempt = 1; attempt <= maxRepairs + 1; attempt++) {
+    const resp = await client.messages.create({
+      model: COPYWRITER_MODEL, // Opus 4.8 (no `thinking` param: incompatible with forced tool_choice)
+      max_tokens: 8192,
+      system: SITUATION_ANALYST_METHOD,
+      tools: [SITUATION_TOOL],
+      tool_choice: { type: 'tool', name: 'emit_situation' },
+      messages: messages as never,
+    });
+
+    const toolUse = resp.content.find((b: { type: string }) => b.type === 'tool_use') as { id?: string; input?: EmitSituationInput } | undefined;
+    const input = toolUse?.input;
+    const toolUseId = toolUse?.id;
+
+    report = input?.report ?? null;
+    opportunities = Array.isArray(input?.opportunities) ? input!.opportunities : [];
+
+    const out: AnalystOutput = { report: report as SituationReport, opportunities };
+    const v = report
+      ? validateSituationReport(pack, out)
+      : { ok: false, errors: ['the model returned no report'], warnings: [] };
+    lastValidation = { ok: v.ok, errors: v.errors, warnings: v.warnings };
+    logger.info('situationAnalyst attempt', {
+      attempt, propertyId, flags: report?.flags?.length ?? 0, opps: opportunities.length,
+      ok: v.ok, errors: v.errors.length, warnings: v.warnings.length,
+    });
+
+    if (v.ok) return { ok: true, report, opportunities, errors: [], warnings: v.warnings, attempts: attempt, pack };
+    if (attempt > maxRepairs) break;
+
+    // Bounded repair: hand back the exact errors (via a tool_result, required after a tool_use).
+    const repairText =
+      `The output failed validation. Fix EXACTLY these and re-emit via emit_situation:\n- ${lastValidation.errors.join('\n- ')}\n\n` +
+      `Reminder: opportunity.action must be on the menu; a whatsapp/ads/page opportunity MUST carry a window ` +
+      `that sits inside a real inventory.freeRuns entry — never invent a free window.`;
+    messages.push({ role: 'assistant', content: resp.content });
+    messages.push({
+      role: 'user',
+      content: toolUseId ? [{ type: 'tool_result', tool_use_id: toolUseId, content: repairText }] : repairText,
+    });
+  }
+
+  return { ok: false, report, opportunities, errors: lastValidation.errors, warnings: lastValidation.warnings, attempts: maxRepairs + 1, pack };
+}


### PR DESCRIPTION
Second phase of Move 2. Engine only — no UI, no Firestore, no arm hand-off (those are P3–P5). Nothing it produces can send, spend, or write.

## What
`src/services/growth/situationAnalyst.ts` → `runSituationAnalysis(propertyId, {asOf, steer})`: `buildSituationPack` → Claude (forced tool-call, Opus 4.8, the analyst method as system prompt) → typed **`SituationReport` + `AnalystOpportunity[]`** → `validateSituationReport` → bounded repair. Same proven shape as `adPlanner`.

- **`situationAnalystMethod.ts`** — the canonical method (mirrored from the skill): read-never-compute, dataQuality-first, the instrument doctrine (*a prior is not a verdict*), the guardrails. `SKILL.md` now points to it as the single source for the in-app service.
- **`validateSituationReport.ts`** — HARD: `action ∈` menu; a `whatsapp/ads/page` window must sit inside a real `inventory.freeRuns` entry (nights-based, so the checkout-vs-last-night convention doesn't false-fail). SOFT: flag evidence path resolves + value matches → warnings (grounding review during calibration).
- **`contracts.ts`** — `SituationReport`, `Flag`, `RecommendedAction` (full menu incl. `price/minstay/los/ota/none`), `AnalystOpportunity`, `AnalystOutput`. Kept distinct from the narrow `Opportunity` (the arms' type); converts at hand-off (P5).

## Tested on live data (the P2 deliverable)
It reasons as well as the skill:
- Flags **September (13% vs 46% baseline)**, the **27 re-opened cancellation nights**, and the **spent WhatsApp channel** (Jul-24 run: 13 recipients → 0 booked in 120d).
- Routes September to **ADS** and explicitly **rejects `whatsapp`** citing the outreach ledger — *the doctrine firing in code*, not in prose.
- Says **`none`** for Oct/Nov (won't act on missing availability docs).
- Under a challenge steer (*"just message WhatsApp"*), it **defends with the ledger** instead of caving, and never invents facts to satisfy it.
- Validator **ok on attempt 1** (3 soft warnings: object-valued evidence paths — a known refinement, not a blocker). `next build` compiles.

## Next (P3)
Persist reports + opportunities and surface them at a **read-only `/admin/situation`**, so you can read a few real reports and calibrate before any action buttons exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)