### PR TITLE
Move 2 · P5 — approve → arm hand-off (the loop closes)

### DIFF
--- a/src/app/admin/situation/_components/situation-console.tsx
+++ b/src/app/admin/situation/_components/situation-console.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
-import { Loader2, Sparkles, AlertTriangle, MapPin, MessageSquareWarning, Pencil, Ban, Clock, RotateCcw, Check, X } from 'lucide-react';
+import { Loader2, Sparkles, AlertTriangle, MapPin, MessageSquareWarning, Pencil, Ban, Clock, RotateCcw, Check, X, ArrowRight, ExternalLink } from 'lucide-react';
 import type { SituationReport, Flag, AnalystOpportunity, RecommendedAction } from '@/lib/growth/contracts';
 import {
   runAnalysisAction,
@@ -23,9 +23,10 @@ import {
   dismissOpportunityAction,
   snoozeOpportunityAction,
   restoreOpportunityAction,
+  approveOpportunityAction,
 } from '../actions';
 
-type OppDoc = AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; edited?: boolean; dismissReason?: string | null };
+type OppDoc = AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; edited?: boolean; dismissReason?: string | null; handoff?: { arm: string; ref?: string; url?: string; note?: string } | null };
 interface ReportDoc {
   id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[]; steer?: string | null;
 }
@@ -201,6 +202,15 @@ function OpportunityCard({ opp, onChanged }: { opp: OppDoc; onChanged: () => voi
     });
   const snooze = () => startBusy(async () => { const res = await snoozeOpportunityAction(opp.id); if (res.ok) onChanged(); else toast({ title: 'Failed', description: res.error, variant: 'destructive' }); });
   const restore = () => startBusy(async () => { const res = await restoreOpportunityAction(opp.id); if (res.ok) onChanged(); else toast({ title: 'Failed', description: res.error, variant: 'destructive' }); });
+  const approve = () =>
+    startBusy(async () => {
+      const res = await approveOpportunityAction(opp.id);
+      if (res.ok) { toast({ title: res.status === 'approved' ? 'Approved — draft created' : 'Accepted', description: res.handoffUrl ? `Draft ready at ${res.handoffUrl}` : res.note }); onChanged(); }
+      else toast({ title: 'Approve failed', description: res.error, variant: 'destructive' });
+    });
+
+  const approved = opp.status === 'approved' || opp.status === 'accepted';
+  const isCampaign = opp.action === 'ads' || opp.action === 'page' || opp.action === 'whatsapp';
 
   if (mode === 'edit') {
     return (
@@ -240,13 +250,23 @@ function OpportunityCard({ opp, onChanged }: { opp: OppDoc; onChanged: () => voi
           {opp.edited ? <Badge variant="outline" className="text-[10px] text-emerald-700">edited</Badge> : null}
           {opp.status === 'dismissed' ? <Badge variant="outline" className="text-[10px] text-destructive">dismissed</Badge> : null}
           {opp.status === 'snoozed' ? <Badge variant="outline" className="text-[10px]">snoozed</Badge> : null}
+          {approved ? <Badge variant="outline" className="text-[10px] text-emerald-700">{opp.status}</Badge> : null}
         </div>
         {opp.audience && <p className="text-xs"><span className="font-medium">Audience:</span> <span className="text-muted-foreground">{opp.audience}</span></p>}
         <p><span className="font-medium">Why:</span> {opp.rationale}</p>
         {opp.rejected && <p className="text-xs text-muted-foreground"><span className="font-medium text-foreground">Rejected:</span> {opp.rejected}</p>}
         {opp.dismissReason && <p className="text-xs text-destructive"><span className="font-medium">Dismissed:</span> {opp.dismissReason}</p>}
 
-        {mode === 'dismiss' ? (
+        {approved ? (
+          <div className="text-xs text-muted-foreground">
+            {opp.handoff?.url ? (
+              <a href={opp.handoff.url} className="inline-flex items-center gap-1 font-medium text-primary hover:underline">
+                Open the {opp.handoff.arm} draft <ExternalLink className="h-3 w-3" />
+              </a>
+            ) : null}
+            {opp.handoff?.note ? <p className="mt-1">{opp.handoff.note}</p> : null}
+          </div>
+        ) : mode === 'dismiss' ? (
           <div className="flex flex-wrap items-center gap-2">
             <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Why dismiss? (a calibration signal)" className="h-8 flex-1 min-w-[200px]" />
             <Button size="sm" variant="destructive" onClick={dismiss} disabled={busy}>{busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Confirm'}</Button>
@@ -256,6 +276,12 @@ function OpportunityCard({ opp, onChanged }: { opp: OppDoc; onChanged: () => voi
           <Button size="sm" variant="outline" onClick={restore} disabled={busy}><RotateCcw className="mr-1 h-3.5 w-3.5" /> Restore</Button>
         ) : (
           <div className="flex flex-wrap gap-2">
+            {opp.action !== 'none' && (
+              <Button size="sm" onClick={approve} disabled={busy}>
+                {busy ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="mr-1 h-3.5 w-3.5" />}
+                {isCampaign ? 'Approve →' : 'Accept'}
+              </Button>
+            )}
             <Button size="sm" variant="outline" onClick={() => setMode('edit')} disabled={busy}><Pencil className="mr-1 h-3.5 w-3.5" /> Edit</Button>
             <Button size="sm" variant="ghost" onClick={() => setMode('dismiss')} disabled={busy}><Ban className="mr-1 h-3.5 w-3.5" /> Dismiss</Button>
             <Button size="sm" variant="ghost" onClick={snooze} disabled={busy}><Clock className="mr-1 h-3.5 w-3.5" /> Snooze</Button>

--- a/src/app/admin/situation/actions.ts
+++ b/src/app/admin/situation/actions.ts
@@ -14,6 +14,8 @@ import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { convertTimestampsToISOStrings } from '@/lib/utils';
 import { runSituationAnalysis, type RunSituationAnalysisResult } from '@/services/growth/situationAnalyst';
 import type { SituationReport, AnalystOpportunity, RecommendedAction } from '@/lib/growth/contracts';
+import { generateAdProposalAction } from '@/app/admin/ads/actions';
+import { generatePagePostAction } from '@/app/admin/page-posts/actions';
 
 const logger = loggers.campaign;
 
@@ -236,10 +238,77 @@ export async function restoreOpportunityAction(oppId: string): Promise<{ ok: tru
   }
 }
 
+/**
+ * Approve an opportunity → hand it to the matching arm's DRAFT flow (P5 — the seam that closes the
+ * loop). ads/page create a real draft (which keeps its OWN review — nothing goes live here); whatsapp
+ * routes to /admin/campaigns to pick recipients (the in-app WhatsApp planner is M6, deferred);
+ * price/minstay/los/ota are owner actions → marked 'accepted'. Only a 'pending' opportunity can be
+ * approved. Super-admin gated.
+ */
+export async function approveOpportunityAction(oppId: string): Promise<
+  | { ok: true; status: 'approved' | 'accepted'; handoffUrl?: string; note?: string }
+  | { ok: false; error: string }
+> {
+  let actor: string;
+  try {
+    actor = await requireActor();
+  } catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  try {
+    const db = await getAdminDb();
+    const ref = db.collection('opportunities').doc(oppId);
+    const snap = await ref.get();
+    if (!snap.exists) return { ok: false, error: 'not-found' };
+    const o = snap.data() as AnalystOpportunity & { propertyId: string; status: string };
+    if (o.status !== 'pending') return { ok: false, error: `not-pending:${o.status}` };
+
+    let handoff: { arm: string; ref?: string; url?: string; note?: string };
+    let status: 'approved' | 'accepted' = 'approved';
+
+    if (o.action === 'ads') {
+      if (!o.window) return { ok: false, error: 'ads opportunity has no window' };
+      const res = await generateAdProposalAction({
+        propertyId: o.propertyId,
+        start: o.window.start,
+        end: o.window.end,
+        occasion: o.occasion ?? undefined,
+        valueAtRisk: o.valueAtRisk ?? undefined,
+        audience: o.audience ?? undefined,
+      });
+      if (!res.ok) return { ok: false, error: `ad draft failed: ${res.error}` };
+      if ('declined' in res) return { ok: false, error: `the ad planner declined: ${res.rationale}` };
+      handoff = { arm: 'ads', ref: res.adCampaignId, url: `/admin/ads/${res.adCampaignId}` };
+    } else if (o.action === 'page') {
+      const prompt = o.occasion?.trim()
+        ? o.occasion.trim()
+        : `A warm post to help fill ${o.window ? `${o.window.start}–${o.window.end}` : 'the upcoming window'}`;
+      const res = await generatePagePostAction({ propertyId: o.propertyId, prompt, goal: 'keep the page warm and support the fill', audience: o.audience ?? undefined });
+      if (!res.ok) return { ok: false, error: `page draft failed: ${res.error}` };
+      handoff = { arm: 'page', ref: res.id, url: '/admin/page-posts' };
+    } else if (o.action === 'whatsapp') {
+      handoff = { arm: 'whatsapp', url: '/admin/campaigns', note: 'Pick recipients + generate messages in Campaigns (the in-app WhatsApp recipient planner is a later phase).' };
+    } else {
+      // price / minstay / los / ota — owner actions; nothing to draft.
+      status = 'accepted';
+      handoff = { arm: 'owner', note: 'Owner action — no draft. Marked accepted for the record.' };
+    }
+
+    await ref.update({ status, handoff, approvedBy: actor, approvedAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp() });
+    logger.info('approveOpportunityAction', { actor, oppId, action: o.action, status, handoffRef: handoff.ref });
+    revalidatePath('/admin/situation');
+    return { ok: true, status, handoffUrl: handoff.url, note: handoff.note };
+  } catch (e) {
+    logger.error('approveOpportunityAction failed', e as Error, { oppId });
+    return { ok: false, error: (e as Error).message || 'internal-error' };
+  }
+}
+
 /** Fetch the newest report + its opportunities for the console. Null if none/auth failure. */
 export async function fetchLatestSituationAction(propertyId: string): Promise<{
   report: { id: string; propertyId: string; asOf: string; createdAt?: string; createdBy?: string; status: string; report: SituationReport; warnings?: string[]; steer?: string | null };
-  opportunities: Array<AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string; edited?: boolean; dismissReason?: string | null }>;
+  opportunities: Array<AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string; edited?: boolean; dismissReason?: string | null; handoff?: { arm: string; ref?: string; url?: string; note?: string } | null }>;
 } | null> {
   try {
     await requireSuperAdmin();
@@ -264,7 +333,7 @@ export async function fetchLatestSituationAction(propertyId: string): Promise<{
 
     const oppSnap = await db.collection('opportunities').where('runId', '==', doc.id).get();
     const opportunities = oppSnap.docs
-      .map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string; edited?: boolean; dismissReason?: string | null })
+      .map((d) => convertTimestampsToISOStrings({ id: d.id, ...d.data() }) as AnalystOpportunity & { id: string; runId: string; propertyId: string; status: string; createdAt?: string; edited?: boolean; dismissReason?: string | null; handoff?: { arm: string; ref?: string; url?: string; note?: string } | null })
       .sort((a, b) => String(a.createdAt ?? '').localeCompare(String(b.createdAt ?? '')));
 
     return { report, opportunities };


### PR DESCRIPTION
The final phase of Move 2. **Approving** an opportunity hands it to the matching arm's **draft** flow — the seam that turns the brain end-to-end. Nothing goes live: each arm keeps its own review, and the owner activates separately.

## `approveOpportunityAction` (super-admin; only a `pending` opportunity)
- **ads** → `generateAdProposalAction` → a real Firestore-only **ad draft** (review-before-push); `handoff.url = /admin/ads/{id}`. A planner decline surfaces as an error (no draft).
- **page** → `generatePagePostAction` → a real **page-post draft**; `handoff.url = /admin/page-posts`.
- **whatsapp** → routes to `/admin/campaigns` to pick recipients there — the in-app WhatsApp recipient planner is **M6 (deferred)**, so this is an honest lighter hand-off, flagged in the UI.
- **price/minstay/los/ota** → owner actions → status `accepted` (no draft, for the record).

Sets status `approved`/`accepted` + `handoff {arm, ref, url, note}`. Nested arm calls run in-request, so their own `requireSuperAdmin` sees the session.

## UI
An **Approve →** (campaign) / **Accept** (owner-action) button on pending opportunities; once approved, the card shows the arm badge + a link to open the draft (or the WhatsApp note).

## Safety
Build compiles. The approve→draft path is auth-gated (calls the already-proven ads/page generators), so it's best verified by a click-through. **Nothing here sends or spends** — the arm's draft is still PAUSED / Gate-1, and the owner activates separately. **Two reviews** stand between a proposal and any real spend/send.

## The loop, now closed
run → read → challenge/edit → **approve → arm drafts it** → review in the arm → you activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)