### PR TITLE
Move 2 · P4 — the human loop on /admin/situation (challenge / edit / dismiss)

### DIFF
--- a/src/app/admin/situation/_components/situation-console.tsx
+++ b/src/app/admin/situation/_components/situation-console.tsx
@@ -1,37 +1,37 @@
 'use client';
 
 /**
- * Situation console (Move 2 · P3) — the read-only surface for the in-app analyst. A "Run analysis"
- * button triggers the analyst + persists; the latest report + routed opportunities render below.
- * Read-only: no edit / challenge / approve yet (those are P4/P5). This is where the owner reads real
- * reports and calibrates before any action exists.
+ * Situation console (Move 2 · P3 + P4) — the owner's surface for the in-app analyst. Run it, read the
+ * report, and act on it: CHALLENGE & re-run with a steer, EDIT a proposal, DISMISS/SNOOZE/RESTORE.
+ * Still NO arm hand-off — approving an opportunity into a real draft is P5. Nothing here sends or spends.
  */
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Sparkles, AlertTriangle, MapPin, ArrowRight } from 'lucide-react';
-import type { SituationReport, Flag, AnalystOpportunity } from '@/lib/growth/contracts';
-import { runAnalysisAction } from '../actions';
+import { Loader2, Sparkles, AlertTriangle, MapPin, MessageSquareWarning, Pencil, Ban, Clock, RotateCcw, Check, X } from 'lucide-react';
+import type { SituationReport, Flag, AnalystOpportunity, RecommendedAction } from '@/lib/growth/contracts';
+import {
+  runAnalysisAction,
+  reRunWithSteerAction,
+  editOpportunityAction,
+  dismissOpportunityAction,
+  snoozeOpportunityAction,
+  restoreOpportunityAction,
+} from '../actions';
 
+type OppDoc = AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; edited?: boolean; dismissReason?: string | null };
 interface ReportDoc {
-  id: string;
-  propertyId: string;
-  asOf: string;
-  createdAt?: string;
-  createdBy?: string;
-  status: string;
-  report: SituationReport;
-  warnings?: string[];
+  id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[]; steer?: string | null;
 }
-type OppDoc = AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string };
-interface SituationData {
-  report: ReportDoc;
-  opportunities: OppDoc[];
-}
+interface SituationData { report: ReportDoc; opportunities: OppDoc[] }
 
+const MENU: RecommendedAction[] = ['whatsapp', 'ads', 'page', 'price', 'minstay', 'los', 'ota', 'none'];
 const SEV_STYLE: Record<string, string> = {
   red: 'border-red-300 bg-red-50/60 text-red-900',
   amber: 'border-amber-300 bg-amber-50/60 text-amber-900',
@@ -39,78 +39,90 @@ const SEV_STYLE: Record<string, string> = {
 };
 const SEV_DOT: Record<string, string> = { red: '🔴', amber: '🟠', yellow: '🟡' };
 const ACTION_STYLE: Record<string, string> = {
-  whatsapp: 'bg-emerald-100 text-emerald-800',
-  ads: 'bg-blue-100 text-blue-800',
-  page: 'bg-violet-100 text-violet-800',
-  price: 'bg-amber-100 text-amber-800',
-  minstay: 'bg-amber-100 text-amber-800',
-  los: 'bg-amber-100 text-amber-800',
-  ota: 'bg-slate-100 text-slate-800',
-  none: 'bg-slate-100 text-slate-600',
+  whatsapp: 'bg-emerald-100 text-emerald-800', ads: 'bg-blue-100 text-blue-800', page: 'bg-violet-100 text-violet-800',
+  price: 'bg-amber-100 text-amber-800', minstay: 'bg-amber-100 text-amber-800', los: 'bg-amber-100 text-amber-800',
+  ota: 'bg-slate-100 text-slate-800', none: 'bg-slate-100 text-slate-600',
 };
 
 export function SituationConsole({ propertyId, initial }: { propertyId: string; initial: SituationData | null }) {
   const router = useRouter();
   const { toast } = useToast();
   const [running, startRun] = useTransition();
-  const [data] = useState<SituationData | null>(initial);
+  const [challenging, startChallenge] = useTransition();
+  const [steer, setSteer] = useState('');
+  const data = initial;
 
   const run = () =>
     startRun(async () => {
       const res = await runAnalysisAction(propertyId);
-      if (res.ok) {
-        toast({ title: 'Analysis complete', description: `${res.opportunities} opportunit${res.opportunities === 1 ? 'y' : 'ies'} · ${res.warnings} grounding warning${res.warnings === 1 ? '' : 's'}.` });
-        router.refresh();
-      } else {
-        toast({ title: 'Analysis failed', description: res.error, variant: 'destructive' });
-      }
+      if (res.ok) { toast({ title: 'Analysis complete', description: `${res.opportunities} opportunit${res.opportunities === 1 ? 'y' : 'ies'} · ${res.warnings} grounding warning${res.warnings === 1 ? '' : 's'}.` }); router.refresh(); }
+      else toast({ title: 'Analysis failed', description: res.error, variant: 'destructive' });
     });
+
+  const challenge = () => {
+    if (!steer.trim()) { toast({ title: 'Write a note first', description: 'What should it reconsider?', variant: 'destructive' }); return; }
+    startChallenge(async () => {
+      const res = await reRunWithSteerAction(propertyId, steer.trim());
+      if (res.ok) { toast({ title: 're-analysed with your steer', description: 'The report below reflects your challenge.' }); setSteer(''); router.refresh(); }
+      else toast({ title: 'Re-run failed', description: res.error, variant: 'destructive' });
+    });
+  };
 
   const r = data?.report.report;
 
   return (
     <div className="space-y-6">
-      {/* Run bar */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="text-sm text-muted-foreground">
-          {data ? (
-            <>Last run <span className="font-medium text-foreground">{data.report.asOf}</span>{data.report.createdBy ? ` · by ${data.report.createdBy}` : ''}{data.report.createdAt ? ` · ${new Date(data.report.createdAt).toLocaleString()}` : ''}</>
-          ) : (
-            <>No analysis yet for this property.</>
-          )}
+          {data ? (<>Last run <span className="font-medium text-foreground">{data.report.asOf}</span>{data.report.createdBy ? ` · by ${data.report.createdBy}` : ''}{data.report.createdAt ? ` · ${new Date(data.report.createdAt).toLocaleString()}` : ''}</>) : (<>No analysis yet for this property.</>)}
         </div>
-        <Button onClick={run} disabled={running}>
+        <Button onClick={run} disabled={running || challenging}>
           {running ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Sparkles className="mr-2 h-4 w-4" />}
           {running ? 'Analysing… (~a minute)' : 'Run analysis'}
         </Button>
       </div>
 
       {!data && (
-        <Card>
-          <CardContent className="py-10 text-center text-sm text-muted-foreground">
-            Press <strong>Run analysis</strong> to generate the first Situation Report. It reads the deterministic fact pack and takes about a minute. Nothing is sent or spent — it only proposes.
-          </CardContent>
-        </Card>
+        <Card><CardContent className="py-10 text-center text-sm text-muted-foreground">
+          Press <strong>Run analysis</strong> to generate the first Situation Report. It reads the deterministic fact pack and takes about a minute. Nothing is sent or spent — it only proposes.
+        </CardContent></Card>
       )}
 
       {data && r && (
         <>
-          {/* Headline */}
+          {data.report.steer && (
+            <div className="rounded-md border border-blue-200 bg-blue-50/50 p-2 text-xs text-blue-900">
+              <span className="font-medium">This run reflects your steer:</span> “{data.report.steer}”
+            </div>
+          )}
+
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <Sparkles className="h-4 w-4 text-muted-foreground" /> Situation
                 {(data.report.warnings?.length ?? 0) > 0 && (
-                  <Badge variant="outline" className="ml-auto text-[10px] text-amber-700">
-                    {data.report.warnings!.length} grounding warning{data.report.warnings!.length === 1 ? '' : 's'}
-                  </Badge>
+                  <Badge variant="outline" className="ml-auto text-[10px] text-amber-700">{data.report.warnings!.length} grounding warning{data.report.warnings!.length === 1 ? '' : 's'}</Badge>
                 )}
               </CardTitle>
               <CardDescription className="text-[15px] leading-relaxed text-foreground">{r.headline}</CardDescription>
             </CardHeader>
           </Card>
 
-          {/* Flags */}
+          {/* Challenge & re-run */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm"><MessageSquareWarning className="h-4 w-4 text-muted-foreground" /> Challenge it</CardTitle>
+              <CardDescription>Disagree, or want it to reconsider something? Write a note and re-run — it folds your steer in (and pushes back with the data if you're wrong).</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Textarea value={steer} onChange={(e) => setSteer(e.target.value)} rows={2} placeholder='e.g. "September is fine, do not flag it" · "push October families harder" · "the WhatsApp list is bigger than you think"' />
+              <Button size="sm" variant="secondary" onClick={challenge} disabled={challenging || running}>
+                {challenging ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <MessageSquareWarning className="mr-2 h-4 w-4" />}
+                {challenging ? 'Re-analysing…' : 'Re-run with this steer'}
+              </Button>
+            </CardContent>
+          </Card>
+
           {r.flags?.length > 0 && (
             <div className="space-y-2">
               <h3 className="text-sm font-medium">Flags <span className="text-muted-foreground">· ranked by money at risk</span></h3>
@@ -123,88 +135,142 @@ export function SituationConsole({ propertyId, initial }: { propertyId: string; 
             </div>
           )}
 
-          {/* Opportunities */}
           {data.opportunities.length > 0 && (
             <div className="space-y-2">
-              <h3 className="text-sm font-medium">Opportunities <span className="text-muted-foreground">· proposals only — nothing runs yet</span></h3>
-              {data.opportunities.map((o) => (
-                <Card key={o.id}>
-                  <CardContent className="space-y-2 pt-5 text-sm">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge className={`uppercase ${ACTION_STYLE[o.action] ?? 'bg-slate-100 text-slate-700'}`}>{o.action}</Badge>
-                      {o.window && (
-                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                          <MapPin className="h-3.5 w-3.5" /> {o.window.start} → {o.window.end} ({o.window.nights}n)
-                        </span>
-                      )}
-                      {o.valueAtRisk ? <span className="text-xs text-muted-foreground">· ~{o.valueAtRisk.toLocaleString()} RON</span> : null}
-                      {o.occasion ? <Badge variant="outline" className="text-[10px]">{o.occasion}</Badge> : null}
-                    </div>
-                    {o.audience && <p className="text-xs"><span className="font-medium">Audience:</span> <span className="text-muted-foreground">{o.audience}</span></p>}
-                    <p><span className="font-medium">Why:</span> {o.rationale}</p>
-                    {o.rejected && (
-                      <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Rejected:</span> {o.rejected}</p>
-                    )}
-                  </CardContent>
-                </Card>
-              ))}
+              <h3 className="text-sm font-medium">Opportunities <span className="text-muted-foreground">· proposals — edit, dismiss, or set aside (nothing runs yet)</span></h3>
+              {data.opportunities.map((o) => <OpportunityCard key={o.id} opp={o} onChanged={() => router.refresh()} />)}
             </div>
           )}
 
-          {/* Supporting sections */}
           <div className="grid gap-3 md:grid-cols-2">
-            {r.normal?.length > 0 && (
-              <Section title="Normal — looks alarming but isn't">
-                {r.normal.map((n, i) => <li key={i}>{n}</li>)}
-              </Section>
-            )}
-            {r.questions?.length > 0 && (
-              <Section title="Questions for you">
-                {r.questions.map((q, i) => <li key={i}>{q}</li>)}
-              </Section>
-            )}
+            {r.normal?.length > 0 && <Section title="Normal — looks alarming but isn't">{r.normal.map((n, i) => <li key={i}>{n}</li>)}</Section>}
+            {r.questions?.length > 0 && <Section title="Questions for you">{r.questions.map((q, i) => <li key={i}>{q}</li>)}</Section>}
             {(r.confidence?.thin?.length > 0 || r.confidence?.guessing?.length > 0) && (
               <Section title="Confidence — the thin bits">
                 {r.confidence.thin.map((t, i) => <li key={`t${i}`}><span className="text-amber-700">thin:</span> {t}</li>)}
                 {r.confidence.guessing.map((g, i) => <li key={`g${i}`}><span className="text-muted-foreground">guessing:</span> {g}</li>)}
               </Section>
             )}
-            {(r.packGaps?.length ?? 0) > 0 && (
-              <Section title="Pack gaps — facts it couldn't get">
-                {r.packGaps!.map((g, i) => <li key={i}>{g}</li>)}
-              </Section>
-            )}
+            {(r.packGaps?.length ?? 0) > 0 && <Section title="Pack gaps — facts it couldn't get">{r.packGaps!.map((g, i) => <li key={i}>{g}</li>)}</Section>}
           </div>
 
           {(data.report.warnings?.length ?? 0) > 0 && (
             <details className="rounded-md border bg-muted/30 p-3 text-xs">
-              <summary className="flex cursor-pointer items-center gap-1.5 font-medium text-amber-700">
-                <AlertTriangle className="h-3.5 w-3.5" /> {data.report.warnings!.length} grounding warning{data.report.warnings!.length === 1 ? '' : 's'} (soft — a cited value didn't exactly match the pack)
-              </summary>
-              <ul className="mt-2 space-y-1 text-muted-foreground">
-                {data.report.warnings!.map((w, i) => <li key={i} className="font-mono">{w}</li>)}
-              </ul>
+              <summary className="flex cursor-pointer items-center gap-1.5 font-medium text-amber-700"><AlertTriangle className="h-3.5 w-3.5" /> {data.report.warnings!.length} grounding warning{data.report.warnings!.length === 1 ? '' : 's'} (soft — a cited value didn't exactly match the pack)</summary>
+              <ul className="mt-2 space-y-1 text-muted-foreground">{data.report.warnings!.map((w, i) => <li key={i} className="font-mono">{w}</li>)}</ul>
             </details>
           )}
 
-          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <ArrowRight className="h-3.5 w-3.5" /> Read-only for now. Editing, challenging, and approving an opportunity into a draft come next.
-          </p>
+          <p className="text-xs text-muted-foreground">Approving an opportunity into a real draft (ads review-before-push / WhatsApp Gate-1) comes next. Nothing here sends or spends.</p>
         </>
       )}
     </div>
   );
 }
 
+function OpportunityCard({ opp, onChanged }: { opp: OppDoc; onChanged: () => void }) {
+  const { toast } = useToast();
+  const [busy, startBusy] = useTransition();
+  const [mode, setMode] = useState<'view' | 'edit' | 'dismiss'>('view');
+  const [reason, setReason] = useState('');
+  const [f, setF] = useState({
+    action: opp.action as RecommendedAction,
+    start: opp.window?.start ?? '',
+    end: opp.window?.end ?? '',
+    nights: opp.window?.nights ?? 0,
+    occasion: opp.occasion ?? '',
+    audience: opp.audience ?? '',
+    valueAtRisk: opp.valueAtRisk ?? 0,
+    rationale: opp.rationale ?? '',
+  });
+
+  const disposed = opp.status === 'dismissed' || opp.status === 'snoozed';
+
+  const save = () =>
+    startBusy(async () => {
+      const window = f.start && f.end ? { start: f.start, end: f.end, nights: Number(f.nights) || 0 } : null;
+      const res = await editOpportunityAction(opp.id, { action: f.action, window, occasion: f.occasion || null, audience: f.audience || null, valueAtRisk: Number(f.valueAtRisk) || null, rationale: f.rationale });
+      if (res.ok) { toast({ title: 'Opportunity edited' }); setMode('view'); onChanged(); }
+      else toast({ title: 'Edit failed', description: res.error, variant: 'destructive' });
+    });
+  const dismiss = () =>
+    startBusy(async () => {
+      const res = await dismissOpportunityAction(opp.id, reason);
+      if (res.ok) { toast({ title: 'Dismissed' }); setMode('view'); onChanged(); }
+      else toast({ title: 'Failed', description: res.error, variant: 'destructive' });
+    });
+  const snooze = () => startBusy(async () => { const res = await snoozeOpportunityAction(opp.id); if (res.ok) onChanged(); else toast({ title: 'Failed', description: res.error, variant: 'destructive' }); });
+  const restore = () => startBusy(async () => { const res = await restoreOpportunityAction(opp.id); if (res.ok) onChanged(); else toast({ title: 'Failed', description: res.error, variant: 'destructive' }); });
+
+  if (mode === 'edit') {
+    return (
+      <Card>
+        <CardContent className="space-y-2 pt-5 text-sm">
+          <div className="grid gap-2 sm:grid-cols-2">
+            <div className="space-y-1"><Label className="text-xs">Action</Label>
+              <select value={f.action} onChange={(e) => setF({ ...f, action: e.target.value as RecommendedAction })} className="h-9 w-full rounded-md border bg-background px-2 text-sm">
+                {MENU.map((a) => <option key={a} value={a}>{a}</option>)}
+              </select>
+            </div>
+            <div className="space-y-1"><Label className="text-xs">Value at risk (RON)</Label><Input type="number" value={f.valueAtRisk} onChange={(e) => setF({ ...f, valueAtRisk: Number(e.target.value) })} className="h-9" /></div>
+            <div className="space-y-1"><Label className="text-xs">Window start</Label><Input type="date" value={f.start} onChange={(e) => setF({ ...f, start: e.target.value })} className="h-9" /></div>
+            <div className="space-y-1"><Label className="text-xs">Window end</Label><Input type="date" value={f.end} onChange={(e) => setF({ ...f, end: e.target.value })} className="h-9" /></div>
+            <div className="space-y-1"><Label className="text-xs">Nights</Label><Input type="number" value={f.nights} onChange={(e) => setF({ ...f, nights: Number(e.target.value) })} className="h-9" /></div>
+            <div className="space-y-1"><Label className="text-xs">Occasion</Label><Input value={f.occasion} onChange={(e) => setF({ ...f, occasion: e.target.value })} className="h-9" /></div>
+          </div>
+          <div className="space-y-1"><Label className="text-xs">Audience</Label><Input value={f.audience} onChange={(e) => setF({ ...f, audience: e.target.value })} className="h-9" /></div>
+          <div className="space-y-1"><Label className="text-xs">Why (rationale)</Label><Textarea value={f.rationale} onChange={(e) => setF({ ...f, rationale: e.target.value })} rows={3} /></div>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={save} disabled={busy}>{busy ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Check className="mr-1 h-3.5 w-3.5" />} Save</Button>
+            <Button size="sm" variant="ghost" onClick={() => setMode('view')} disabled={busy}><X className="mr-1 h-3.5 w-3.5" /> Cancel</Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={disposed ? 'opacity-60' : ''}>
+      <CardContent className="space-y-2 pt-5 text-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge className={`uppercase ${ACTION_STYLE[opp.action] ?? 'bg-slate-100 text-slate-700'}`}>{opp.action}</Badge>
+          {opp.window && <span className="inline-flex items-center gap-1 text-xs text-muted-foreground"><MapPin className="h-3.5 w-3.5" /> {opp.window.start} → {opp.window.end} ({opp.window.nights}n)</span>}
+          {opp.valueAtRisk ? <span className="text-xs text-muted-foreground">· ~{opp.valueAtRisk.toLocaleString()} RON</span> : null}
+          {opp.occasion ? <Badge variant="outline" className="text-[10px]">{opp.occasion}</Badge> : null}
+          {opp.edited ? <Badge variant="outline" className="text-[10px] text-emerald-700">edited</Badge> : null}
+          {opp.status === 'dismissed' ? <Badge variant="outline" className="text-[10px] text-destructive">dismissed</Badge> : null}
+          {opp.status === 'snoozed' ? <Badge variant="outline" className="text-[10px]">snoozed</Badge> : null}
+        </div>
+        {opp.audience && <p className="text-xs"><span className="font-medium">Audience:</span> <span className="text-muted-foreground">{opp.audience}</span></p>}
+        <p><span className="font-medium">Why:</span> {opp.rationale}</p>
+        {opp.rejected && <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Rejected:</span> {opp.rejected}</p>}
+        {opp.dismissReason && <p className="text-xs text-destructive"><span className="font-medium">Dismissed:</span> {opp.dismissReason}</p>}
+
+        {mode === 'dismiss' ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Why dismiss? (a calibration signal)" className="h-8 flex-1 min-w-[200px]" />
+            <Button size="sm" variant="destructive" onClick={dismiss} disabled={busy}>{busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Confirm'}</Button>
+            <Button size="sm" variant="ghost" onClick={() => setMode('view')} disabled={busy}>Cancel</Button>
+          </div>
+        ) : disposed ? (
+          <Button size="sm" variant="outline" onClick={restore} disabled={busy}><RotateCcw className="mr-1 h-3.5 w-3.5" /> Restore</Button>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" onClick={() => setMode('edit')} disabled={busy}><Pencil className="mr-1 h-3.5 w-3.5" /> Edit</Button>
+            <Button size="sm" variant="ghost" onClick={() => setMode('dismiss')} disabled={busy}><Ban className="mr-1 h-3.5 w-3.5" /> Dismiss</Button>
+            <Button size="sm" variant="ghost" onClick={snooze} disabled={busy}><Clock className="mr-1 h-3.5 w-3.5" /> Snooze</Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-xs font-medium text-muted-foreground">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ul className="list-disc space-y-1 pl-4 text-sm text-foreground">{children}</ul>
-      </CardContent>
+      <CardHeader className="pb-2"><CardTitle className="text-xs font-medium text-muted-foreground">{title}</CardTitle></CardHeader>
+      <CardContent><ul className="list-disc space-y-1 pl-4 text-sm text-foreground">{children}</ul></CardContent>
     </Card>
   );
 }

--- a/src/app/admin/situation/actions.ts
+++ b/src/app/admin/situation/actions.ts
@@ -1,26 +1,69 @@
 'use server';
 /**
- * Situation admin actions (Move 2 · P3). `runAnalysisAction` runs the IN-APP analyst and PERSISTS the
- * Situation Report + routed opportunities; `fetchLatestSituationAction` reads the newest run for the
- * read-only console. Read-only phase — no edit/challenge/approve yet (P4/P5). Super-admin gated;
- * Admin SDK writes only.
+ * Situation admin actions (Move 2 · P3 + P4). Run/persist the analyst, and the human loop over its
+ * output — challenge/re-run with a steer, edit a proposal, dismiss/snooze/restore. NO arm hand-off yet
+ * (approve → a real draft is P5); nothing here sends or spends. Super-admin gated; Admin SDK writes.
  *
- * NB: a 'use server' file may ONLY export async functions (never types/objects) — the doc shapes live
- * in the console component, matched structurally.
+ * NB: a 'use server' file may ONLY export async functions (never types/objects) — doc shapes live in
+ * the console component, matched structurally; the persist helper below is non-exported (allowed).
  */
 import { revalidatePath } from 'next/cache';
 import { loggers } from '@/lib/logger';
 import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { convertTimestampsToISOStrings } from '@/lib/utils';
-import { runSituationAnalysis } from '@/services/growth/situationAnalyst';
-import type { SituationReport, AnalystOpportunity } from '@/lib/growth/contracts';
+import { runSituationAnalysis, type RunSituationAnalysisResult } from '@/services/growth/situationAnalyst';
+import type { SituationReport, AnalystOpportunity, RecommendedAction } from '@/lib/growth/contracts';
 
 const logger = loggers.campaign;
 
 async function requireActor(): Promise<string> {
   const user = await requireSuperAdmin();
   return user.email || user.uid;
+}
+
+/** Persist a completed analysis (report + its opportunities). Non-exported helper. Returns the runId. */
+async function persistAnalysis(
+  propertyId: string,
+  actor: string,
+  res: RunSituationAnalysisResult,
+  extra?: { steer?: string; supersedesRunId?: string },
+): Promise<string> {
+  const db = await getAdminDb();
+  const reportRef = db.collection('situationReports').doc();
+  const runId = reportRef.id;
+  await reportRef.set({
+    propertyId,
+    asOf: res.pack.meta.asOf,
+    status: 'open',
+    report: res.report,
+    warnings: res.warnings ?? [],
+    steer: extra?.steer ?? null,
+    supersedesRunId: extra?.supersedesRunId ?? null,
+    createdBy: actor,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  const batch = db.batch();
+  (res.opportunities ?? []).forEach((o) => {
+    const ref = db.collection('opportunities').doc();
+    batch.set(ref, {
+      runId,
+      propertyId,
+      status: 'pending',
+      action: o.action,
+      window: o.window ?? null,
+      occasion: o.occasion ?? null,
+      valueAtRisk: o.valueAtRisk ?? null,
+      audience: o.audience ?? null,
+      rationale: o.rationale,
+      rejected: o.rejected ?? null,
+      edited: false,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  });
+  await batch.commit();
+  return runId;
 }
 
 /** Run the in-app analyst for a property and persist the report + opportunities. Super-admin gated. */
@@ -35,52 +78,14 @@ export async function runAnalysisAction(propertyId: string): Promise<
     if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
     throw e;
   }
-
   try {
     const res = await runSituationAnalysis(propertyId);
     if (!res.ok || !res.report) {
       logger.warn('runAnalysisAction: analysis failed', { propertyId, errors: res.errors });
       return { ok: false, error: res.errors.join('; ') || 'analysis-failed' };
     }
-
-    const db = await getAdminDb();
-    const asOf = res.pack.meta.asOf;
-
-    const reportRef = db.collection('situationReports').doc();
-    const runId = reportRef.id;
-    await reportRef.set({
-      propertyId,
-      asOf,
-      status: 'open',
-      report: res.report,
-      warnings: res.warnings ?? [],
-      createdBy: actor,
-      createdAt: FieldValue.serverTimestamp(),
-      updatedAt: FieldValue.serverTimestamp(),
-    });
-
-    // Each opportunity is its own doc (per-item status for P4/P5). Optionals default to null —
-    // the Admin SDK rejects `undefined` on write.
-    const batch = db.batch();
-    res.opportunities.forEach((o) => {
-      const ref = db.collection('opportunities').doc();
-      batch.set(ref, {
-        runId,
-        propertyId,
-        status: 'pending',
-        action: o.action,
-        window: o.window ?? null,
-        occasion: o.occasion ?? null,
-        valueAtRisk: o.valueAtRisk ?? null,
-        audience: o.audience ?? null,
-        rationale: o.rationale,
-        rejected: o.rejected ?? null,
-        createdAt: FieldValue.serverTimestamp(),
-      });
-    });
-    await batch.commit();
-
-    logger.info('runAnalysisAction: persisted', { actor, propertyId, runId, opps: res.opportunities.length, warnings: res.warnings.length });
+    const runId = await persistAnalysis(propertyId, actor, res);
+    logger.info('runAnalysisAction: persisted', { actor, propertyId, runId, opps: res.opportunities.length });
     revalidatePath('/admin/situation');
     return { ok: true, runId, opportunities: res.opportunities.length, warnings: res.warnings.length };
   } catch (e) {
@@ -89,10 +94,152 @@ export async function runAnalysisAction(propertyId: string): Promise<
   }
 }
 
-/** Fetch the newest report + its opportunities for the read-only console. Null if none/auth failure. */
+/** Re-run the analyst with the owner's CHALLENGE note (the steer), supersede the current run (P4). */
+export async function reRunWithSteerAction(propertyId: string, steer: string): Promise<
+  | { ok: true; runId: string; opportunities: number }
+  | { ok: false; error: string }
+> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  const note = steer?.trim();
+  if (!note) return { ok: false, error: 'empty-steer' };
+  try {
+    const db = await getAdminDb();
+    // The run being challenged (to record supersession + retire it from the "latest" view).
+    const prev = await db.collection('situationReports').where('propertyId', '==', propertyId).orderBy('createdAt', 'desc').limit(1).get();
+    const supersedesRunId = prev.empty ? undefined : prev.docs[0].id;
+
+    const res = await runSituationAnalysis(propertyId, { steer: note });
+    if (!res.ok || !res.report) {
+      logger.warn('reRunWithSteerAction: analysis failed', { propertyId, errors: res.errors });
+      return { ok: false, error: res.errors.join('; ') || 'analysis-failed' };
+    }
+    const runId = await persistAnalysis(propertyId, actor, res, { steer: note, supersedesRunId });
+    if (supersedesRunId) {
+      await db.collection('situationReports').doc(supersedesRunId).update({ status: 'superseded', updatedAt: FieldValue.serverTimestamp() }).catch(() => {});
+    }
+    logger.info('reRunWithSteerAction: persisted', { actor, propertyId, runId, supersedesRunId });
+    revalidatePath('/admin/situation');
+    return { ok: true, runId, opportunities: res.opportunities.length };
+  } catch (e) {
+    logger.error('reRunWithSteerAction failed', e as Error, { propertyId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
+/** Edit an opportunity before it is acted on (owner override). Only the provided fields change. */
+export async function editOpportunityAction(
+  oppId: string,
+  patch: {
+    action?: RecommendedAction;
+    window?: { start: string; end: string; nights: number } | null;
+    occasion?: string | null;
+    audience?: string | null;
+    valueAtRisk?: number | null;
+    rationale?: string;
+  },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  try {
+    const db = await getAdminDb();
+    const update: Record<string, unknown> = { edited: true, editedBy: actor, editedAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp() };
+    if (patch.action !== undefined) update.action = patch.action;
+    if (patch.window !== undefined) update.window = patch.window;
+    if (patch.occasion !== undefined) update.occasion = patch.occasion;
+    if (patch.audience !== undefined) update.audience = patch.audience;
+    if (patch.valueAtRisk !== undefined) update.valueAtRisk = patch.valueAtRisk;
+    if (patch.rationale !== undefined) update.rationale = patch.rationale;
+    await db.collection('opportunities').doc(oppId).update(update);
+    logger.info('editOpportunityAction', { actor, oppId, fields: Object.keys(patch) });
+    revalidatePath('/admin/situation');
+    return { ok: true };
+  } catch (e) {
+    logger.error('editOpportunityAction failed', e as Error, { oppId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
+/** Dismiss an opportunity with a reason (a calibration signal). */
+export async function dismissOpportunityAction(oppId: string, reason: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  try {
+    const db = await getAdminDb();
+    await db.collection('opportunities').doc(oppId).update({
+      status: 'dismissed',
+      dismissReason: reason?.trim() || null,
+      disposedBy: actor,
+      disposedAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    logger.info('dismissOpportunityAction', { actor, oppId });
+    revalidatePath('/admin/situation');
+    return { ok: true };
+  } catch (e) {
+    logger.error('dismissOpportunityAction failed', e as Error, { oppId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
+/** Snooze an opportunity (set aside without a verdict). */
+export async function snoozeOpportunityAction(oppId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  try {
+    const db = await getAdminDb();
+    await db.collection('opportunities').doc(oppId).update({ status: 'snoozed', disposedBy: actor, disposedAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp() });
+    revalidatePath('/admin/situation');
+    return { ok: true };
+  } catch (e) {
+    logger.error('snoozeOpportunityAction failed', e as Error, { oppId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
+/** Restore a dismissed/snoozed opportunity back to pending. */
+export async function restoreOpportunityAction(oppId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  try {
+    const db = await getAdminDb();
+    await db.collection('opportunities').doc(oppId).update({ status: 'pending', dismissReason: null, disposedBy: null, disposedAt: null, updatedAt: FieldValue.serverTimestamp() });
+    revalidatePath('/admin/situation');
+    return { ok: true };
+  } catch (e) {
+    logger.error('restoreOpportunityAction failed', e as Error, { oppId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
+/** Fetch the newest report + its opportunities for the console. Null if none/auth failure. */
 export async function fetchLatestSituationAction(propertyId: string): Promise<{
-  report: { id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[] };
-  opportunities: Array<AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string }>;
+  report: { id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[]; steer?: string | null };
+  opportunities: Array<AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string; edited?: boolean; dismissReason?: string | null }>;
 } | null> {
   try {
     await requireSuperAdmin();
@@ -100,7 +247,6 @@ export async function fetchLatestSituationAction(propertyId: string): Promise<{
     if (e instanceof AuthorizationError) return null;
     throw e;
   }
-
   try {
     const db = await getAdminDb();
     const snap = await db
@@ -113,12 +259,12 @@ export async function fetchLatestSituationAction(propertyId: string): Promise<{
 
     const doc = snap.docs[0];
     const report = convertTimestampsToISOStrings({ id: doc.id, ...doc.data() }) as {
-      id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[];
+      id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[]; steer?: string | null;
     };
 
     const oppSnap = await db.collection('opportunities').where('runId', '==', doc.id).get();
     const opportunities = oppSnap.docs
-      .map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string })
+      .map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string; edited?: boolean; dismissReason?: string | null })
       .sort((a, b) => String(a.createdAt ?? '').localeCompare(String(b.createdAt ?? '')));
 
     return { report, opportunities };


### PR DESCRIPTION
Fourth phase of Move 2. The owner can now **act on** what they read. Still **no arm hand-off** (approve → a real draft is P5); nothing sends or spends.

## Actions (super-admin)
- **`reRunWithSteerAction`** — the *challenge*: re-run the analyst with the owner's steer note folded in, **supersede** the current run, record the steer. (The analyst defends with data if the steer is wrong — proven in P2.)
- **`editOpportunityAction`** — owner override of window / action / audience / rationale / value; only provided fields change; flags `edited`.
- **`dismissOpportunityAction`** (+reason — a calibration signal) · **`snooze`** · **`restore`**.
- Shared non-exported `persistAnalysis` helper.

## UI
A **"Challenge it"** note box → re-run (and a banner showing the steer that shaped a run); per-opportunity **Edit** (inline form) / **Dismiss** (with reason) / **Snooze** / **Restore**; edited/dismissed/snoozed badges; disposed cards muted.

## Verified
Build compiles (route 6.6 kB). A dismiss → edit → restore round-trip persists correctly against live data (the test self-cleans, leaving the seeded report intact).

**Owner dispositions are now recorded** — the raw material for calibrating the brain to the owner's judgement over time.

## Next (P5, the last phase)
Approve → hand the (possibly edited) opportunity into the existing arm draft flow (ads review-before-push / WhatsApp Gate-1), which keeps its own review. That's the seam where the loop closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)