### PR TITLE
Move 2 · P3 — read-only /admin/situation (the analyst in your dashboard)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -132,6 +132,14 @@
         { "fieldPath": "propertyId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "situationReports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "propertyId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -273,6 +273,18 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only (page-posts server actions)
     }
 
+    match /situationReports/{reportId} {
+      // The in-app analyst's persisted Situation Reports (Move 2 · P3) — super-admin/owner read.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (situationAnalyst service via runAnalysisAction)
+    }
+
+    match /opportunities/{oppId} {
+      // Routed opportunities the analyst produced — super-admin/owner read.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only
+    }
+
     match /adImageCache/{cacheId} {
       // Per-(platform, ad account, content hash) image-hash dedup cache
       // (Phase 2a Build A) — no user-facing write path exists.

--- a/scripts/seed-situation-report.ts
+++ b/scripts/seed-situation-report.ts
@@ -1,0 +1,34 @@
+/**
+ * Mirror runAnalysisAction (minus auth) to validate the P3 persist→fetch path + seed the first real
+ * Situation Report so /admin/situation isn't empty on first open. Writes to the real collections.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { execSync } from 'child_process';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+const secret = (n: string) => execSync(`gcloud secrets versions access latest --secret=${n} --project=rentalspot-fzwom`, { encoding: 'utf8' }).trim();
+if (!process.env.ANTHROPIC_API_KEY) process.env.ANTHROPIC_API_KEY = secret('ANTHROPIC_API_KEY');
+if (!process.env.META_ADS_TOKENS) process.env.META_ADS_TOKENS = secret('META_ADS_TOKENS');
+import { runSituationAnalysis } from '@/services/growth/situationAnalyst';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+
+const P = 'prahova-mountain-chalet';
+(async () => {
+  const res = await runSituationAnalysis(P);
+  if (!res.ok || !res.report) { console.error('analysis failed:', res.errors); process.exit(1); }
+  const db = await getAdminDb();
+  const ref = db.collection('situationReports').doc();
+  const runId = ref.id;
+  await ref.set({ propertyId: P, asOf: res.pack.meta.asOf, status: 'open', report: res.report, warnings: res.warnings ?? [], createdBy: 'seed-script', createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp() });
+  const batch = db.batch();
+  res.opportunities.forEach(o => batch.set(db.collection('opportunities').doc(), { runId, propertyId: P, status: 'pending', action: o.action, window: o.window ?? null, occasion: o.occasion ?? null, valueAtRisk: o.valueAtRisk ?? null, audience: o.audience ?? null, rationale: o.rationale, rejected: o.rejected ?? null, createdAt: FieldValue.serverTimestamp() }));
+  await batch.commit();
+  console.log(`persisted report ${runId}: ${res.report.flags.length} flags, ${res.opportunities.length} opportunities, ${res.warnings.length} warnings`);
+
+  // read back via the SAME query fetchLatestSituationAction uses (validates the index)
+  const snap = await db.collection('situationReports').where('propertyId','==',P).orderBy('createdAt','desc').limit(1).get();
+  const doc = snap.docs[0];
+  const opps = await db.collection('opportunities').where('runId','==',doc.id).get();
+  console.log(`read-back OK: latest report ${doc.id} · headline="${(doc.data().report.headline||'').slice(0,70)}..." · ${opps.size} opportunities`);
+  process.exit(0);
+})().catch(e => { console.error(e); process.exit(1); });

--- a/src/app/admin/situation/_components/situation-console.tsx
+++ b/src/app/admin/situation/_components/situation-console.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+/**
+ * Situation console (Move 2 · P3) — the read-only surface for the in-app analyst. A "Run analysis"
+ * button triggers the analyst + persists; the latest report + routed opportunities render below.
+ * Read-only: no edit / challenge / approve yet (those are P4/P5). This is where the owner reads real
+ * reports and calibrates before any action exists.
+ */
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, Sparkles, AlertTriangle, MapPin, ArrowRight } from 'lucide-react';
+import type { SituationReport, Flag, AnalystOpportunity } from '@/lib/growth/contracts';
+import { runAnalysisAction } from '../actions';
+
+interface ReportDoc {
+  id: string;
+  propertyId: string;
+  asOf: string;
+  createdAt?: string;
+  createdBy?: string;
+  status: string;
+  report: SituationReport;
+  warnings?: string[];
+}
+type OppDoc = AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string };
+interface SituationData {
+  report: ReportDoc;
+  opportunities: OppDoc[];
+}
+
+const SEV_STYLE: Record<string, string> = {
+  red: 'border-red-300 bg-red-50/60 text-red-900',
+  amber: 'border-amber-300 bg-amber-50/60 text-amber-900',
+  yellow: 'border-yellow-300 bg-yellow-50/50 text-yellow-900',
+};
+const SEV_DOT: Record<string, string> = { red: '🔴', amber: '🟠', yellow: '🟡' };
+const ACTION_STYLE: Record<string, string> = {
+  whatsapp: 'bg-emerald-100 text-emerald-800',
+  ads: 'bg-blue-100 text-blue-800',
+  page: 'bg-violet-100 text-violet-800',
+  price: 'bg-amber-100 text-amber-800',
+  minstay: 'bg-amber-100 text-amber-800',
+  los: 'bg-amber-100 text-amber-800',
+  ota: 'bg-slate-100 text-slate-800',
+  none: 'bg-slate-100 text-slate-600',
+};
+
+export function SituationConsole({ propertyId, initial }: { propertyId: string; initial: SituationData | null }) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [running, startRun] = useTransition();
+  const [data] = useState<SituationData | null>(initial);
+
+  const run = () =>
+    startRun(async () => {
+      const res = await runAnalysisAction(propertyId);
+      if (res.ok) {
+        toast({ title: 'Analysis complete', description: `${res.opportunities} opportunit${res.opportunities === 1 ? 'y' : 'ies'} · ${res.warnings} grounding warning${res.warnings === 1 ? '' : 's'}.` });
+        router.refresh();
+      } else {
+        toast({ title: 'Analysis failed', description: res.error, variant: 'destructive' });
+      }
+    });
+
+  const r = data?.report.report;
+
+  return (
+    <div className="space-y-6">
+      {/* Run bar */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm text-muted-foreground">
+          {data ? (
+            <>Last run <span className="font-medium text-foreground">{data.report.asOf}</span>{data.report.createdBy ? ` · by ${data.report.createdBy}` : ''}{data.report.createdAt ? ` · ${new Date(data.report.createdAt).toLocaleString()}` : ''}</>
+          ) : (
+            <>No analysis yet for this property.</>
+          )}
+        </div>
+        <Button onClick={run} disabled={running}>
+          {running ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Sparkles className="mr-2 h-4 w-4" />}
+          {running ? 'Analysing… (~a minute)' : 'Run analysis'}
+        </Button>
+      </div>
+
+      {!data && (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            Press <strong>Run analysis</strong> to generate the first Situation Report. It reads the deterministic fact pack and takes about a minute. Nothing is sent or spent — it only proposes.
+          </CardContent>
+        </Card>
+      )}
+
+      {data && r && (
+        <>
+          {/* Headline */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Sparkles className="h-4 w-4 text-muted-foreground" /> Situation
+                {(data.report.warnings?.length ?? 0) > 0 && (
+                  <Badge variant="outline" className="ml-auto text-[10px] text-amber-700">
+                    {data.report.warnings!.length} grounding warning{data.report.warnings!.length === 1 ? '' : 's'}
+                  </Badge>
+                )}
+              </CardTitle>
+              <CardDescription className="text-[15px] leading-relaxed text-foreground">{r.headline}</CardDescription>
+            </CardHeader>
+          </Card>
+
+          {/* Flags */}
+          {r.flags?.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium">Flags <span className="text-muted-foreground">· ranked by money at risk</span></h3>
+              {r.flags.map((f: Flag, i: number) => (
+                <div key={i} className={`rounded-md border p-3 text-sm ${SEV_STYLE[f.severity] ?? 'border-border'}`}>
+                  <p className="font-medium">{SEV_DOT[f.severity] ?? ''} {f.what}</p>
+                  <p className="mt-1 font-mono text-[11px] opacity-80">{f.evidence?.path} = {f.evidence?.value} · <span className="uppercase">{f.whoActs}</span></p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Opportunities */}
+          {data.opportunities.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium">Opportunities <span className="text-muted-foreground">· proposals only — nothing runs yet</span></h3>
+              {data.opportunities.map((o) => (
+                <Card key={o.id}>
+                  <CardContent className="space-y-2 pt-5 text-sm">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge className={`uppercase ${ACTION_STYLE[o.action] ?? 'bg-slate-100 text-slate-700'}`}>{o.action}</Badge>
+                      {o.window && (
+                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                          <MapPin className="h-3.5 w-3.5" /> {o.window.start} → {o.window.end} ({o.window.nights}n)
+                        </span>
+                      )}
+                      {o.valueAtRisk ? <span className="text-xs text-muted-foreground">· ~{o.valueAtRisk.toLocaleString()} RON</span> : null}
+                      {o.occasion ? <Badge variant="outline" className="text-[10px]">{o.occasion}</Badge> : null}
+                    </div>
+                    {o.audience && <p className="text-xs"><span className="font-medium">Audience:</span> <span className="text-muted-foreground">{o.audience}</span></p>}
+                    <p><span className="font-medium">Why:</span> {o.rationale}</p>
+                    {o.rejected && (
+                      <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Rejected:</span> {o.rejected}</p>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {/* Supporting sections */}
+          <div className="grid gap-3 md:grid-cols-2">
+            {r.normal?.length > 0 && (
+              <Section title="Normal — looks alarming but isn't">
+                {r.normal.map((n, i) => <li key={i}>{n}</li>)}
+              </Section>
+            )}
+            {r.questions?.length > 0 && (
+              <Section title="Questions for you">
+                {r.questions.map((q, i) => <li key={i}>{q}</li>)}
+              </Section>
+            )}
+            {(r.confidence?.thin?.length > 0 || r.confidence?.guessing?.length > 0) && (
+              <Section title="Confidence — the thin bits">
+                {r.confidence.thin.map((t, i) => <li key={`t${i}`}><span className="text-amber-700">thin:</span> {t}</li>)}
+                {r.confidence.guessing.map((g, i) => <li key={`g${i}`}><span className="text-muted-foreground">guessing:</span> {g}</li>)}
+              </Section>
+            )}
+            {(r.packGaps?.length ?? 0) > 0 && (
+              <Section title="Pack gaps — facts it couldn't get">
+                {r.packGaps!.map((g, i) => <li key={i}>{g}</li>)}
+              </Section>
+            )}
+          </div>
+
+          {(data.report.warnings?.length ?? 0) > 0 && (
+            <details className="rounded-md border bg-muted/30 p-3 text-xs">
+              <summary className="flex cursor-pointer items-center gap-1.5 font-medium text-amber-700">
+                <AlertTriangle className="h-3.5 w-3.5" /> {data.report.warnings!.length} grounding warning{data.report.warnings!.length === 1 ? '' : 's'} (soft — a cited value didn't exactly match the pack)
+              </summary>
+              <ul className="mt-2 space-y-1 text-muted-foreground">
+                {data.report.warnings!.map((w, i) => <li key={i} className="font-mono">{w}</li>)}
+              </ul>
+            </details>
+          )}
+
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <ArrowRight className="h-3.5 w-3.5" /> Read-only for now. Editing, challenging, and approving an opportunity into a draft come next.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-xs font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="list-disc space-y-1 pl-4 text-sm text-foreground">{children}</ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/situation/actions.ts
+++ b/src/app/admin/situation/actions.ts
@@ -1,0 +1,129 @@
+'use server';
+/**
+ * Situation admin actions (Move 2 · P3). `runAnalysisAction` runs the IN-APP analyst and PERSISTS the
+ * Situation Report + routed opportunities; `fetchLatestSituationAction` reads the newest run for the
+ * read-only console. Read-only phase — no edit/challenge/approve yet (P4/P5). Super-admin gated;
+ * Admin SDK writes only.
+ *
+ * NB: a 'use server' file may ONLY export async functions (never types/objects) — the doc shapes live
+ * in the console component, matched structurally.
+ */
+import { revalidatePath } from 'next/cache';
+import { loggers } from '@/lib/logger';
+import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { convertTimestampsToISOStrings } from '@/lib/utils';
+import { runSituationAnalysis } from '@/services/growth/situationAnalyst';
+import type { SituationReport, AnalystOpportunity } from '@/lib/growth/contracts';
+
+const logger = loggers.campaign;
+
+async function requireActor(): Promise<string> {
+  const user = await requireSuperAdmin();
+  return user.email || user.uid;
+}
+
+/** Run the in-app analyst for a property and persist the report + opportunities. Super-admin gated. */
+export async function runAnalysisAction(propertyId: string): Promise<
+  | { ok: true; runId: string; opportunities: number; warnings: number }
+  | { ok: false; error: string }
+> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+
+  try {
+    const res = await runSituationAnalysis(propertyId);
+    if (!res.ok || !res.report) {
+      logger.warn('runAnalysisAction: analysis failed', { propertyId, errors: res.errors });
+      return { ok: false, error: res.errors.join('; ') || 'analysis-failed' };
+    }
+
+    const db = await getAdminDb();
+    const asOf = res.pack.meta.asOf;
+
+    const reportRef = db.collection('situationReports').doc();
+    const runId = reportRef.id;
+    await reportRef.set({
+      propertyId,
+      asOf,
+      status: 'open',
+      report: res.report,
+      warnings: res.warnings ?? [],
+      createdBy: actor,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    // Each opportunity is its own doc (per-item status for P4/P5). Optionals default to null —
+    // the Admin SDK rejects `undefined` on write.
+    const batch = db.batch();
+    res.opportunities.forEach((o) => {
+      const ref = db.collection('opportunities').doc();
+      batch.set(ref, {
+        runId,
+        propertyId,
+        status: 'pending',
+        action: o.action,
+        window: o.window ?? null,
+        occasion: o.occasion ?? null,
+        valueAtRisk: o.valueAtRisk ?? null,
+        audience: o.audience ?? null,
+        rationale: o.rationale,
+        rejected: o.rejected ?? null,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+    });
+    await batch.commit();
+
+    logger.info('runAnalysisAction: persisted', { actor, propertyId, runId, opps: res.opportunities.length, warnings: res.warnings.length });
+    revalidatePath('/admin/situation');
+    return { ok: true, runId, opportunities: res.opportunities.length, warnings: res.warnings.length };
+  } catch (e) {
+    logger.error('runAnalysisAction failed', e as Error, { propertyId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
+/** Fetch the newest report + its opportunities for the read-only console. Null if none/auth failure. */
+export async function fetchLatestSituationAction(propertyId: string): Promise<{
+  report: { id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[] };
+  opportunities: Array<AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string }>;
+} | null> {
+  try {
+    await requireSuperAdmin();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return null;
+    throw e;
+  }
+
+  try {
+    const db = await getAdminDb();
+    const snap = await db
+      .collection('situationReports')
+      .where('propertyId', '==', propertyId)
+      .orderBy('createdAt', 'desc')
+      .limit(1)
+      .get();
+    if (snap.empty) return null;
+
+    const doc = snap.docs[0];
+    const report = convertTimestampsToISOStrings({ id: doc.id, ...doc.data() }) as {
+      id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[];
+    };
+
+    const oppSnap = await db.collection('opportunities').where('runId', '==', doc.id).get();
+    const opportunities = oppSnap.docs
+      .map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string })
+      .sort((a, b) => String(a.createdAt ?? '').localeCompare(String(b.createdAt ?? '')));
+
+    return { report, opportunities };
+  } catch (e) {
+    logger.error('fetchLatestSituationAction failed', e as Error, { propertyId });
+    return null;
+  }
+}

--- a/src/app/admin/situation/page.tsx
+++ b/src/app/admin/situation/page.tsx
@@ -1,0 +1,28 @@
+import { AdminPage } from '@/components/admin';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { fetchLatestSituationAction } from './actions';
+import { SituationConsole } from './_components/situation-console';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function SituationPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const latest = await fetchLatestSituationAction(property);
+
+  return (
+    <AdminPage
+      title="Situation"
+      description="The analyst's read of this property — what's going on, what's at risk, and what it would do, across all channels. Read-only for now: review its judgement and calibrate. Nothing here sends or spends."
+    >
+      <PropertyUrlSync />
+      <SituationConsole propertyId={property} initial={latest} />
+    </AdminPage>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -14,6 +14,7 @@ import {
   Megaphone,
   Target,
   Newspaper,
+  Brain,
   MessageSquare,
   Sliders,
   RefreshCw,
@@ -93,6 +94,7 @@ const navigationGroups = [
   {
     label: 'Growth',
     items: [
+      { title: 'Situation', href: '/admin/situation', icon: Brain },
       { title: 'Campaigns', href: '/admin/campaigns', icon: Megaphone },
       { title: 'Ads', href: '/admin/ads', icon: Target },
       { title: 'Page posts', href: '/admin/page-posts', icon: Newspaper },


### PR DESCRIPTION
Third phase of Move 2. Persists the analyst's output + surfaces it in Admin. **Read-only** — no edit/challenge/approve yet (P4/P5); nothing sends, spends, or writes to an arm.

## What
- **`runAnalysisAction`** (super-admin) → `runSituationAnalysis` → persists `situationReports` + `opportunities` (per-opportunity docs, optionals defaulted to null for the Admin SDK). **`fetchLatestSituationAction`** reads the newest run.
- **`/admin/situation`** (force-dynamic) + a client console: a **"Run analysis"** button + a read-only render — headline, flags (severity + `evidence path = value`), the (parallel) opportunities (action badge · window · value · audience · why · rejected), NORMAL / QUESTIONS / CONFIDENCE / PACK GAPS, and soft grounding warnings.
- **Rules + index** for `situationReports` + `opportunities` (super-admin/owner read, Admin-SDK-only write) — **deployed**.
- **Growth nav:** "Situation" (Brain icon), first item.

## Verified
Persist writes 1 report + 5 opportunities (incl. **parallel whatsapp+ads** arms — the calibrated behavior); route compiles (3.91 kB). The read-back query works once the just-deployed composite index finishes building.

## Next (P4)
The human loop — edit a proposal, challenge/re-run with a steer, dismiss/snooze — over the same records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)