### PR TITLE
feat: leads, off-WhatsApp notes, and a capture surface for both

### DIFF
--- a/.claude/skills/whatsapp-planner/SKILL.md
+++ b/.claude/skills/whatsapp-planner/SKILL.md
@@ -68,7 +68,8 @@ discount and spends no margin. Only `gap_fill` carries an offer.
   (a guest whose `lastStaySeason` is a strong *source* season for this target fits — NOT "same
   season"), `lastHadChildren` vs whether the occasion is a family window, `typicalNights` vs the
   gap's nights, and `reviewThemes` vs the occasion.
-- **Relationship** — `tier` and `daysSinceLastOutbound`. Warm repeat/engaged guests are safe
+- **Relationship** — `tier` and `daysSinceLastContact` (WhatsApp outbound OR a logged phone call —
+  see `loggedCalls`/`lastCall`; a call counts as both engagement and contact). Warm repeat/engaged guests are safe
   ground; `unknown` (never contacted) is a real growth pool; a `complaintSignals > 0` guest is
   fine to include but flag it so the copywriter handles the past issue with care (never hard-sell
   someone with an unresolved problem).

--- a/firestore.rules
+++ b/firestore.rules
@@ -240,6 +240,18 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only (backfill / incremental fetcher)
     }
 
+    match /whatsappThreadImports/{importId} {
+      // Immutable raw captures the threads above are derived from — same sensitivity.
+      allow read: if isSuperAdmin();
+      allow write: if false;  // Admin SDK only (importer)
+    }
+
+    match /guestNotes/{noteId} {
+      // Off-WhatsApp interactions (phone calls, in-person) — private conversation content.
+      allow read: if isSuperAdmin();
+      allow write: if false;  // Admin SDK only (CLI / admin actions)
+    }
+
     match /campaigns/{campaignId} {
       allow read: if isSuperAdmin() || isPropertyOwner();
       allow write: if false;  // Admin SDK only

--- a/scripts/guest-note.ts
+++ b/scripts/guest-note.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env npx tsx
+/**
+ * guest-note — record what happened off-WhatsApp (a phone call, a conversation on site).
+ *
+ * The engagement layer reads the message vault, so a relationship conducted by phone is invisible
+ * to it — and worse than invisible: unanswered outbound messages read as "silent, never replied"
+ * for someone who was warm on a call. A note supplies the missing half of the timeline. It counts
+ * as a TOUCH for pacing, and — only when marked `--assertable` — it may be used as a fact.
+ *
+ * Usage:
+ *   guest-note add   (--guest <id> | --phone <e164>) --text "..." [--kind call|inperson|observation]
+ *                    [--at YYYY-MM-DD] [--by owner|guest] [--assertable] [--fact key=value ...]
+ *                    [--expires YYYY-MM-DD]
+ *   guest-note list  [(--guest <id> | --phone <e164>)]
+ *   guest-note rm    --id <noteId>
+ *
+ * `--assertable` licenses the copywriter to STATE the note. Leave it off for anything that should
+ * only shape tone. `--expires` retires a note whose relevance has a shelf life.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+import { getAdminDb } from '../src/lib/firebaseAdminSafe';
+import { addGuestNote, listGuestNotes, deleteGuestNote, getNotesByGuest } from '../src/services/guestNoteService';
+import type { GuestNoteKind } from '../src/types';
+
+const flag = (n: string): string | undefined => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : undefined; };
+const has = (n: string) => process.argv.includes(`--${n}`);
+const all = (n: string): string[] => process.argv.reduce<string[]>((acc, a, i) => (a === `--${n}` && process.argv[i + 1] ? [...acc, process.argv[i + 1]] : acc), []);
+const digits = (s: string) => (s || '').replace(/[^0-9]/g, '');
+
+/** Resolve --guest / --phone to a guest id + label. Phone matches on the last 9 digits. */
+async function resolveGuest(): Promise<{ id: string; label: string } | null> {
+  const gid = flag('guest');
+  const phone = flag('phone');
+  const db = await getAdminDb();
+  if (gid) {
+    const d = await db.collection('guests').doc(gid).get();
+    if (!d.exists) { console.error(`No guest ${gid}`); return null; }
+    const g: any = d.data();
+    return { id: d.id, label: [g.firstName, g.lastName].filter(Boolean).join(' ') || d.id };
+  }
+  if (phone) {
+    const p9 = digits(phone).slice(-9);
+    const snap = await db.collection('guests').get();
+    const hit = snap.docs.find((d) => digits((d.data() as any).normalizedPhone || (d.data() as any).phone || '').slice(-9) === p9);
+    if (!hit) { console.error(`No guest/lead with phone …${p9}`); return null; }
+    const g: any = hit.data();
+    return { id: hit.id, label: [g.firstName, g.lastName].filter(Boolean).join(' ') || hit.id };
+  }
+  return null;
+}
+
+async function main() {
+  const cmd = process.argv[2];
+
+  if (cmd === 'add') {
+    const who = await resolveGuest();
+    const text = flag('text');
+    if (!who || !text) { console.error('add requires (--guest <id> | --phone <e164>) and --text "..."'); process.exit(1); }
+    const facts = all('fact').map((f) => { const i = f.indexOf('='); return { key: f.slice(0, i), value: f.slice(i + 1) }; }).filter((f) => f.key && f.value);
+    const assertable = has('assertable');
+    if (facts.length && !assertable) console.warn('note: --fact given without --assertable — the facts will NOT be usable by the copywriter');
+
+    const id = await addGuestNote({
+      guestId: who.id,
+      text,
+      kind: (flag('kind') as GuestNoteKind) || 'call',
+      occurredAt: flag('at'),
+      initiatedBy: flag('by') as 'owner' | 'guest' | undefined,
+      assertable,
+      facts,
+      expiresAt: flag('expires'),
+      createdBy: 'cli',
+    });
+    console.log(`Noted ${who.label} [${who.id}] → ${id}${assertable ? ' (assertable)' : ' (context-only)'}${facts.length ? ` · ${facts.length} fact(s)` : ''}`);
+    return;
+  }
+
+  if (cmd === 'list') {
+    const who = await resolveGuest();
+    if (who) {
+      const notes = await listGuestNotes(who.id);
+      console.log(`${who.label} [${who.id}] · ${notes.length} note(s)\n`);
+      notes.forEach((n) => {
+        console.log(`  ${n.id}  ${n.occurredAt}  ${n.kind.padEnd(11)} ${n.assertable ? 'assertable ' : 'context    '}${n.expiresAt ? `expires ${n.expiresAt} ` : ''}`);
+        console.log(`     ${n.text}`);
+        (n.facts || []).forEach((f) => console.log(`     · note:${f.key} = ${f.value}`));
+      });
+      return;
+    }
+    const byGuest = await getNotesByGuest();
+    const total = [...byGuest.values()].reduce((s, a) => s + a.length, 0);
+    console.log(`${total} note(s) across ${byGuest.size} guest(s)\n`);
+    for (const [gid, notes] of byGuest) {
+      console.log(`  ${gid.padEnd(24)} ${String(notes.length).padStart(2)} note(s) · latest ${notes[notes.length - 1].occurredAt}`);
+    }
+    return;
+  }
+
+  if (cmd === 'rm') {
+    const id = flag('id');
+    if (!id) { console.error('rm requires --id <noteId>'); process.exit(1); }
+    await deleteGuestNote(id);
+    console.log(`Deleted ${id}.`);
+    return;
+  }
+
+  console.error('Unknown command. Use: add | list | rm');
+  process.exit(1);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/import-whatsapp-export.ts
+++ b/scripts/import-whatsapp-export.ts
@@ -5,11 +5,21 @@
  * The phone export (_chat.txt inside the per-chat zip) is the COMPLETE verbatim history — far
  * richer than the desktop scrape (e.g. Razvan/Loredana: 88 msgs vs 1). It also captures the
  * owner's real sent messages, which feed voice-learning. This parses that file, matches it to a
- * guest by the phone number in the zip filename, and merges it into `whatsappThreads` (dedup +
- * sort via upsertThreadMessages — safe to re-run).
+ * guest by the phone number in the zip filename, archives the raw batch, and reconciles it into
+ * `whatsappThreads`.
+ *
+ * The export is AUTHORITATIVE but not assumed complete: it supersedes stored duplicates (matched
+ * loosely, since the scrape only knows the minute) while RESCUING anything the vault holds that the
+ * export lacks. An export reflects one device at one moment — a restored phone or a disappearing-
+ * messages timer yields a legitimately short file, and the vault may be the only surviving copy.
+ * Shrink / starts-later warnings are printed so a trimmed export is visible rather than silent.
  *
  * Usage:
- *   npx tsx scripts/import-whatsapp-export.ts <file.zip | _chat.txt | dir-of-zips> [--guest <id>] [--dry-run]
+ *   npx tsx scripts/import-whatsapp-export.ts <file.zip | _chat.txt | dir-of-zips>
+ *          [--guest <id>] [--create-lead [--property <slug>]] [--dry-run]
+ *
+ * `--create-lead` opens a lead record for a number that has never booked, so a direct enquiry has
+ * somewhere to land instead of being skipped.
  *
  * Export format (phone app): `[DD.MM.YY, HH:MM:SS] Sender: text` + continuation lines; the owner's
  * sender name is WHATSAPP_OWNER_NAME (default "Bogdan Coman"); "~Name" = the guest. Media/system
@@ -21,13 +31,17 @@ import * as fs from 'fs';
 import { execSync } from 'child_process';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 import { getAdminDb } from '../src/lib/firebaseAdminSafe';
-import { upsertThreadMessages } from '../src/services/whatsappThreadService';
+import { upsertThreadMessages, archiveImport } from '../src/services/whatsappThreadService';
+import { createLead, cleanPushName } from '../src/services/leadService';
+import { isSystemNotice } from '../src/lib/whatsapp/parse-thread';
 import type { WhatsAppMessage } from '../src/types';
 
 const arg = (n: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : undefined; };
 const INPUT = process.argv[2];
 const GUEST_OVERRIDE = arg('guest');
 const DRY = process.argv.includes('--dry-run');
+const CREATE_LEAD = process.argv.includes('--create-lead');
+const LEAD_PROPERTY = arg('property');
 const OWNER = process.env.WHATSAPP_OWNER_NAME || 'Bogdan Coman';
 
 if (!INPUT || INPUT.startsWith('--')) { console.error('usage: import-whatsapp-export <file.zip|_chat.txt|dir> [--guest <id>] [--dry-run]'); process.exit(2); }
@@ -35,31 +49,44 @@ if (!INPUT || INPUT.startsWith('--')) { console.error('usage: import-whatsapp-ex
 const digits = (s: string) => (s || '').replace(/[^0-9]/g, '');
 const stripQuery = (t: string) => t.replace(/(https?:\/\/[^\s?]+)\?[^\s]*/g, '$1'); // drop URL query strings (clean vault)
 
-const START = /^‎?\[(\d\d)\.(\d\d)\.(\d\d), (\d\d):(\d\d):(\d\d)\] ([^:]+): ([\s\S]*)$/;
+// The header tolerates a MISSING space after the colon — WhatsApp emits bare `[ts] Sender:` lines
+// (stripped system events). Matching them keeps their (empty) body from being glued onto the
+// PREVIOUS message as a continuation line.
+const START = /^‎?\[(\d\d)\.(\d\d)\.(\d\d), (\d\d):(\d\d):(\d\d)\] ([^:]+):[ \t]?([\s\S]*)$/;
 const MEDIA = /(image|video|audio|document|GIF|sticker|Contact card) omitted|Missed (voice|video) call/i;
-const SYSTEM = /end-to-end encrypted|changed to a new number|created group|added you|security code/i;
 
 function parseChat(raw: string): WhatsAppMessage[] {
   const out: WhatsAppMessage[] = [];
+  let dropping = false;   // inside a system notice — swallow its continuation lines too
+
   for (const ln of raw.split(/\r?\n/)) {
     const m = ln.match(START);
     if (m) {
       const [, dd, mm, yy, hh, mi, ss, senderRaw, textRaw] = m;
-      const sender = senderRaw.replace(/^~/, '').trim();
       const text = textRaw.replace(/^‎/, '');
-      if (SYSTEM.test(text)) continue; // drop the encryption / system notices
+      if (isSystemNotice(text)) { dropping = true; continue; }  // chat event, not a message
+      dropping = false;
+      const sender = senderRaw.replace(/^~/, '').trim();
       out.push({
         ts: `20${yy}-${mm}-${dd}T${hh}:${mi}:${ss}`,   // phone-local = Bucharest, matches the scrape format
         direction: sender === OWNER ? 'out' : 'in',
         sender,
         text: stripQuery(text),
-        type: MEDIA.test(text) ? 'media' : /https?:\/\//.test(text) ? 'link' : 'text',
+        type: 'text',                                   // classified below, over the joined body
       });
-    } else if (out.length && ln.length) {
-      out[out.length - 1].text += '\n' + stripQuery(ln.replace(/^‎/, '')); // continuation line
+    } else if (!dropping && out.length) {
+      // Continuation line — appended even when blank, so paragraph breaks inside a message survive.
+      out[out.length - 1].text += '\n' + stripQuery(ln.replace(/^‎/, ''));
     }
   }
-  return out;
+
+  return out
+    .map((m) => ({ ...m, text: m.text.replace(/\n{3,}/g, '\n\n').trim() }))
+    .filter((m) => m.text.length > 0)   // bare `[ts] Sender:` artifacts carry no content
+    .map((m) => ({
+      ...m,
+      type: MEDIA.test(m.text) ? 'media' : /https?:\/\//.test(m.text) ? 'link' : 'text',
+    }));
 }
 
 function readChatText(file: string): string {
@@ -75,15 +102,49 @@ async function importOne(file: string, guestByPhone: Map<string, { id: string; n
 
   let guest = GUEST_OVERRIDE ? [...guestByPhone.values()].find((g) => g.id === GUEST_OVERRIDE) : guestByPhone.get(phone9);
   const label = `${path.basename(file)}  (phone …${phone9})`;
-  if (!guest) { console.log(`SKIP  ${label} — no guest matches this phone (use --guest <id> to force)`); return; }
 
+  // Nobody by this number has ever stayed — it is a LEAD. Without a record the chat has nowhere to
+  // land at all, so `--create-lead` opens one and the conversation is kept from the first contact.
+  if (!guest && CREATE_LEAD && phone9.length === 9 && !DRY) {
+    const e164 = `+${digits(path.basename(file))}`;
+    const sorted = [...msgs].sort((a, b) => a.ts.localeCompare(b.ts));
+    const theirName = cleanPushName(sorted.find((m) => m.direction === 'in')?.sender);   // may be empty — many leads have no name at all
+    const res = await createLead({
+      phone: e164,
+      name: theirName,
+      leadSource: 'whatsapp',
+      propertyId: LEAD_PROPERTY,
+      firstContactAt: sorted[0]?.ts.slice(0, 10),
+    });
+    guest = { id: res.id, name: theirName || e164, phone: e164 };
+    console.log(`\n${res.created ? 'LEAD CREATED' : 'lead exists'} ${guest.name} [${guest.id}]${theirName ? '' : ' (no name — WhatsApp gave only the number)'}`);
+    if (!LEAD_PROPERTY) console.log('  ⚠ no --property given: this lead belongs to no property yet and will not appear in any audience');
+  }
+
+  if (!guest) {
+    console.log(`SKIP  ${label} — no guest matches this phone (use --create-lead for a new lead, or --guest <id> to force)`);
+    return;
+  }
+
+  const sorted = [...msgs].sort((a, b) => a.ts.localeCompare(b.ts));
   const outCount = msgs.filter((m) => m.direction === 'out' && m.type === 'text').length;
+  const inCount = msgs.filter((m) => m.direction === 'in' && m.type === 'text').length;
   console.log(`\n${guest.name} [${guest.id}]  ← ${label}`);
-  console.log(`  parsed: ${msgs.length} msgs (${textMsgs.length} text, ${msgs.length - textMsgs.length} media) · ${outCount} owner-sent · ${msgs[0]?.ts.slice(0,10)}→${msgs[msgs.length-1]?.ts.slice(0,10)}`);
+  console.log(`  parsed: ${msgs.length} msgs (${textMsgs.length} text, ${msgs.length - textMsgs.length} media) · ${outCount} owner-sent, ${inCount} inbound · ${sorted[0]?.ts.slice(0, 10)}→${sorted[sorted.length - 1]?.ts.slice(0, 10)}`);
   if (DRY) { console.log('  (dry-run — not written)'); return; }
-  // The official export is the COMPLETE, clean history → REPLACE the (partial, artifact-laden) scrape.
-  const res = await upsertThreadMessages({ guestId: guest.id, phone: guest.phone, messages: msgs, replace: true });
-  console.log(`  replaced → ${res.total} messages in vault (was scrape/partial)`);
+
+  // Archive the raw batch FIRST — the thread doc is derived and can be rebuilt from these.
+  const importId = await archiveImport({ guestId: guest.id, phone: guest.phone, source: 'export', label: path.basename(file), messages: msgs });
+
+  const res = await upsertThreadMessages({ guestId: guest.id, phone: guest.phone, messages: msgs, authoritative: true });
+  const r = res.reconcile;
+  console.log(`  vault → ${res.total} messages (${res.added >= 0 ? '+' : ''}${res.added}) · archived as ${importId}`);
+  if (r && r.supersededCount) console.log(`  ${r.supersededCount} stored message(s) superseded by the richer export capture`);
+  if (r && r.rescued.length) {
+    console.log(`  ⚠ ${r.rescued.length} stored message(s) are NOT in this export — kept, not dropped (${r.rescued[0].ts.slice(0, 10)}→${r.rescued[r.rescued.length - 1].ts.slice(0, 10)})`);
+  }
+  if (r && r.shrinks) console.log(`  ⚠ this export is SMALLER than what was stored (${r.incomingCount} vs ${r.existingCount}) — likely a trimmed device or a disappearing-messages timer`);
+  if (r && r.startsLater) console.log(`  ⚠ this export starts at ${r.incomingEarliest?.slice(0, 16).replace('T', ' ')} but the vault holds history from ${r.existingEarliest?.slice(0, 16).replace('T', ' ')} — older history is phone-side gone`);
 }
 
 async function main() {

--- a/scripts/land-campaign.ts
+++ b/scripts/land-campaign.ts
@@ -53,11 +53,14 @@ async function main() {
     const copyPack = readJson(copyPackFile);
     const guests: GuestForDraftValidation[] = (copyPack.guests ?? copyPack).map((g: {
       guestId: string; careFlags?: string[]; groundedFacts?: Array<{ key: string; value: unknown }>; thread?: unknown[];
+      audienceKind?: 'guest' | 'lead'; relationship?: { state?: GuestForDraftValidation['relationshipState'] };
     }) => ({
       guestId: g.guestId,
       careFlags: g.careFlags ?? [],
       groundedFacts: g.groundedFacts ?? [],
       thread: g.thread ?? [],
+      audienceKind: g.audienceKind,
+      relationshipState: g.relationship?.state,
     }));
     const dv = validateDrafts(guests, drafts);
     console.log(`draft validation — ${dv.ok ? 'PASS' : 'REJECT'}`);

--- a/scripts/lead.ts
+++ b/scripts/lead.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env npx tsx
+/**
+ * lead — maintain records for people who contacted us directly but never stayed.
+ *
+ * A lead has no stay, so the material a message can honestly be built on is different: what they
+ * ASKED for, and why it did not happen. `--reason` and `request` capture exactly that. Requested
+ * periods are also demand telemetry — a window we could not fill is evidence about pricing and
+ * calendar pressure that never becomes a booking record.
+ *
+ * Usage:
+ *   lead create  --phone <e164> [--name "..."] [--property <slug>] [--source whatsapp|phone|website]
+ *                [--first-contact YYYY-MM-DD] [--lang ro|en]
+ *   lead set     (--guest <id> | --phone <e164>) [--name "..."] [--name-source booking|pushname|manual|unknown]
+ *                [--reason unavailable|declined|unservable|unresolved] [--property <slug>] [--source ...]
+ *   lead request (--guest <id> | --phone <e164>) --start YYYY-MM-DD --end YYYY-MM-DD
+ *                [--asked-on YYYY-MM-DD] [--outcome unavailable|declined|booked|unresolved] [--note "..."]
+ *   lead list
+ *
+ * See NonConversionReason in src/types for what each --reason licenses in a later message.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+import { createLead, updateLead, addRequestedPeriod, listLeads, findByPhone } from '../src/services/leadService';
+import type { Guest, NonConversionReason, RequestedPeriod } from '../src/types';
+
+const flag = (n: string): string | undefined => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : undefined; };
+const today = () => new Date().toISOString().slice(0, 10);
+
+async function resolve(): Promise<{ id: string; label: string } | null> {
+  const gid = flag('guest');
+  if (gid) return { id: gid, label: gid };
+  const phone = flag('phone');
+  if (!phone) return null;
+  const g = await findByPhone(phone);
+  if (!g) { console.error(`No guest/lead with phone ${phone} — create one first`); return null; }
+  return { id: g.id, label: [g.firstName, g.lastName].filter(Boolean).join(' ') || g.normalizedPhone || g.id };
+}
+
+async function main() {
+  const cmd = process.argv[2];
+
+  if (cmd === 'create') {
+    const phone = flag('phone');
+    if (!phone) { console.error('create requires --phone <e164>'); process.exit(1); }
+    const res = await createLead({
+      phone,
+      name: flag('name'),
+      nameSource: flag('name') ? 'manual' : undefined,
+      leadSource: flag('source'),
+      propertyId: flag('property'),
+      firstContactAt: flag('first-contact'),
+      language: flag('lang') as Guest['language'],
+    });
+    if (!res.created) {
+      const e = res.existing!;
+      console.log(`Already known: ${[e.firstName, e.lastName].filter(Boolean).join(' ') || e.id} [${e.id}] · kind=${e.kind || 'guest'}`);
+      return;
+    }
+    console.log(`Lead created [${res.id}]`);
+    if (!flag('property')) console.log('  ⚠ no --property: this lead belongs to no property yet and will not appear in any audience');
+    return;
+  }
+
+  if (cmd === 'set') {
+    const who = await resolve();
+    if (!who) { console.error('set requires --guest <id> or --phone <e164>'); process.exit(1); }
+    await updateLead(who.id, {
+      firstName: flag('name'),
+      nameSource: flag('name-source') as Guest['nameSource'],
+      leadSource: flag('source'),
+      nonConversionReason: flag('reason') as NonConversionReason | undefined,
+      propertyId: flag('property'),
+      language: flag('lang') as Guest['language'],
+    });
+    console.log(`Updated ${who.label} [${who.id}]`);
+    return;
+  }
+
+  if (cmd === 'request') {
+    const who = await resolve();
+    const start = flag('start'); const end = flag('end');
+    if (!who || !start || !end) { console.error('request requires (--guest|--phone) --start YYYY-MM-DD --end YYYY-MM-DD'); process.exit(1); }
+    const period: RequestedPeriod = {
+      start, end,
+      askedOn: flag('asked-on') || today(),
+      outcome: (flag('outcome') as RequestedPeriod['outcome']) || 'unresolved',
+      ...(flag('note') ? { note: flag('note')! } : {}),
+    };
+    await addRequestedPeriod(who.id, period);
+    console.log(`Recorded ${who.label} [${who.id}] wanted ${start}→${end} · ${period.outcome}`);
+    return;
+  }
+
+  if (cmd === 'list') {
+    const leads = await listLeads();
+    console.log(`${leads.length} lead(s)\n`);
+    for (const l of leads) {
+      const name = [l.firstName, l.lastName].filter(Boolean).join(' ') || '(no name)';
+      const req = (l.requestedPeriods || []).map(p => `${p.start}→${p.end} ${p.outcome}`).join('; ');
+      console.log(`  ${l.id.padEnd(24)} ${(l.normalizedPhone || '').padEnd(15)} ${name.padEnd(20)} first ${l.firstContactAt || '?'} · ${l.nonConversionReason || 'reason unset'}${req ? ` · ${req}` : ''}`);
+    }
+    return;
+  }
+
+  console.error('Unknown command. Use: create | set | request | list');
+  process.exit(1);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/planner-pack.ts
+++ b/scripts/planner-pack.ts
@@ -22,6 +22,7 @@ import * as fs from 'fs';
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 import { getAdminDb } from '../src/lib/firebaseAdminSafe';
 import { isRomaniaBased, classifyResidency } from '../src/lib/growth/audience';
+import { getNotesByGuest, isTouch } from '../src/services/guestNoteService';
 
 const arg = (n: string, d?: string) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
 const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
@@ -53,13 +54,14 @@ function lastStayPhrase(last: Date | null): string | null {
 
 async function main() {
   const db = await getAdminDb();
-  const [bSnap, gSnap, rSnap, tSnap, sSnap, hSnap] = await Promise.all([
+  const [bSnap, gSnap, rSnap, tSnap, sSnap, hSnap, notesByGuest] = await Promise.all([
     db.collection('bookings').get(),
     db.collection('guests').get(),
     db.collection('reviews').get(),
     db.collection('whatsappThreads').get(),
     db.collection('suppressionList').get(),
     db.collection('holidays').get(),
+    getNotesByGuest(),
   ]);
 
   const price = (b: any) => b.pricing?.total ?? b.pricing?.totalPrice ?? 0;
@@ -116,10 +118,16 @@ async function main() {
     const inbound = msgs.filter(m => m.direction === 'in' && m.ts < ymd(AS_OF)).length;
     const outbound = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).length;
     const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
-    const daysSinceOut = lastOut ? days(new Date(`${lastOut}T00:00:00Z`), AS_OF) : null;
+    // Logged phone/in-person contact counts as BOTH engagement and contact — a relationship held on
+    // the phone is otherwise read as "we messaged them and they never answered".
+    const calls = (notesByGuest.get(g.id) || []).filter(n => isTouch(n.kind) && n.occurredAt <= ymd(AS_OF));
+    const lastCall = calls.map(n => n.occurredAt).sort().pop();
+    const lastContact = [lastOut, lastCall].filter(Boolean).sort().pop();
+    const daysSinceOut = lastContact ? days(new Date(`${lastContact}T00:00:00Z`), AS_OF) : null;
 
     const totalBookings = stayB.length;   // REAL completed stays — g.totalBookings is unreliable (inflated; counts cancelled)
-    const tier = totalBookings >= 2 ? 'repeat' : inbound >= 3 ? 'engaged' : inbound >= 1 ? 'responsive' : outbound >= 1 ? 'silent' : 'unknown';
+    const engagements = inbound + calls.length;
+    const tier = totalBookings >= 2 ? 'repeat' : engagements >= 3 ? 'engaged' : engagements >= 1 ? 'responsive' : outbound >= 1 ? 'silent' : 'unknown';
 
     // coarse complaint signal (the copywriter does the real sentiment read over the full thread)
     const complaintRe = /problem|nu merge|stricat|defect|rece|frig|murdar|nu funct|nu mai merge|scurgere|presiune/i;
@@ -149,6 +157,14 @@ async function main() {
     dossiers.push({
       guestId: g.id,
       firstName: g.firstName || null,
+      nameSource: g.nameSource || (g.firstName ? 'booking' : 'unknown'),   // 'pushname'/'unknown' ⇒ do not greet by it
+      // A LEAD never stayed: no season to reference, no review, no channel history. What it has
+      // instead is a request and a reason it went unfilled — see nonConversionReason for what a
+      // later message may honestly do.
+      kind: g.kind || 'guest',
+      firstContactAt: g.firstContactAt || null,
+      nonConversionReason: g.nonConversionReason || null,
+      requestedPeriods: g.requestedPeriods || [],
       eligible: reasons.length === 0,
       ineligibleReasons: reasons,
       tier,
@@ -166,7 +182,9 @@ async function main() {
       reviewText: reviewText || null,
       complaintSignals,
       inboundMessages: inbound,
-      daysSinceLastOutbound: daysSinceOut,
+      loggedCalls: calls.length,
+      lastCall: lastCall ?? null,
+      daysSinceLastContact: daysSinceOut,   // WhatsApp outbound OR a logged call, whichever is later
     });
   }
 

--- a/scripts/whatsapp-thread.ts
+++ b/scripts/whatsapp-thread.ts
@@ -43,7 +43,8 @@
 // suffices; `save` dedupes against the stored thread, appending only genuinely-new messages.
 //
 // Usage:
-//   npx tsx scripts/whatsapp-thread.ts queue [--lang ro|en|all] [--missing]
+//   npx tsx scripts/whatsapp-thread.ts queue [--lang ro|en|all] [--missing] [--stale]
+//     --stale = order by capture staleness (never-captured, then oldest) — the re-export work-list
 //   npx tsx scripts/whatsapp-thread.ts save --guest <id> --phone <e164> --rows <file.json> [--owner "Bogdan Coman"] [--fmt MDY|DMY]
 //   npx tsx scripts/whatsapp-thread.ts mark --guest <id> --phone <e164> --status no-chat|empty   # record a guest with no retrievable messages
 //   npx tsx scripts/whatsapp-thread.ts show --guest <id>
@@ -69,11 +70,14 @@ async function main() {
 
   if (cmd === 'queue') {
     const language = (flag('lang') as 'ro' | 'en' | 'all') || 'ro';
-    const q = await getBackfillQueue({ language, onlyMissing: has('missing') });
+    const stale = has('stale');
+    const q = await getBackfillQueue({ language, onlyMissing: has('missing'), byStaleness: stale });
     const todo = q.filter((i) => !i.hasThread).length;
-    console.log(`${q.length} guests (${language})${has('missing') ? ' — missing only' : ''} · ${todo} without a thread\n`);
+    console.log(`${q.length} guests (${language})${has('missing') ? ' — missing only' : ''}${stale ? ' — stalest capture first' : ''} · ${todo} without a thread\n`);
     for (const i of q) {
-      const status = i.hasThread ? `✓ ${i.messageCount} msgs, last ${i.lastMessageTs ?? '?'}` : '— (backfill)';
+      const status = i.hasThread
+        ? `✓ ${String(i.messageCount).padStart(3)} msgs, last ${i.lastMessageTs?.slice(0, 10) ?? '?'}, captured ${i.lastFetchedAt ?? '?'}`
+        : '— (never captured)';
       console.log(`  ${i.guestId.padEnd(24)} ${i.phone.padEnd(15)} ${i.name.padEnd(26)} ${status}`);
     }
     return;

--- a/src/app/admin/contacts/_components/contact-console.tsx
+++ b/src/app/admin/contacts/_components/contact-console.tsx
@@ -1,0 +1,446 @@
+'use client';
+
+/**
+ * The capture surface for everything that happens off WhatsApp.
+ *
+ * Built for the moment right after hanging up, on a phone: type a few digits or letters, tap the
+ * person (or open a record straight from an unknown number), say what happened, save. Anything that
+ * is not that — the lead's reason, the dates they wanted, the fact toggle — sits below the fold and
+ * stays optional, because a capture flow that asks for classification first is a capture flow that
+ * does not get used.
+ */
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { Phone, User, Search, Trash2, Plus, MessageSquare, ExternalLink } from 'lucide-react';
+import {
+  addNoteAction, createLeadAction, deleteNoteAction, fetchContactDetailAction,
+  setLeadReasonAction, addRequestedPeriodAction,
+  type ContactRow, type ContactDetail,
+} from '../actions';
+import type { GuestNoteKind, NonConversionReason, RequestedPeriod } from '@/types';
+
+const today = () => new Date().toISOString().slice(0, 10);
+const digits = (s: string) => s.replace(/[^0-9]/g, '');
+
+const KIND_LABEL: Record<GuestNoteKind, string> = { call: 'Phone call', inperson: 'In person', observation: 'Noticed' };
+const REASONS: Array<{ value: NonConversionReason; label: string; hint: string }> = [
+  { value: 'unavailable', label: 'We were full', hint: 'We could not host them — nothing went wrong. Safe to reach out when something opens.' },
+  { value: 'declined', label: 'They passed', hint: 'Price, or they went elsewhere. Do not re-offer the same terms.' },
+  { value: 'unservable', label: 'We cannot serve it', hint: 'Structural — payment method, capacity, pets. Leave it unless something changed.' },
+  { value: 'unresolved', label: 'Just fizzled', hint: 'No conclusion. A light re-open, not a follow-up.' },
+];
+
+export function ContactConsole({ contacts, propertyId, initialGuestId }: {
+  contacts: ContactRow[];
+  propertyId: string;
+  initialGuestId?: string;   // deep link from a guest record: /admin/contacts?guestId=…
+}) {
+  const { toast } = useToast();
+  const [pending, startTransition] = useTransition();
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<ContactRow | null>(
+    () => (initialGuestId ? contacts.find((c) => c.id === initialGuestId) ?? null : null),
+  );
+  const [detail, setDetail] = useState<ContactDetail | null>(null);
+  const [rows, setRows] = useState(contacts);
+
+  // Load the deep-linked contact's detail once on mount; clicks go through open() instead.
+  const didInit = useRef(false);
+  useEffect(() => {
+    if (didInit.current || !selected) return;
+    didInit.current = true;
+    startTransition(async () => setDetail(await fetchContactDetailAction(selected.id)));
+  }, [selected]);
+
+  // note composer
+  const [text, setText] = useState('');
+  const [kind, setKind] = useState<GuestNoteKind>('call');
+  const [occurredAt, setOccurredAt] = useState(today());
+  const [assertable, setAssertable] = useState(false);
+  const [factValue, setFactValue] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+
+  // lead extras
+  const [reqStart, setReqStart] = useState('');
+  const [reqEnd, setReqEnd] = useState('');
+  const [reqOutcome, setReqOutcome] = useState<RequestedPeriod['outcome']>('unavailable');
+
+  const q = query.trim().toLowerCase();
+  const qDigits = digits(query);
+  const matches = useMemo(() => {
+    if (!q) return rows.slice(0, 12);
+    return rows.filter((c) =>
+      c.name.toLowerCase().includes(q) || (qDigits.length >= 3 && digits(c.phone).includes(qDigits))
+    ).slice(0, 30);
+  }, [rows, q, qDigits]);
+
+  // A number we have never seen is the common case after a call from a stranger.
+  const unknownNumber = qDigits.length >= 9 && !rows.some((c) => digits(c.phone).slice(-9) === qDigits.slice(-9));
+
+  function open(c: ContactRow) {
+    setSelected(c);
+    setDetail(null);
+    resetComposer();
+    startTransition(async () => setDetail(await fetchContactDetailAction(c.id)));
+  }
+
+  function resetComposer() {
+    setText(''); setKind('call'); setOccurredAt(today());
+    setAssertable(false); setFactValue(''); setExpiresAt('');
+    setReqStart(''); setReqEnd(''); setReqOutcome('unavailable');
+  }
+
+  function refreshDetail(id: string) {
+    startTransition(async () => setDetail(await fetchContactDetailAction(id)));
+  }
+
+  function createLead() {
+    startTransition(async () => {
+      const res = await createLeadAction({ phone: query.trim(), propertyId, leadSource: 'phone' });
+      if (!res.ok || !res.id) { toast({ title: 'Could not create', description: res.error, variant: 'destructive' }); return; }
+      const row: ContactRow = {
+        id: res.id, name: '', phone: query.trim(), kind: 'lead', lastStay: null,
+        firstContactAt: today(), nonConversionReason: null, messages: 0, inbound: 0, notes: 0,
+        lastContact: today(), unsubscribed: false,
+      };
+      setRows((prev) => [row, ...prev]);
+      setQuery('');
+      open(row);
+      toast({ title: res.created ? 'Lead created' : 'Already known', description: 'Now write what happened.' });
+    });
+  }
+
+  function saveNote() {
+    if (!selected) return;
+    startTransition(async () => {
+      const res = await addNoteAction({
+        guestId: selected.id, text, kind, occurredAt, assertable,
+        ...(assertable && factValue.trim() ? { factKey: 'fromCall', factValue: factValue.trim() } : {}),
+        ...(expiresAt ? { expiresAt } : {}),
+      });
+      if (!res.ok) { toast({ title: 'Not saved', description: res.error, variant: 'destructive' }); return; }
+      toast({ title: 'Noted', description: assertable ? 'Usable as a fact in future messages.' : 'Kept as context.' });
+      setRows((prev) => prev.map((r) => (r.id === selected.id ? { ...r, notes: r.notes + 1, lastContact: occurredAt } : r)));
+      resetComposer();
+      refreshDetail(selected.id);
+    });
+  }
+
+  function saveReason(reason: NonConversionReason) {
+    if (!selected) return;
+    startTransition(async () => {
+      const res = await setLeadReasonAction(selected.id, reason);
+      if (!res.ok) { toast({ title: 'Not saved', description: res.error, variant: 'destructive' }); return; }
+      setRows((prev) => prev.map((r) => (r.id === selected.id ? { ...r, nonConversionReason: reason } : r)));
+      setSelected({ ...selected, nonConversionReason: reason });
+      refreshDetail(selected.id);
+    });
+  }
+
+  function savePeriod() {
+    if (!selected || !reqStart || !reqEnd) return;
+    startTransition(async () => {
+      const res = await addRequestedPeriodAction({ guestId: selected.id, start: reqStart, end: reqEnd, outcome: reqOutcome });
+      if (!res.ok) { toast({ title: 'Not saved', description: res.error, variant: 'destructive' }); return; }
+      toast({ title: 'Recorded', description: 'Also counted as demand we could not fill.' });
+      setReqStart(''); setReqEnd('');
+      refreshDetail(selected.id);
+    });
+  }
+
+  function removeNote(noteId: string) {
+    if (!selected) return;
+    startTransition(async () => {
+      await deleteNoteAction(noteId, selected.id);
+      setRows((prev) => prev.map((r) => (r.id === selected.id ? { ...r, notes: Math.max(0, r.notes - 1) } : r)));
+      refreshDetail(selected.id);
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* ── search ── */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Name or phone number…"
+          className="pl-9 h-12 text-base"
+          inputMode="search"
+          autoComplete="off"
+        />
+      </div>
+
+      {unknownNumber && (
+        <Button onClick={createLead} disabled={pending} className="w-full h-12" variant="secondary">
+          <Plus className="h-4 w-4 mr-2" />
+          New lead from {query.trim()}
+        </Button>
+      )}
+
+      {/* ── results ── */}
+      {!selected && (
+        <div className="space-y-2">
+          {matches.length === 0 && !unknownNumber && (
+            <p className="text-sm text-muted-foreground py-6 text-center">No one matches that.</p>
+          )}
+          {matches.map((c) => (
+            <button
+              key={c.id}
+              onClick={() => open(c)}
+              className="w-full text-left rounded-lg border p-3 hover:bg-accent transition-colors"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium truncate">{c.name || <span className="text-muted-foreground italic">no name</span>}</span>
+                <div className="flex items-center gap-1 shrink-0">
+                  {c.kind === 'lead' && <Badge variant="outline" className="text-xs">lead</Badge>}
+                  {c.unsubscribed && <Badge variant="destructive" className="text-xs">unsub</Badge>}
+                </div>
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                <span className="font-mono">{c.phone}</span>
+                {c.messages > 0 && <span>{c.messages} msg ({c.inbound} in)</span>}
+                {c.notes > 0 && <span>{c.notes} note{c.notes > 1 ? 's' : ''}</span>}
+                {c.lastContact && <span>last {c.lastContact}</span>}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* ── selected contact ── */}
+      {selected && (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <CardTitle className="text-lg truncate">
+                    {selected.name || <span className="text-muted-foreground italic font-normal">no name on WhatsApp</span>}
+                  </CardTitle>
+                  <p className="text-sm text-muted-foreground font-mono mt-0.5">{selected.phone}</p>
+                </div>
+                <Button variant="ghost" size="sm" onClick={() => { setSelected(null); setDetail(null); }}>
+                  Change
+                </Button>
+              </div>
+              {detail && (
+                <p className="text-xs text-muted-foreground pt-1">
+                  {selected.kind === 'lead' ? 'Never stayed. ' : ''}
+                  {detail.messageCount} message{detail.messageCount === 1 ? '' : 's'} ({detail.inboundCount} from them)
+                  {detail.callCount > 0 && ` · ${detail.callCount} logged call${detail.callCount > 1 ? 's' : ''}`}
+                  {selected.lastStay && ` · last stay ${selected.lastStay}`}
+                </p>
+              )}
+            </CardHeader>
+          </Card>
+
+          {/* ── the primary action ── */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">What happened?</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Textarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                rows={4}
+                placeholder="We spoke on the phone. He liked the place a lot, wanted 16–21 Aug but we were full. Said he'd come another time."
+                className="text-base"
+              />
+
+              <div className="flex flex-wrap gap-2">
+                {(Object.keys(KIND_LABEL) as GuestNoteKind[]).map((k) => (
+                  <Button
+                    key={k}
+                    type="button"
+                    size="sm"
+                    variant={kind === k ? 'default' : 'outline'}
+                    onClick={() => setKind(k)}
+                  >
+                    {KIND_LABEL[k]}
+                  </Button>
+                ))}
+                <Input
+                  type="date"
+                  value={occurredAt}
+                  onChange={(e) => setOccurredAt(e.target.value)}
+                  className="h-9 w-auto"
+                />
+              </div>
+
+              <div className="rounded-md border p-3 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="assertable" className="text-sm">Can be mentioned back to them</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Off by default: the note still shapes tone and counts as contact, but nothing here will be
+                      stated as fact in a future message.
+                    </p>
+                  </div>
+                  <Switch id="assertable" checked={assertable} onCheckedChange={setAssertable} />
+                </div>
+
+                {assertable && (
+                  <div className="space-y-3 pt-1">
+                    <div className="space-y-1">
+                      <Label htmlFor="fact" className="text-xs">The one thing worth saying back (optional)</Label>
+                      <Input
+                        id="fact"
+                        value={factValue}
+                        onChange={(e) => setFactValue(e.target.value)}
+                        placeholder="said he'd like to come another time"
+                        className="text-sm"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Leave empty to make the whole note usable.
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="expires" className="text-xs">Stop using it after (optional)</Label>
+                      <Input id="expires" type="date" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} className="text-sm w-auto" />
+                      <p className="text-xs text-muted-foreground">
+                        For anything with a shelf life — &ldquo;planning something for October&rdquo; is useless in December.
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <Button onClick={saveNote} disabled={pending || text.trim().length < 3} className="w-full h-11">
+                Save note
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* ── lead-only: why it didn't happen, and what they wanted ── */}
+          {selected.kind === 'lead' && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base">Why it didn&apos;t happen</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  {REASONS.map((r) => (
+                    <button
+                      key={r.value}
+                      onClick={() => saveReason(r.value)}
+                      disabled={pending}
+                      className={`w-full text-left rounded-md border p-2.5 transition-colors ${
+                        detail?.nonConversionReason === r.value ? 'border-primary bg-accent' : 'hover:bg-accent'
+                      }`}
+                    >
+                      <div className="text-sm font-medium">{r.label}</div>
+                      <div className="text-xs text-muted-foreground">{r.hint}</div>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="border-t pt-3 space-y-2">
+                  <Label className="text-sm">Dates they asked for</Label>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Input type="date" value={reqStart} onChange={(e) => setReqStart(e.target.value)} className="h-9 w-auto" />
+                    <span className="text-muted-foreground text-sm">→</span>
+                    <Input type="date" value={reqEnd} onChange={(e) => setReqEnd(e.target.value)} className="h-9 w-auto" />
+                    <Select value={reqOutcome} onValueChange={(v) => setReqOutcome(v as RequestedPeriod['outcome'])}>
+                      <SelectTrigger className="h-9 w-[150px]"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="unavailable">we were full</SelectItem>
+                        <SelectItem value="declined">they passed</SelectItem>
+                        <SelectItem value="booked">they booked</SelectItem>
+                        <SelectItem value="unresolved">unresolved</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button size="sm" variant="secondary" onClick={savePeriod} disabled={pending || !reqStart || !reqEnd}>
+                      Add
+                    </Button>
+                  </div>
+                  {detail?.requestedPeriods.length ? (
+                    <ul className="text-xs text-muted-foreground space-y-1 pt-1">
+                      {detail.requestedPeriods.map((p, i) => (
+                        <li key={i}>{p.start} → {p.end} · {p.outcome} <span className="opacity-70">(asked {p.askedOn})</span></li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      Worth adding even when they never book — a window we keep missing is a pricing signal.
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* ── history ── */}
+          {detail && (detail.notes.length > 0 || detail.recentMessages.length > 0) && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base">History</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {detail.notes.length > 0 && (
+                  <ul className="space-y-2">
+                    {detail.notes.slice().reverse().map((n) => (
+                      <li key={n.id} className="rounded-md border p-2.5">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                              <Phone className="h-3 w-3" />
+                              <span>{n.occurredAt}</span>
+                              <span>{KIND_LABEL[n.kind]}</span>
+                              {n.assertable
+                                ? <Badge variant="secondary" className="text-[10px] py-0">quotable</Badge>
+                                : <Badge variant="outline" className="text-[10px] py-0">context</Badge>}
+                              {n.expiresAt && <span className="opacity-70">until {n.expiresAt}</span>}
+                            </div>
+                            <p className="text-sm mt-1 whitespace-pre-wrap">{n.text}</p>
+                          </div>
+                          <Button variant="ghost" size="icon" className="shrink-0 h-8 w-8" onClick={() => removeNote(n.id)} disabled={pending}>
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {detail.recentMessages.length > 0 && (
+                  <div className="space-y-1.5">
+                    <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+                      <MessageSquare className="h-3 w-3" /> Last WhatsApp messages
+                    </p>
+                    {detail.recentMessages.map((m, i) => (
+                      <div key={i} className="text-xs">
+                        <span className="text-muted-foreground font-mono">{m.ts.slice(0, 10)} {m.direction === 'out' ? '→' : '←'} </span>
+                        <span className="text-muted-foreground">{m.text.slice(0, 140)}{m.text.length > 140 ? '…' : ''}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {selected.kind === 'guest' && (
+                  <Button variant="ghost" size="sm" asChild className="px-0">
+                    <Link href={`/admin/guests/${selected.id}`}>
+                      <User className="h-3.5 w-3.5 mr-1.5" /> Full guest record
+                      <ExternalLink className="h-3 w-3 ml-1.5" />
+                    </Link>
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/contacts/actions.ts
+++ b/src/app/admin/contacts/actions.ts
@@ -1,0 +1,264 @@
+'use server';
+
+/**
+ * Contacts — server actions for capturing what happened off-WhatsApp, and for the lead records
+ * those conversations belong to.
+ *
+ * This exists because the capture path decided whether any of it works at all. A note system that
+ * only has a CLI never gets filled: after a phone call the owner is holding a phone, not a
+ * terminal. Everything here is shaped around the ten seconds right after hanging up — find them (or
+ * open a record from just a number), say what happened, done.
+ *
+ * Super-admin only, matching firestore.rules for `guestNotes` (private conversation content).
+ */
+import { z } from 'zod';
+import { revalidatePath } from 'next/cache';
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
+import { addGuestNote, listGuestNotes, deleteGuestNote, isTouch } from '@/services/guestNoteService';
+import { createLead, updateLead, addRequestedPeriod } from '@/services/leadService';
+import type { Guest, GuestNote, GuestNoteKind, NonConversionReason, RequestedPeriod, WhatsAppThread } from '@/types';
+
+const logger = loggers.guest;
+
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const toDateStr = (v: unknown): string | null => {
+  if (!v) return null;
+  const o = v as { _seconds?: number; toDate?: () => Date };
+  if (typeof v === 'string') return v.slice(0, 10);
+  if (o._seconds) return new Date(o._seconds * 1000).toISOString().slice(0, 10);
+  if (o.toDate) return o.toDate().toISOString().slice(0, 10);
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return null;
+};
+
+export interface ContactRow {
+  id: string;
+  name: string;
+  phone: string;
+  kind: 'guest' | 'lead';
+  lastStay: string | null;
+  firstContactAt: string | null;
+  nonConversionReason: string | null;
+  messages: number;
+  inbound: number;
+  notes: number;
+  /** Latest interaction of any kind — the "how warm is this" number. */
+  lastContact: string | null;
+  unsubscribed: boolean;
+}
+
+/** The searchable index: every guest and lead with a phone, annotated with interaction counts. */
+export async function fetchContactsAction(): Promise<ContactRow[]> {
+  try {
+    await requireSuperAdmin();
+    const db = await getAdminDb();
+    const [gSnap, tSnap, nSnap] = await Promise.all([
+      db.collection('guests').get(),
+      db.collection('whatsappThreads').get(),
+      db.collection('guestNotes').get(),
+    ]);
+
+    const threads = new Map(tSnap.docs.map((d) => [d.id, d.data() as WhatsAppThread]));
+    const notesByGuest = new Map<string, GuestNote[]>();
+    nSnap.docs.forEach((d) => {
+      const n = { id: d.id, ...(d.data() as Omit<GuestNote, 'id'>) };
+      if (!n.guestId) return;
+      if (!notesByGuest.has(n.guestId)) notesByGuest.set(n.guestId, []);
+      notesByGuest.get(n.guestId)!.push(n);
+    });
+
+    const rows: ContactRow[] = [];
+    gSnap.docs.forEach((d) => {
+      const g = { id: d.id, ...(d.data() as Omit<Guest, 'id'>) };
+      if (!g.normalizedPhone && !g.phone) return;   // unreachable — nothing to capture against
+      const th = threads.get(d.id);
+      const msgs = th?.messages || [];
+      const notes = notesByGuest.get(d.id) || [];
+      const lastMsg = msgs.length ? String(msgs[msgs.length - 1].ts).slice(0, 10) : null;
+      const lastNote = notes.map((n) => n.occurredAt).sort().pop() || null;
+      rows.push({
+        id: d.id,
+        name: [g.firstName, g.lastName].filter(Boolean).join(' ').trim(),
+        phone: g.normalizedPhone || g.phone || '',
+        kind: g.kind === 'lead' ? 'lead' : 'guest',
+        lastStay: toDateStr(g.lastStayDate) || toDateStr(g.lastBookingDate),
+        firstContactAt: g.firstContactAt || null,
+        nonConversionReason: g.nonConversionReason || null,
+        messages: msgs.length,
+        inbound: msgs.filter((m) => m.direction === 'in').length,
+        notes: notes.length,
+        lastContact: [lastMsg, lastNote].filter(Boolean).sort().pop() || null,
+        unsubscribed: !!g.unsubscribed,
+      });
+    });
+
+    rows.sort((a, b) => (b.lastContact || '').localeCompare(a.lastContact || ''));
+    return rows;
+  } catch (error) {
+    if (error instanceof AuthorizationError) return [];
+    logger.error('fetchContactsAction failed', error as Error);
+    return [];
+  }
+}
+
+export interface ContactDetail {
+  notes: Array<Pick<GuestNote, 'id' | 'occurredAt' | 'kind' | 'text' | 'assertable' | 'expiresAt' | 'initiatedBy'> & { facts: Array<{ key: string; value: string }> }>;
+  requestedPeriods: RequestedPeriod[];
+  nonConversionReason: string | null;
+  /** Last few messages, so the owner can see where the conversation left off before writing. */
+  recentMessages: Array<{ ts: string; direction: string; text: string }>;
+  messageCount: number;
+  inboundCount: number;
+  callCount: number;
+}
+
+export async function fetchContactDetailAction(guestId: string): Promise<ContactDetail | null> {
+  try {
+    await requireSuperAdmin();
+    const db = await getAdminDb();
+    const [gDoc, tDoc, notes] = await Promise.all([
+      db.collection('guests').doc(guestId).get(),
+      db.collection('whatsappThreads').doc(guestId).get(),
+      listGuestNotes(guestId),
+    ]);
+    if (!gDoc.exists) return null;
+    const g = gDoc.data() as Guest;
+    const msgs = (tDoc.exists ? (tDoc.data() as WhatsAppThread).messages : []) || [];
+
+    return {
+      notes: notes.map((n) => ({
+        id: n.id, occurredAt: n.occurredAt, kind: n.kind, text: n.text,
+        assertable: n.assertable, expiresAt: n.expiresAt, initiatedBy: n.initiatedBy,
+        facts: n.facts || [],
+      })),
+      requestedPeriods: g.requestedPeriods || [],
+      nonConversionReason: g.nonConversionReason || null,
+      recentMessages: msgs.slice(-8).map((m) => ({ ts: m.ts, direction: m.direction, text: m.text })),
+      messageCount: msgs.length,
+      inboundCount: msgs.filter((m) => m.direction === 'in').length,
+      callCount: notes.filter((n) => isTouch(n.kind)).length,
+    };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return null;
+    logger.error('fetchContactDetailAction failed', error as Error, { guestId });
+    return null;
+  }
+}
+
+const noteSchema = z.object({
+  guestId: z.string().min(1),
+  text: z.string().min(3, 'Write at least a few words'),
+  kind: z.enum(['call', 'inperson', 'observation']),
+  occurredAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  initiatedBy: z.enum(['owner', 'guest']).optional(),
+  assertable: z.boolean(),
+  expiresAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  factKey: z.string().optional(),
+  factValue: z.string().optional(),
+});
+
+export async function addNoteAction(input: {
+  guestId: string; text: string; kind: GuestNoteKind; occurredAt: string;
+  initiatedBy?: 'owner' | 'guest'; assertable: boolean; expiresAt?: string;
+  factKey?: string; factValue?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const user = await requireSuperAdmin();
+    const p = noteSchema.parse(input);
+    const facts = p.factKey && p.factValue ? [{ key: p.factKey.trim(), value: p.factValue.trim() }] : [];
+    await addGuestNote({
+      guestId: p.guestId, text: p.text, kind: p.kind, occurredAt: p.occurredAt,
+      initiatedBy: p.initiatedBy, assertable: p.assertable, expiresAt: p.expiresAt,
+      facts, createdBy: user.email || 'admin',
+    });
+    revalidatePath('/admin/contacts');
+    revalidatePath(`/admin/guests/${p.guestId}`);
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    if (error instanceof z.ZodError) return { ok: false, error: error.errors[0]?.message || 'Invalid note' };
+    logger.error('addNoteAction failed', error as Error);
+    return { ok: false, error: 'Could not save the note' };
+  }
+}
+
+export async function deleteNoteAction(noteId: string, guestId: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+    await deleteGuestNote(noteId);
+    revalidatePath('/admin/contacts');
+    revalidatePath(`/admin/guests/${guestId}`);
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    logger.error('deleteNoteAction failed', error as Error, { noteId });
+    return { ok: false, error: 'Could not delete the note' };
+  }
+}
+
+export async function createLeadAction(input: {
+  phone: string; name?: string; propertyId?: string; leadSource?: string;
+}): Promise<{ ok: boolean; id?: string; created?: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+    if (!/^\+?\d[\d\s().-]{6,}$/.test(input.phone.trim())) return { ok: false, error: 'That does not look like a phone number' };
+    const res = await createLead({
+      phone: input.phone.trim(),
+      name: input.name?.trim(),
+      nameSource: input.name?.trim() ? 'manual' : undefined,
+      leadSource: input.leadSource || 'phone',
+      propertyId: input.propertyId,
+      firstContactAt: ymd(new Date()),
+    });
+    revalidatePath('/admin/contacts');
+    return { ok: true, id: res.id, created: res.created };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    logger.error('createLeadAction failed', error as Error);
+    return { ok: false, error: 'Could not create the lead' };
+  }
+}
+
+export async function setLeadReasonAction(guestId: string, reason: NonConversionReason): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+    await updateLead(guestId, { nonConversionReason: reason });
+    revalidatePath('/admin/contacts');
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    logger.error('setLeadReasonAction failed', error as Error, { guestId });
+    return { ok: false, error: 'Could not save' };
+  }
+}
+
+const periodSchema = z.object({
+  guestId: z.string().min(1),
+  start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  outcome: z.enum(['unavailable', 'declined', 'booked', 'unresolved']),
+  note: z.string().optional(),
+});
+
+export async function addRequestedPeriodAction(input: {
+  guestId: string; start: string; end: string; outcome: RequestedPeriod['outcome']; note?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await requireSuperAdmin();
+    const p = periodSchema.parse(input);
+    if (p.end < p.start) return { ok: false, error: 'End date is before the start date' };
+    await addRequestedPeriod(p.guestId, {
+      start: p.start, end: p.end, askedOn: ymd(new Date()), outcome: p.outcome,
+      ...(p.note ? { note: p.note } : {}),
+    });
+    revalidatePath('/admin/contacts');
+    return { ok: true };
+  } catch (error) {
+    if (error instanceof AuthorizationError) return { ok: false, error: handleAuthError(error).error };
+    if (error instanceof z.ZodError) return { ok: false, error: 'Check the dates' };
+    logger.error('addRequestedPeriodAction failed', error as Error);
+    return { ok: false, error: 'Could not save' };
+  }
+}

--- a/src/app/admin/contacts/page.tsx
+++ b/src/app/admin/contacts/page.tsx
@@ -1,0 +1,28 @@
+import { AdminPage } from '@/components/admin';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { fetchContactsAction } from './actions';
+import { ContactConsole } from './_components/contact-console';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function ContactsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string; guestId?: string }>;
+}) {
+  const { propertyId, guestId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const contacts = await fetchContactsAction();
+
+  return (
+    <AdminPage
+      title="Contacts"
+      description="Everything that happens off WhatsApp — phone calls above all. Write it here right after you hang up: the system reads messages, so a relationship held on the phone is invisible to it until you say so. Also where a new caller becomes a record."
+    >
+      <PropertyUrlSync />
+      <ContactConsole contacts={contacts} propertyId={property} initialGuestId={guestId} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/guests/[guestId]/page.tsx
+++ b/src/app/admin/guests/[guestId]/page.tsx
@@ -14,8 +14,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ArrowLeft, Mail, Phone, Globe, MapPin, Eye } from 'lucide-react';
+import { ArrowLeft, Mail, Phone, Globe, MapPin, Eye, PhoneCall } from 'lucide-react';
 import { fetchGuestDetailAction } from '../actions';
+import { fetchContactDetailAction } from '../../contacts/actions';
 import { getCountryName } from '@/lib/country-utils';
 import { EditGuestContactDialog } from '../_components/edit-guest-contact-dialog';
 import type { SerializableTimestamp } from '@/types';
@@ -54,13 +55,17 @@ const formatCurrency = (amount: number, currency: string): string => {
 
 export default async function GuestDetailPage({ params }: PageProps) {
   const { guestId } = await params;
-  const data = await fetchGuestDetailAction(guestId);
+  const [data, contact] = await Promise.all([
+    fetchGuestDetailAction(guestId),
+    fetchContactDetailAction(guestId),
+  ]);
 
   if (!data) {
     notFound();
   }
 
   const { guest, bookings } = data;
+  const notes = contact?.notes ?? [];
 
   return (
     <AdminPage
@@ -236,6 +241,44 @@ export default async function GuestDetailPage({ params }: PageProps) {
                   </TableBody>
                 </Table>
               </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Calls & notes — interactions that never touched WhatsApp, and are invisible without this */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <CardTitle className="text-lg">Calls &amp; notes</CardTitle>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={`/admin/contacts?guestId=${guest.id}`}>
+                <PhoneCall className="h-4 w-4 mr-1.5" />
+                Add a note
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {notes.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Nothing recorded. Phone calls are invisible to the engagement system until they are written down —
+                a guest you spoke to yesterday still reads as &ldquo;not contacted&rdquo;.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {notes.slice().reverse().map((n) => (
+                  <li key={n.id} className="rounded-md border p-3">
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <span>{n.occurredAt}</span>
+                      <span>·</span>
+                      <span>{n.kind === 'call' ? 'Phone call' : n.kind === 'inperson' ? 'In person' : 'Noticed'}</span>
+                      <Badge variant={n.assertable ? 'secondary' : 'outline'} className="text-[10px] py-0">
+                        {n.assertable ? 'quotable' : 'context'}
+                      </Badge>
+                      {n.expiresAt && <span className="opacity-70">until {n.expiresAt}</span>}
+                    </div>
+                    <p className="text-sm mt-1.5 whitespace-pre-wrap">{n.text}</p>
+                  </li>
+                ))}
+              </ul>
             )}
           </CardContent>
         </Card>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -30,6 +30,7 @@ import {
   PanelTop,
   Settings,
   Wand2,
+  PhoneCall,
 } from 'lucide-react';
 import { useAuth } from '@/contexts/SimpleAuthContext';
 import { usePropertySelector } from '@/contexts/PropertySelectorContext';
@@ -79,6 +80,7 @@ const navigationGroups = [
       { title: 'Bookings', href: '/admin/bookings', icon: CalendarCheck },
       { title: 'Inquiries', href: '/admin/inquiries', icon: MessageSquare },
       { title: 'Guests', href: '/admin/guests', icon: Users },
+      { title: 'Contacts', href: '/admin/contacts', icon: PhoneCall },
       { title: 'Reviews', href: '/admin/reviews', icon: Star },
       { title: 'Housekeeping', href: '/admin/housekeeping', icon: Sparkles },
     ],

--- a/src/components/admin/Breadcrumb.tsx
+++ b/src/components/admin/Breadcrumb.tsx
@@ -35,6 +35,7 @@ const pathLabels: Record<string, string> = {
   settings: 'Settings',
   calendar: 'Calendar',
   guests: 'Guests',
+  contacts: 'Contacts',
   reviews: 'Reviews',
   housekeeping: 'Housekeeping',
   revenue: 'Revenue',

--- a/src/lib/growth/__tests__/validateDrafts.test.ts
+++ b/src/lib/growth/__tests__/validateDrafts.test.ts
@@ -1,0 +1,71 @@
+import { validateDrafts, type GuestForDraftValidation } from '../validateDrafts';
+import type { DraftMessage } from '../contracts';
+
+const facts = [{ key: 'firstName', value: 'Marius' }, { key: 'requestedPeriod', value: '2026-08-16 → 2026-08-21' }];
+
+// Filler long enough to clear minChars, deliberately free of self-ID and opt-out markers so each
+// test controls exactly one variable.
+const FILLER = ' Va scriu pentru ca in perioada urmatoare avem cateva zile libere la munte, iar toamna e chiar frumoasa pe aici, cu liniste multa si aer curat. Daca va tenteaza o escapada scurta, va pot tine la curent cu ce se elibereaza in calendar, fara nicio obligatie.';
+const SELF_ID = ' Bogdan sunt, de la casuta din Comarnic.';
+const OPT_OUT = ' Daca preferati sa nu va mai scriu, spuneti-mi linistit.';
+
+const lead = (over: Partial<GuestForDraftValidation> = {}): GuestForDraftValidation => ({
+  guestId: 'g1', groundedFacts: facts, thread: [{}, {}, {}],
+  audienceKind: 'lead', relationshipState: 'active', ...over,
+});
+const draft = (body: string, factsUsed: string[] = ['firstName']): DraftMessage =>
+  ({ guestId: 'g1', body, factsUsed } as DraftMessage);
+
+describe('validateDrafts — a lead never stayed', () => {
+  it('REJECTS a draft that asserts a past stay for a lead', () => {
+    const r = validateDrafts([lead()], [draft(`Buna Marius! Sper ca v-a placut sejurul la noi.${FILLER}${SELF_ID}${OPT_OUT}`)]);
+    expect(r.ok).toBe(false);
+    expect(r.perGuest[0].errors.join(' ')).toMatch(/claims a past stay/);
+  });
+
+  it('accepts the same warmth built on the REQUEST instead of a stay', () => {
+    const r = validateDrafts([lead()], [draft(`Buna Marius! Ati intrebat de 16-21 august si atunci era ocupat.${FILLER}${SELF_ID}${OPT_OUT}`, ['firstName', 'requestedPeriod'])]);
+    expect(r.perGuest[0].errors).toEqual([]);
+  });
+
+  it('does not police stay language for a guest who really stayed', () => {
+    const r = validateDrafts(
+      [lead({ audienceKind: 'guest' })],
+      [draft(`Buna Marius! Sper ca v-a placut sejurul la noi.${FILLER}${SELF_ID}`)],
+    );
+    expect(r.perGuest[0].errors).toEqual([]);
+  });
+
+  it('warns when a lead gets no opt-out, even mid-conversation', () => {
+    const r = validateDrafts([lead()], [draft(`Buna Marius!${FILLER}${SELF_ID}`)]);
+    expect(r.perGuest[0].warnings.join(' ')).toMatch(/opt-out/);
+  });
+});
+
+describe('validateDrafts — relationship state beats thread length', () => {
+  it('treats a phone-only relationship (empty thread, logged call) as NOT a first contact', () => {
+    const r = validateDrafts(
+      [{ guestId: 'g1', groundedFacts: facts, thread: [], relationshipState: 'active' }],
+      [draft(`Buna Marius!${FILLER}`)],
+    );
+    expect(r.perGuest[0].errors).toEqual([]);                                   // no hard self-ID demand
+    expect(r.perGuest[0].warnings.join(' ')).toMatch(/self-identification/);    // just a nudge
+  });
+
+  it('still hard-errors on a missing self-ID for a genuine first contact', () => {
+    const r = validateDrafts(
+      [{ guestId: 'g1', groundedFacts: facts, thread: [], relationshipState: 'first-contact' }],
+      [draft(`Buna Marius!${FILLER}`)],
+    );
+    expect(r.ok).toBe(false);
+    expect(r.perGuest[0].errors.join(' ')).toMatch(/self-identification/);
+  });
+
+  it('falls back to thread length when the pack gives no relationship state', () => {
+    const r = validateDrafts(
+      [{ guestId: 'g1', groundedFacts: facts, thread: [] }],
+      [draft(`Buna Marius!${FILLER}`)],
+    );
+    expect(r.ok).toBe(false);   // empty thread ⇒ first contact ⇒ self-ID required (legacy behaviour)
+  });
+});

--- a/src/lib/growth/copywriterPack.ts
+++ b/src/lib/growth/copywriterPack.ts
@@ -14,6 +14,7 @@
  */
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { detectLanguage } from '@/lib/growth/audience';
+import { getNotesByGuest, isTouch, isLive } from '@/services/guestNoteService';
 import type { CampaignBrief } from '@/lib/growth/contracts';
 
 const toD = (v: any): Date | null => v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
@@ -50,9 +51,10 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
   const framingUpdates: any[] = brief.updates || [];
 
   const db = await getAdminDb();
-  const [gSnap, bSnap, rSnap, tSnap] = await Promise.all([
+  const [gSnap, bSnap, rSnap, tSnap, notesByGuest] = await Promise.all([
     db.collection('guests').get(), db.collection('bookings').get(),
     db.collection('reviews').get(), db.collection('whatsappThreads').get(),
+    getNotesByGuest(),
   ]);
   const guestById = new Map(gSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
   const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
@@ -110,20 +112,48 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
     const detected = detectLanguage(threadText);
     const writeLanguage = detected === 'unknown' ? (g.language || 'ro') : detected;
 
+    // Off-WhatsApp interactions (phone calls above all), live as of AS_OF.
+    const notes = (notesByGuest.get(gid) || []).filter(n => n.occurredAt <= ymd(AS_OF) && isLive(n, ymd(AS_OF)));
+    const touches = notes.filter(n => isTouch(n.kind));           // calls / in-person = real exchanges
+
     // Relationship state — so the copywriter continues the conversation instead of cold-opening,
     // and decides self-ID / opt-out from the REAL history (facts; the LLM judges from these).
+    // Computed across BOTH channels: judging engagement from WhatsApp alone inverts the read on a
+    // phone-first relationship — unanswered outbound messages look like "silent, never replied"
+    // for someone who was warm on a call. A logged call is proof of engagement.
     const inboundCount = thread.filter(m => m.dir === 'in').length;
-    const lastExchange = thread.length ? String(thread[thread.length - 1].ts).slice(0, 10) : null;
+    const lastMessageDate = thread.length ? String(thread[thread.length - 1].ts).slice(0, 10) : null;
+    const lastTouch = touches.length ? touches[touches.length - 1] : null;
+    const lastExchange = [lastMessageDate, lastTouch?.occurredAt].filter(Boolean).sort().pop() ?? null;
+    const lastExchangeVia = lastExchange && lastTouch?.occurredAt === lastExchange ? lastTouch.kind : lastExchange ? 'whatsapp' : null;
     const daysSinceLastExchange = lastExchange ? days(new Date(`${lastExchange}T00:00:00Z`), AS_OF) : null;
+    const engaged = inboundCount > 0 || touches.length > 0;       // they have actually engaged with us
     const relationshipState =
-      thread.length === 0 ? 'first-contact'                       // never messaged
-      : inboundCount === 0 ? 'silent'                              // messaged before, never replied
-      : (daysSinceLastExchange ?? 999) <= 120 ? 'active'          // replied + spoke recently
-      : 'lapsed';                                                 // replied before, but long ago
-    const relationship = { state: relationshipState, totalMessages: thread.length, replies: inboundCount, lastExchange, daysSinceLastExchange };
+      thread.length === 0 && notes.length === 0 ? 'first-contact' // no history at all
+      : !engaged ? 'silent'                                        // contacted before, never engaged
+      : (daysSinceLastExchange ?? 999) <= 120 ? 'active'          // engaged + spoke recently
+      : 'lapsed';                                                 // engaged before, but long ago
+    const relationship = {
+      state: relationshipState, totalMessages: thread.length, replies: inboundCount,
+      calls: touches.length, lastExchange, lastExchangeVia, daysSinceLastExchange,
+    };
+
+    // A LEAD asked for something and it did not happen. That request — and the reason — is the only
+    // specific material a message to them can honestly be built on; there is no stay, no season, no
+    // review, no booking channel. See NonConversionReason for what each reason licenses.
+    const kind: 'guest' | 'lead' = g.kind === 'lead' ? 'lead' : 'guest';
+    const nameSource = g.nameSource || (g.firstName ? 'booking' : 'unknown');
+    const nameConfidence = !g.firstName ? 'none' : (nameSource === 'booking' || nameSource === 'manual') ? 'verified' : 'unverified';
+    const requestedPeriods = (g.requestedPeriods || []) as Array<{ start: string; end: string; askedOn: string; outcome: string; note?: string }>;
+    const lastRequest = requestedPeriods.length ? requestedPeriods[requestedPeriods.length - 1] : null;
 
     const groundedFacts: any[] = [];
     if (g.firstName) groundedFacts.push({ key: 'firstName', value: g.firstName, source: `guests/${gid}` });
+    if (kind === 'lead') {
+      if (lastRequest) groundedFacts.push({ key: 'requestedPeriod', value: `${lastRequest.start} → ${lastRequest.end} (asked ${lastRequest.askedOn}; ${lastRequest.outcome})`, source: `guests/${gid}` });
+      if (g.nonConversionReason === 'unavailable') groundedFacts.push({ key: 'weCouldNotHost', value: 'the dates they asked for were already taken — nothing went wrong between us', source: `guests/${gid}` });
+      if (g.firstContactAt) groundedFacts.push({ key: 'firstContactAt', value: g.firstContactAt, source: `guests/${gid}` });
+    }
     if (g.partnerName) groundedFacts.push({ key: 'partnerName', value: g.partnerName, source: `guests/${gid}` });
     if (last) groundedFacts.push({ key: 'lastStayPhrase', value: lastStayPhrase(last, AS_OF), source: `bookings/${lastBk.id}` });
     if (last) groundedFacts.push({ key: 'lastStaySeason', value: seasonOf(last), source: `bookings/${lastBk.id}` });
@@ -133,17 +163,32 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
     if (booksDirect) groundedFacts.push({ key: 'booksDirect', value: { directBookings: directCount, otaBookings: otaCount }, source: `bookings(guests/${gid})` });
     reviewThemes.forEach(t => groundedFacts.push({ key: `reviewPraised:${t}`, value: t, source: `reviews/${(rv[0] || {}).id || gid}` }));
     applicableUpdates.forEach((u: any) => groundedFacts.push({ key: `update:${u.id}`, value: u.text, source: 'campaign.updates' }));
+    // Only an ASSERTABLE note is admitted to the whitelist; the rest are context (tone, topic) and
+    // are still shown below, but the copywriter may not state them.
+    notes.filter(n => n.assertable).forEach(n => {
+      if (n.facts?.length) n.facts.forEach(f => groundedFacts.push({ key: `note:${f.key}`, value: f.value, source: `guestNotes/${n.id}` }));
+      else groundedFacts.push({ key: `note:${n.id}`, value: n.text, source: `guestNotes/${n.id}` });
+    });
 
     return {
       guestId: gid,
+      audienceKind: kind,
       firstName: g.firstName || null,
+      nameConfidence,   // 'verified' (from a booking) · 'unverified' (a WhatsApp push-name) · 'none'
       writeLanguage,
       recordLanguage: g.language || null,
       threadLanguageDetected: detected,
       careFlags: careByGuest.get(gid) || [],
       relationship,
+      lead: kind === 'lead' ? {
+        firstContactAt: g.firstContactAt || null,
+        daysSinceFirstContact: g.firstContactAt ? days(new Date(`${g.firstContactAt}T00:00:00Z`), AS_OF) : null,
+        nonConversionReason: g.nonConversionReason || null,
+        requestedPeriods,
+        note: 'This person never stayed. Do NOT imply they did — no "cand ati fost la noi", no season reference, no review. Build on what they asked for and what happened to it.',
+      } : null,
       dossier: {
-        tier: totalBookings >= 2 ? 'repeat' : 'single',
+        tier: kind === 'lead' ? 'lead' : totalBookings >= 2 ? 'repeat' : 'single',
         totalBookings,
         lastStay: last ? ymd(last) : null,
         lastStayPhrase: lastStayPhrase(last, AS_OF),
@@ -157,6 +202,14 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
       groundedFacts,
       thread,
       threadNote: thread.length ? `${thread.length} prior messages — read to AVOID repeating what was already said, and to match tone. Do NOT assert a new guest-specific fact from the thread that is not in groundedFacts.` : 'no prior WhatsApp history — a first contact; include the opt-out line.',
+      notes: notes.map(n => ({
+        id: n.id, at: n.occurredAt, kind: n.kind, initiatedBy: n.initiatedBy ?? null,
+        text: n.text, assertable: n.assertable,
+        factKeys: n.assertable ? (n.facts?.length ? n.facts.map(f => `note:${f.key}`) : [`note:${n.id}`]) : [],
+      })),
+      notesNote: notes.length
+        ? `${notes.length} note(s) about interactions OUTSIDE WhatsApp — the owner's own record, mostly phone calls. This is where the relationship actually is; the thread alone would misread it. Only notes with assertable=true may be STATED (tag their factKeys); the others inform tone and topic only.`
+        : 'no off-WhatsApp interactions recorded.',
     };
   });
 
@@ -172,13 +225,16 @@ export async function buildCopywriterPack(brief: CampaignBrief, opts?: { asOf?: 
       register: 'Pick ONE register per message and keep it consistent throughout — either tu (informal: tu/iti/te/ai) OR voi/dumneavoastra (formal: voi/va/ati). NEVER mix them in the same message (not even "ati fost… iti dau"). Choose per guest: if there is a prior thread, match how the owner addressed them there; if there is NO prior thread (a first contact), use polite voi (you do not address a stranger with tu); otherwise default to the warm informal tu.',
       length: '300–600 characters, 3–6 short sentences',
       emoji: 'Use emoji SPARINGLY — at most one or two in a message, only to underline a warm note (a 🍂 for autumn, a 😉 for a wink, a ;) like the owner does), never decorative, never several in a row. Match the owner\'s real light touch; when in doubt, none.',
-      continuity: 'These are ONGOING relationships, not cold sends. READ the guest\'s `thread` and `relationship` and continue it naturally — pick up where you left off, and where it fits, nod to the last exchange. NEVER re-say something the thread shows you already told them (see `updates`). Use `relationship.state`: "active" (replied, spoke ≤120d ago) → continue warmly, do NOT re-introduce yourself; "lapsed" (replied before, long ago) → a light reconnect ("a trecut ceva vreme"); "silent" (messaged, never replied) → a fresh, low-pressure note; "first-contact" (no thread) → introduce yourself.',
+      continuity: 'These are ONGOING relationships, not cold sends. READ the guest\'s `thread`, `notes` and `relationship` and continue it naturally — pick up where you left off, and where it fits, nod to the last exchange. NEVER re-say something the thread shows you already told them (see `updates`). Use `relationship.state`, which is computed across BOTH channels (messages AND logged calls): "active" (engaged, spoke ≤120d ago) → continue warmly, do NOT re-introduce yourself; "lapsed" (engaged before, long ago) → a light reconnect ("a trecut ceva vreme"); "silent" (contacted before, never engaged at all) → a fresh, low-pressure note; "first-contact" (no history whatsoever) → introduce yourself. `relationship.lastExchangeVia` says whether the last contact was WhatsApp or a call — if it was a call, continue from the call, not from the last message.',
+      audienceKind: 'Check `audienceKind` FIRST — it changes what you have to work with. A "guest" STAYED: you may reference the stay, the season, the party, what their review praised. A "lead" NEVER stayed — they asked about a stay and it did not happen. Never imply otherwise: no "cand ati fost la noi", no season reference, no review, no "va asteptam din nou". What a lead has instead is in `lead`: the period they asked for (`requestedPeriod`) and `nonConversionReason` — read it, because the four cases are not interchangeable. "unavailable" = WE could not host them, nothing negative happened, so a later "acum s-a eliberat / am putea gasi altceva" is genuinely welcome and is your strongest opening. "declined" = they chose not to; do NOT re-present the same terms as if nothing happened — a lighter, no-pressure note only. "unservable" = we structurally cannot serve what they need; do not raise it again unless something changed. "unresolved" = the conversation simply stopped; a light re-open, not a follow-up. If the reason is null, do not guess one.',
+      naming: 'Use `nameConfidence`. "verified" — greet by firstName normally. "unverified" — the name came from a WhatsApp push-name, which may be a nickname, a handle or a shop name; use it ONLY if it plainly reads as a real first name, otherwise greet without a name ("Buna ziua!"). "none" — there is no name at all; greet without one and never invent or guess a name from the phone number or the thread.',
+      notes: 'A guest\'s `notes` record interactions that never touched WhatsApp — overwhelmingly phone calls. They are the owner\'s OWN RECALL: real, but unverified and possibly stale, unlike booking data. Read them to know where the relationship truly stands (a warm call outweighs an unanswered message) and to continue from the right point. You may only STATE something from a note whose `assertable` is true, and you must tag its listed `factKeys` in factsUsed. A note with assertable=false may shape tone, topic and warmth but must NEVER be asserted as fact — and never quote a note back verbatim as though the guest had written it.',
       selfId: 'Identify yourself ("Bogdan sunt, de la casuta din Comarnic") ONLY when it helps — a first-contact, a "lapsed"/"silent" state, or a long gap. For an "active" recent thread they know who you are; opening with a re-introduction reads as a form letter — just continue. (Self-ID must still appear somewhere for a first/cold contact — the validator checks it there.)',
       partnerGreeting: 'If a `partnerName` grounded fact is present, the WhatsApp number belongs to that partner (who booked under the guest firstName) — greet BOTH warmly, e.g. "Buna Razvan si Loredana!", and tag `partnerName` in factsUsed. If there is no partnerName, greet only by firstName.',
-      optOut: 'Give a graceful, low-pressure way out to a FIRST contact AND to a "silent" guest (messaged before, never replied) — e.g. "daca preferi sa nu-ti mai scriu, spune-mi". An "active"/"lapsed" guest who has replied does NOT need one — it would be odd. Use judgment from `relationship.state`.',
+      optOut: 'Give a graceful, low-pressure way out to a FIRST contact AND to a "silent" guest (messaged before, never replied) — e.g. "daca preferi sa nu-ti mai scriu, spune-mi". An "active"/"lapsed" guest who has replied does NOT need one — it would be odd. Use judgment from `relationship.state`. Any LEAD (audienceKind "lead") gets one regardless of state: a past guest has a real relationship with you, whereas someone who enquired once and never stayed has a much thinner basis for being written to again — so always leave the door open in both directions.',
       grounding: 'assert ONLY facts present in that guest\'s groundedFacts; tag each claim in factsUsed with its key. No emoji. No invented stays/preferences.',
       intent: 'campaign.intent sets the ASK. "gap_fill" = a warm invite that carries the offer (see offerPresentation). "share" = a NO-ASK keep-in-touch or re-introduction: do NOT mention any offer or discount, do NOT ask them to book — write a genuine, short, warm hello that only keeps the door open (e.g. "cand va doriti, stiti unde ne gasiti"). For a "share" to a long-lapsed or first contact, gently remind them who you are and roughly when they stayed, and ALWAYS include an easy opt-out. Pure good mood, zero pressure.',
-      offerPresentation: 'ONLY for intent "gap_fill". The offer (campaign.offer) is set by the owner — never inflate or invent one, only phrase it. Adapt HOW you present it per guest: a guest with a `booksDirect` fact already knows they get your best price directly, so acknowledge that warmly (e.g. "si asa cum stii deja, iti pot da cea mai buna oferta direct") rather than quoting a discount as if it were news; a guest who has only booked via an OTA gets the explicit offer. For a free-night/value offer, describe the value in words, not a bare percentage. Tag `booksDirect` in factsUsed when you use that angle.',
+      offerPresentation: 'ONLY for intent "gap_fill". The offer (campaign.offer) is set by the owner — never inflate or invent one, only phrase it. Adapt HOW you present it per guest: a guest with a `booksDirect` fact already knows they get your best price directly, so acknowledge that warmly (e.g. "si asa cum stii deja, iti pot da cea mai buna oferta direct") rather than quoting a discount as if it were news; a guest who has only booked via an OTA gets the explicit offer. For a free-night/value offer, describe the value in words, not a bare percentage. Tag `booksDirect` in factsUsed when you use that angle. A LEAD has no booking channel at all — do not reach for either branch. They came to you directly, which is already the best channel there is, so present the offer plainly and warmly, without implying they ever paid a different price.',
       updates: 'Each guest\'s `applicableUpdates` lists campaign news new SINCE THAT guest\'s last stay (date-filtered). BUT before mentioning one, CHECK the thread: if you already told this guest about it in a previous message, do NOT re-announce it as "noutate" — either build on it ("cum ti-am zis, avem acum…") or leave it out; mention only the part that is genuinely new to them. Decide per guest whether it is worth raising at all — do not force it into every message. You may mention ONLY updates in that guest\'s applicableUpdates, tagging factsUsed with the `update:<id>` key.',
       sentiment: 'always positive. For a careFlag complaint: if (and only if) an issueResolved:* fact is present, you MAY add a warm PS acknowledging the fix; otherwise do NOT mention the past problem at all — write a normal forward-looking message.',
     },

--- a/src/lib/growth/situationPack.ts
+++ b/src/lib/growth/situationPack.ts
@@ -17,6 +17,7 @@
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { getPageHealth, getAdAccountHealth } from '@/services/growth/metaAds/brandHealth';
 import { computeRecentCancellations, computeOutreachLedger } from '@/lib/growth/signals';
+import { getNotesByGuest, isTouch } from '@/services/guestNoteService';
 
 const toD = (v: any): Date | null =>
   v?._seconds ? new Date(v._seconds * 1000) : v?.toDate ? v.toDate() : typeof v === 'string' ? new Date(v) : v instanceof Date ? v : null;
@@ -59,12 +60,13 @@ export async function buildSituationPack(
   const generator = opts?.generator ?? 'src/lib/growth/situationPack.ts';
 
   const db = await getAdminDb();
-  const [bSnap, gSnap, aSnap, rSnap, tSnap] = await Promise.all([
+  const [bSnap, gSnap, aSnap, rSnap, tSnap, notesByGuest] = await Promise.all([
     db.collection('bookings').get(),
     db.collection('guests').get(),
     db.collection('availability').get(),
     db.collection('reviews').get(),
     db.collection('whatsappThreads').get(),
+    getNotesByGuest(),
   ]);
 
   const price = (b: any) => b.pricing?.total ?? b.pricing?.totalPrice ?? 0;
@@ -320,10 +322,20 @@ export async function buildSituationPack(
     const msgs = (th?.messages || []) as any[];
     const inbound = msgs.filter(m => m.direction === 'in' && m.ts < ymd(AS_OF)).length;
     const outbound = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).length;
-    const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => m.ts).sort().pop();
-    const tier = stays.length >= 2 ? 'repeat' : inbound >= 3 ? 'engaged' : inbound >= 1 ? 'responsive' : outbound >= 1 ? 'silent' : 'unknown';
+    const lastOutMsg = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
+    // Logged phone/in-person contact counts as engagement AND as contact (see guestNoteService):
+    // without it a phone-first relationship reads as "messaged, never replied".
+    const calls = (notesByGuest.get(g.id) || []).filter(n => isTouch(n.kind) && n.occurredAt <= ymd(AS_OF));
+    const lastCall = calls.map(n => n.occurredAt).sort().pop();
+    const lastOut = [lastOutMsg, lastCall].filter(Boolean).sort().pop();
+    const engagements = inbound + calls.length;
+    const tier = stays.length >= 2 ? 'repeat' : engagements >= 3 ? 'engaged' : engagements >= 1 ? 'responsive' : outbound >= 1 ? 'silent' : 'unknown';
     return {
       guestId: g.id, tier,
+      kind: (g.kind || 'guest') as 'guest' | 'lead',
+      nonConversionReason: g.nonConversionReason || null,
+      requestedPeriods: (g.requestedPeriods || []) as Array<{ start: string; end: string; askedOn: string; outcome: string; note?: string }>,
+      firstContactAt: g.firstContactAt || null,
       reachable: !!g.normalizedPhone && !g.unsubscribed,
       language: g.language || 'unknown',
       stays: stays.length,
@@ -333,22 +345,27 @@ export async function buildSituationPack(
       lastStayHadChildren: lastBooking ? (lastBooking.numberOfChildren ?? 0) > 0 : null,
       hasReview: (reviewsBy.get(g.id) || 0) > 0,
       inboundMessages: inbound,
+      loggedCalls: calls.length,
       // Romanian = the ONLY audience that returns. Verified: of 146 foreign guests ever, exactly 1
       // came back (14 repeat guests = 13 RO + 1 DE). Reactivation/outreach is Romanian by evidence,
       // not assumption. Foreigners are one-and-done OTA/ads acquisition, never retention.
       // Match on language OR country so RO-diaspora and missing-country guests aren't dropped.
       isRomanian: (g.language || '').toLowerCase() === 'ro' || ['RO', 'ROMANIA'].includes(String(g.country || '').toUpperCase()),
       // relationship depth — neutral INFORMATION for the owner, not a permission gate.
-      relationship: stays.length >= 2 ? 'repeat' : inbound >= 1 ? 'replied' : outbound >= 1 ? 'messaged-no-reply' : 'never-contacted',
+      relationship: stays.length >= 2 ? 'repeat' : engagements >= 1 ? 'replied' : outbound >= 1 ? 'messaged-no-reply' : 'never-contacted',
       // freq-cap: is this guest inside a cooling-off window right now?
       // ts is 'YYYY-MM-DDTHH:MM:SS' — slice to the date before making a Date (appending another
       // 'T..Z' to a string that already has a 'T' yields Invalid Date → NaN → everyone mis-flagged).
       contactableNow: !lastOut || nightsBetween(new Date(`${String(lastOut).slice(0, 10)}T00:00:00Z`), AS_OF) >= FREQ_CAP_DAYS,
-      daysSinceLastOutbound: lastOut ? nightsBetween(new Date(`${String(lastOut).slice(0, 10)}T00:00:00Z`), AS_OF) : null,
+      daysSinceLastOutbound: lastOut ? nightsBetween(new Date(`${String(lastOut).slice(0, 10)}T00:00:00Z`), AS_OF) : null,   // outbound message OR logged call
     };
   });
 
-  const reachable = guestRows.filter(g => g.reachable);
+  // Leads never stayed, so they must not dilute the stay-based audience view — they are reported
+  // separately under `audience.leads`.
+  const leadRows = guestRows.filter(g => g.kind === 'lead');
+  const guestOnlyRows = guestRows.filter(g => g.kind !== 'lead');
+  const reachable = guestOnlyRows.filter(g => g.reachable);
   const dueWindow = (g: typeof guestRows[0]) => g.daysSinceLastStay !== null && g.daysSinceLastStay >= 70 && g.daysSinceLastStay <= 252;
   // Return intervals over ALL repeat guests (2+ stays). Origin is carried as a dimension
   // (repeatGuests.byOrigin) rather than filtered — so the RO/foreign split is visible as data.
@@ -394,8 +411,8 @@ export async function buildSituationPack(
 
   // Raw fact behind any origin-based retention judgement: how many foreign vs Romanian guests
   // ever returned. No interpretation — the numbers are here; the conclusion is the reader's.
-  const everStayed = guestRows.filter(g => g.stays >= 1);
-  const repeatGuestRows = guestRows.filter(g => g.stays >= 2);
+  const everStayed = guestOnlyRows.filter(g => g.stays >= 1);
+  const repeatGuestRows = guestOnlyRows.filter(g => g.stays >= 2);
   const foreignEver = everStayed.filter(g => !g.isRomanian);
 
   const audience = {
@@ -406,8 +423,24 @@ export async function buildSituationPack(
       familySegment: 'children present on the guest\'s most recent stay',
       recencyBuckets: 'days since last stay; cumulative-eligible (a 2-year-lapsed guest is still a guest)',
     },
-    totalGuests: guests.length,
+    totalGuests: guestOnlyRows.length,
     reachable: reachable.length,
+    // People who contacted us directly and never stayed. Kept out of the counts above (they have no
+    // stay) but tracked here, because they are the only warm audience acquired at zero commission.
+    leads: {
+      definition: 'contacted us directly but never booked. No stay to reference — what they have instead is a request and a reason it went unfilled (nonConversionReason: unavailable | declined | unservable | unresolved).',
+      total: leadRows.length,
+      reachable: leadRows.filter(g => g.reachable).length,
+      byReason: leadRows.reduce((m: Record<string, number>, g) => ((m[g.nonConversionReason || 'unset'] = (m[g.nonConversionReason || 'unset'] || 0) + 1), m), {}),
+      turnedAwayDemand: {
+        note: 'periods people ASKED for that we could not fill. Demand that never becomes a booking record and is therefore invisible to occupancy, pace and revenue alike — but it is evidence about pricing and calendar pressure. Repeated misses on the same window are worth reading as a signal, not as a list of individuals.',
+        requests: guestRows
+          .flatMap(g => g.requestedPeriods.map(p => ({ guestId: g.guestId, kind: g.kind, ...p })))
+          .filter(p => p.outcome === 'unavailable' || p.outcome === 'declined')
+          .sort((a, b) => b.askedOn.localeCompare(a.askedOn))
+          .slice(0, 40),
+      },
+    },
     // origin retention — the raw counts, no conclusion drawn
     repeatGuests: {
       total: repeatGuestRows.length,

--- a/src/lib/growth/validateDrafts.ts
+++ b/src/lib/growth/validateDrafts.ts
@@ -8,7 +8,9 @@
  *                    must declare each guest-specific claim, and we verify the declarations are all
  *                    grounded. Also: no affection/"we-fixed-it" claim for a complaint guest unless a
  *                    grounded issueResolved:* fact backs it.
- *   2. Voice       — no emoji; self-ID present; length in range; opt-out iff first contact.
+ *   1b. Audience   — a LEAD never stayed, so any phrase asserting a past stay is a factual error.
+ *   2. Voice       — emoji kept light; self-ID present; length in range; an opt-out for a first
+ *                    contact, for anyone who never engaged, and for every lead.
  *   3. Coverage    — exactly one draft per selected guest, each with matching phone/language later
  *                    (phone/lang are re-checked at send by executionGateway).
  *
@@ -22,7 +24,18 @@ export interface GuestForDraftValidation {
   careFlags?: string[];
   groundedFacts: Array<{ key: string; value: unknown }>;
   thread: Array<unknown>;               // length 0 ⇒ first contact ⇒ opt-out required
+  /** 'lead' = never stayed. Stay language is a factual error for them, not a style choice. */
+  audienceKind?: 'guest' | 'lead';
+  /** Cross-channel state from the pack (a logged phone call counts, unlike thread length alone). */
+  relationshipState?: 'first-contact' | 'silent' | 'active' | 'lapsed';
 }
+
+/**
+ * Phrases that assert a past stay. Harmless for a guest, false for a lead — and a message that
+ * tells someone "it was lovely having you" when they never came is the one error that cannot be
+ * walked back. Deliberately narrow: only patterns that CLAIM a stay, not warm language in general.
+ */
+const CLAIMS_A_STAY = /\b(c[âa]nd a[țt]i fost la noi|c[âa]nd ai fost la noi|de c[âa]nd a[țt]i stat|c[âa]nd a[țt]i stat|ne-a[țt]i vizitat|a[țt]i fost oaspe|ne bucur[ăa]m c[ăa] a[țt]i stat|sper c[ăa] v-a pl[ăa]cut (sejurul|vizita)|last time you stayed|when you stayed with us|your stay with us)\b/i;
 
 export interface DraftRules {
   minChars?: number; maxChars?: number;
@@ -80,8 +93,17 @@ export function validateDrafts(
       errors.push('references a past problem for a complaint guest with no grounded issueResolved fact — write forward-looking, do not mention it');
     }
 
+    // 1b. a lead never stayed — stay language is a factual error, not a stylistic one
+    const isLead = g.audienceKind === 'lead';
+    if (isLead && CLAIMS_A_STAY.test(body)) {
+      errors.push('claims a past stay for a LEAD who has never stayed — build on what they asked for (requestedPeriod / nonConversionReason), not on a visit that never happened');
+    }
+
     // 2. voice
-    const firstContact = (g.thread || []).length === 0;
+    // A logged phone call makes someone NOT a first contact even with an empty thread, and leaves
+    // them a first contact despite a full thread only when they never engaged at all — so prefer
+    // the pack's cross-channel state and fall back to thread length.
+    const firstContact = g.relationshipState ? g.relationshipState === 'first-contact' : (g.thread || []).length === 0;
     const emojiCount = (body.match(EMOJI) || []).length;
     if (emojiCount > EMOJI_MAX) warnings.push(`${emojiCount} emoji — keep them light (1-2, only to underline)`);
     // Self-ID: a first/cold contact MUST say who is writing (a stranger needs it); when continuing an
@@ -92,7 +114,12 @@ export function validateDrafts(
     }
     if (body.length < r.minChars) errors.push(`too short (${body.length} < ${r.minChars})`);
     else if (body.length > r.maxChars) warnings.push(`long (${body.length} > ${r.maxChars})`);
-    if (firstContact && !r.optOutMarkers.some((m) => loose(body).includes(loose(m)))) warnings.push('first contact but no opt-out line found');
+    // Opt-out: required for a first contact, for anyone who has never engaged, and for every lead —
+    // an enquiry that never became a stay is a thinner basis for writing again than a real stay is.
+    const needsOptOut = firstContact || isLead || g.relationshipState === 'silent';
+    if (needsOptOut && !r.optOutMarkers.some((m) => loose(body).includes(loose(m)))) {
+      warnings.push(`no opt-out line found (${isLead ? 'lead' : firstContact ? 'first contact' : 'never engaged'})`);
+    }
 
     return { guestId: d.guestId, errors, warnings };
   });

--- a/src/lib/growth/warmupAudience.ts
+++ b/src/lib/growth/warmupAudience.ts
@@ -10,6 +10,7 @@
  */
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { isRomaniaBased } from '@/lib/growth/audience';
+import { getNotesByGuest, isTouch } from '@/services/guestNoteService';
 import type { CampaignBrief } from '@/lib/growth/contracts';
 
 export type WarmupSegment = 'keepintouch' | 'coldreintro';
@@ -36,9 +37,10 @@ export async function buildWarmupBrief(segment: WarmupSegment, opts?: { property
   const cap = opts?.cap ?? win.defaultCap;
 
   const db = await getAdminDb();
-  const [gSnap, bSnap, tSnap, sSnap] = await Promise.all([
+  const [gSnap, bSnap, tSnap, sSnap, notesByGuest] = await Promise.all([
     db.collection('guests').get(), db.collection('bookings').get(),
     db.collection('whatsappThreads').get(), db.collection('suppressionList').get(),
+    getNotesByGuest(),
   ]);
   const bookingById = new Map(bSnap.docs.map(d => [d.id, { id: d.id, ...(d.data() as any) }]));
   const threads = new Map(tSnap.docs.map(d => [d.id, d.data() as any]));
@@ -48,6 +50,9 @@ export async function buildWarmupBrief(segment: WarmupSegment, opts?: { property
   const picked: any[] = [];
   for (const g of guests) {
     if (!g.normalizedPhone || g.unsubscribed) continue;
+    // Warm-up is stay-anchored — every angle it writes references when they stayed. A lead has no
+    // stay, so it belongs to lead outreach, not here.
+    if (g.kind === 'lead') continue;
     if (suppressed.has(norm(g.normalizedPhone).slice(-9))) continue;
     const stayB = (g.bookingIds || []).map((id: string) => bookingById.get(id)).filter(Boolean)
       .filter((b: any) => b.status !== 'cancelled' && toD(b.checkInDate) && toD(b.checkInDate)! < AS_OF)
@@ -65,7 +70,11 @@ export async function buildWarmupBrief(segment: WarmupSegment, opts?: { property
     const th = threads.get(g.id);
     const msgs = (th?.messages || []) as any[];
     const lastOut = msgs.filter(m => m.direction === 'out' && m.ts < ymd(AS_OF)).map(m => String(m.ts).slice(0, 10)).sort().pop();
-    const daysSinceOut = lastOut ? days(new Date(`${lastOut}T00:00:00Z`), AS_OF) : null;
+    // A phone call is contact too. Pacing off WhatsApp alone would happily send a "we haven't
+    // spoken in a while" hello the day after speaking on the phone.
+    const lastCall = (notesByGuest.get(g.id) || []).filter(n => isTouch(n.kind) && n.occurredAt < ymd(AS_OF)).map(n => n.occurredAt).sort().pop();
+    const lastContact = [lastOut, lastCall].filter(Boolean).sort().pop();
+    const daysSinceOut = lastContact ? days(new Date(`${lastContact}T00:00:00Z`), AS_OF) : null;
     if (daysSinceOut !== null && daysSinceOut < win.recentOutboundFloor) continue;
 
     const careFlags = msgs.some(m => m.direction === 'in' && complaintRe.test(m.text || '')) ? ['complaint-in-thread'] : [];

--- a/src/lib/whatsapp/__tests__/parse-thread.test.ts
+++ b/src/lib/whatsapp/__tests__/parse-thread.test.ts
@@ -1,4 +1,4 @@
-import { parseWhatsAppRows, mergeMessages, type RawRow } from '../parse-thread';
+import { parseWhatsAppRows, mergeMessages, isSystemNotice, reconcileAuthoritative, type RawRow } from '../parse-thread';
 import type { WhatsAppMessage } from '@/types';
 
 const OWNER = 'Bogdan Coman';
@@ -103,5 +103,73 @@ describe('mergeMessages (incremental top-up)', () => {
     ]);
     expect(merged[0].text).toBe('earliest');
     expect(merged.map((m) => m.ts)).toEqual([...merged.map((m) => m.ts)].sort());
+  });
+});
+
+describe('isSystemNotice', () => {
+  it('drops the notices WhatsApp renders as if they were messages', () => {
+    expect(isSystemNotice('Messages and calls are end-to-end encrypted. Only people in this chat can read them.')).toBe(true);
+    // The live regression: a lead whose ONLY inbound "message" was this notice read as
+    // relationship.state 'active' — "replied today" — when he had never written at all.
+    expect(isSystemNotice("+40 725 918 590 uses a default timer for disappearing messages in new chats. New messages will disappear from this chat 24 hours after they're sent.")).toBe(true);
+    expect(isSystemNotice('You turned on disappearing messages')).toBe(true);
+    expect(isSystemNotice('+40 722 629 587 changed to a new number')).toBe(true);
+    expect(isSystemNotice('This message was deleted')).toBe(true);
+  });
+
+  it('keeps real messages, including a missed call (a genuine interaction signal)', () => {
+    expect(isSystemNotice('Missed voice call')).toBe(false);
+    expect(isSystemNotice('Buna ziua! Am vorbit mai devreme la telefon')).toBe(false);
+    expect(isSystemNotice('image omitted')).toBe(false);
+  });
+});
+
+describe('reconcileAuthoritative (official export folded into the vault)', () => {
+  // The SAME message as captured by each collector: the scrape only knows the minute and collapses
+  // newlines; the export carries real seconds and keeps them.
+  const scraped: WhatsAppMessage[] = [
+    { ts: '2026-01-08T11:49:00', direction: 'out', sender: OWNER, text: 'Buna Marius! Voiam sa impartasesc cu tine doua poze', type: 'text' },
+    { ts: '2025-08-02T12:19:00', direction: 'in', sender: 'Dmytro', text: 'Salut Bogdan, sper ca acest mesaj va gaseste bine', type: 'text' },
+  ];
+  const exported: WhatsAppMessage[] = [
+    { ts: '2026-01-08T11:49:37', direction: 'out', sender: OWNER, text: 'Buna Marius!\nVoiam sa impartasesc cu tine doua poze', type: 'text' },
+    { ts: '2026-02-14T10:00:12', direction: 'in', sender: 'Marius', text: 'multumesc frumos!', type: 'text' },
+  ];
+
+  it('supersedes the duplicate rather than double-storing it', () => {
+    const r = reconcileAuthoritative(scraped, exported);
+    const marius = r.messages.filter((m) => /impartasesc/.test(m.text));
+    expect(marius).toHaveLength(1);
+    expect(marius[0].ts).toBe('2026-01-08T11:49:37');   // the richer export capture wins
+    expect(r.supersededCount).toBe(1);
+  });
+
+  it('RESCUES stored messages the export does not contain — a short export never destroys history', () => {
+    const r = reconcileAuthoritative(scraped, exported);
+    expect(r.rescued.map((m) => m.sender)).toEqual(['Dmytro']);
+    expect(r.messages).toHaveLength(3);
+  });
+
+  it('flags a truncated export (smaller, and starting later) without losing anything', () => {
+    const stored = [...scraped, ...exported];
+    const trimmed = exported.slice(1);   // a restored phone: only the recent tail survives
+    const r = reconcileAuthoritative(stored, trimmed);
+    expect(r.shrinks).toBe(true);
+    expect(r.startsLater).toBe(true);
+    expect(r.messages).toHaveLength(stored.length);   // nothing dropped
+  });
+
+  it('matches across diacritics and scrape file-size artifacts', () => {
+    const a: WhatsAppMessage[] = [{ ts: '2026-03-01T09:15:00', direction: 'in', sender: 'X', text: '42 kB Mulțumesc mult!', type: 'text' }];
+    const b: WhatsAppMessage[] = [{ ts: '2026-03-01T09:15:44', direction: 'in', sender: 'X', text: 'Multumesc mult!', type: 'text' }];
+    const r = reconcileAuthoritative(a, b);
+    expect(r.messages).toHaveLength(1);
+    expect(r.rescued).toHaveLength(0);
+  });
+
+  it('is idempotent — re-importing the same export changes nothing', () => {
+    const once = reconcileAuthoritative([], exported).messages;
+    const twice = reconcileAuthoritative(once, exported).messages;
+    expect(twice).toHaveLength(once.length);
   });
 });

--- a/src/lib/whatsapp/parse-thread.ts
+++ b/src/lib/whatsapp/parse-thread.ts
@@ -21,6 +21,37 @@ export interface RawRow {
   text: string;
 }
 
+/**
+ * WhatsApp SYSTEM notices — chat events rendered as if they were messages. They MUST be dropped
+ * before they reach a thread, because they carry a sender (so they parse as inbound) and a
+ * timestamp that is often LATER than the real conversation (WhatsApp stamps them when the chat
+ * metadata was written). Left in, a single notice becomes the thread's newest "inbound message",
+ * which corrupts `lastMessageTs`, `relationship.state` and every pacing floor derived from it.
+ *
+ * Observed live: a lead whose only inbound "message" was the disappearing-messages notice read as
+ * `state: 'active'` ("replied today") when he had in fact never written at all.
+ *
+ * Deliberately NOT here: "Missed voice call" — a missed call is a real interaction signal and is
+ * kept as a `media` message.
+ */
+export const SYSTEM_NOTICE_RE = new RegExp([
+  'end-to-end encrypted',
+  'default timer for disappearing messages',
+  'turned (on|off) disappearing messages',
+  'messages will disappear',
+  'changed to a new number',
+  'changed their phone number',
+  'created (this )?group',
+  'added you',
+  'security code',
+  'message was deleted',
+].join('|'), 'i');
+
+/** True for a chat event that must never be stored as a message. */
+export function isSystemNotice(text: string): boolean {
+  return SYSTEM_NOTICE_RE.test(text || '');
+}
+
 export interface ParseOptions {
   ownerName: string;              // the owner's WhatsApp display name → classifies 'out'
   dateFormat?: 'MDY' | 'DMY';     // owner-locale date order (Bogdan's WhatsApp = MDY); default 'MDY'
@@ -74,6 +105,7 @@ export function parseWhatsAppRows(rows: RawRow[], opts: ParseOptions): WhatsAppM
     const direction: WhatsAppDirection = sender === owner ? 'out' : 'in';
     const text = cleanText(row.text);
     if (!text) continue;
+    if (isSystemNotice(text)) continue;   // a chat event, not a message (see SYSTEM_NOTICE_RE)
 
     const msg: WhatsAppMessage = { ts, direction, sender, text, type: 'text' };
     const fp = fingerprint(msg);
@@ -102,4 +134,89 @@ export function mergeMessages(existing: WhatsAppMessage[], incoming: WhatsAppMes
   }
   merged.sort((a, b) => a.ts.localeCompare(b.ts));
   return merged;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-source reconciliation (official phone export vs. the older browser scrape)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Text normalized hard enough that the SAME message captured by two different collectors matches.
+ * The scrape collapses newlines to spaces and occasionally prefixes a file-size artifact ("42 kB ");
+ * the export preserves line breaks. Diacritics are stripped too, so an encoding difference between
+ * sources cannot masquerade as a distinct message.
+ */
+const looseText = (t: string): string => (t || '')
+  .replace(/^\d+\s*kB\s+/i, '')
+  .normalize('NFD').replace(/[̀-ͯ]/g, '')
+  .toLowerCase()
+  .replace(/[^a-z0-9 ]+/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+/**
+ * Source-independent identity for a message: MINUTE + direction + normalized text.
+ *
+ * The exact `fingerprint` (full second + raw text) can never match across sources — the scrape only
+ * ever knows the minute (seconds forced to `:00`) while the export carries real seconds. That
+ * mismatch is why importing an export used to require a destructive whole-thread overwrite.
+ */
+export function looseFingerprint(m: Pick<WhatsAppMessage, 'ts' | 'direction' | 'text'>): string {
+  return `${String(m.ts).slice(0, 16)}|${m.direction}|${looseText(m.text)}`;
+}
+
+export interface ReconcileResult {
+  messages: WhatsAppMessage[];
+  /** Stored messages the authoritative batch does NOT contain — carried over rather than dropped. */
+  rescued: WhatsAppMessage[];
+  /** Stored messages the batch supersedes (same message, richer capture). */
+  supersededCount: number;
+  existingCount: number;
+  incomingCount: number;
+  /** The batch is smaller than what is stored — usually a truncated export. Informational. */
+  shrinks: boolean;
+  /** The batch's history starts later than the stored history — the tell of a trimmed device. */
+  startsLater: boolean;
+  existingEarliest?: string;
+  incomingEarliest?: string;
+}
+
+/**
+ * Fold an AUTHORITATIVE batch (an official "Export chat" file) into a stored thread.
+ *
+ * The batch wins wherever the two describe the same message — it is the richer capture (real
+ * seconds, preserved line breaks, media markers). But anything the vault holds and the batch does
+ * NOT contain is RESCUED, never dropped. That matters because an export reflects one device at one
+ * moment: a phone restored from backup, a chat with a disappearing-messages timer, or a trimmed
+ * history all produce a legitimately shorter file. A blind overwrite would silently destroy the
+ * only surviving copy; this keeps both without double-storing anything.
+ */
+export function reconcileAuthoritative(existing: WhatsAppMessage[], incoming: WhatsAppMessage[]): ReconcileResult {
+  const seen = new Set<string>();
+  const batch = incoming.filter((m) => {
+    const fp = fingerprint(m);
+    if (seen.has(fp)) return false;
+    seen.add(fp);
+    return true;
+  });
+
+  const batchKeys = new Set(batch.map(looseFingerprint));
+  const rescued = existing.filter((m) => !batchKeys.has(looseFingerprint(m)));
+  const messages = [...batch, ...rescued].sort((a, b) => a.ts.localeCompare(b.ts));
+
+  const earliest = (arr: WhatsAppMessage[]) => (arr.length ? arr.reduce((min, m) => (m.ts < min ? m.ts : min), arr[0].ts) : undefined);
+  const existingEarliest = earliest(existing);
+  const incomingEarliest = earliest(batch);
+
+  return {
+    messages,
+    rescued,
+    supersededCount: existing.length - rescued.length,
+    existingCount: existing.length,
+    incomingCount: batch.length,
+    shrinks: batch.length < existing.length,
+    startsLater: !!existingEarliest && !!incomingEarliest && incomingEarliest > existingEarliest,
+    existingEarliest,
+    incomingEarliest,
+  };
 }

--- a/src/services/growth/copywriter.ts
+++ b/src/services/growth/copywriter.ts
@@ -76,7 +76,10 @@ prose, no extra guests, none skipped.`;
 function packGuestsForValidation(pack: Awaited<ReturnType<typeof buildCopywriterPack>>): GuestForDraftValidation[] {
   return pack.guests
     .filter((g: any) => !g.error)
-    .map((g: any) => ({ guestId: g.guestId, careFlags: g.careFlags || [], groundedFacts: g.groundedFacts || [], thread: g.thread || [] }));
+    .map((g: any) => ({
+      guestId: g.guestId, careFlags: g.careFlags || [], groundedFacts: g.groundedFacts || [], thread: g.thread || [],
+      audienceKind: g.audienceKind, relationshipState: g.relationship?.state,
+    }));
 }
 
 export interface GenerateDraftsResult {

--- a/src/services/guestNoteService.ts
+++ b/src/services/guestNoteService.ts
@@ -1,0 +1,97 @@
+/**
+ * guestNoteService — the record of interactions that never touched WhatsApp.
+ *
+ * Most of a lead relationship happens on the phone. The message vault cannot see it, so without
+ * notes the engagement layer reads the WhatsApp residue and draws the opposite conclusion: three
+ * unanswered outbound messages look like "silent — messaged, never replied" for someone who was
+ * warm and enthusiastic on a call. Notes restore the missing half of the timeline.
+ *
+ * Two duties, deliberately separate:
+ *   1. TOUCH  — a call/in-person note is a real contact and counts against pacing floors, so the
+ *               system cannot follow a phone call with a "we haven't spoken in a while" message.
+ *   2. FACT   — an `assertable` note (optionally narrowed to specific `facts`) is admitted to the
+ *               copywriter's groundedFacts whitelist. Everything else is context: it may shape
+ *               tone, never a claim.
+ *
+ * Storage: `guestNotes/{noteId}` — append-only, admin-locked (private conversation content, same
+ * sensitivity as the thread vault).
+ *
+ * Plain server module (NOT 'use server').
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { GuestNote, GuestNoteFact, GuestNoteKind } from '@/types';
+
+const logger = loggers.campaign;
+
+/** Kinds that represent a real two-way exchange (an observation is not one). */
+export function isTouch(kind: GuestNoteKind): boolean {
+  return kind === 'call' || kind === 'inperson';
+}
+
+/** True if the note is still relevant as of `asOf` (unexpired). */
+export function isLive(note: Pick<GuestNote, 'expiresAt'>, asOf: string): boolean {
+  return !note.expiresAt || note.expiresAt >= asOf;
+}
+
+export async function addGuestNote(input: {
+  guestId: string;
+  text: string;
+  kind?: GuestNoteKind;
+  occurredAt?: string;          // defaults to today
+  initiatedBy?: 'owner' | 'guest';
+  assertable?: boolean;
+  facts?: GuestNoteFact[];
+  expiresAt?: string;
+  createdBy?: string;
+}): Promise<string> {
+  const db = await getAdminDb();
+  const doc: Omit<GuestNote, 'id'> = {
+    guestId: input.guestId,
+    occurredAt: input.occurredAt || new Date().toISOString().slice(0, 10),
+    kind: input.kind || 'call',
+    text: input.text.trim(),
+    assertable: input.assertable ?? false,
+    ...(input.initiatedBy ? { initiatedBy: input.initiatedBy } : {}),
+    ...(input.facts?.length ? { facts: input.facts } : {}),
+    ...(input.expiresAt ? { expiresAt: input.expiresAt } : {}),
+    ...(input.createdBy ? { createdBy: input.createdBy } : {}),
+    createdAt: FieldValue.serverTimestamp() as unknown as GuestNote['createdAt'],
+  };
+  const ref = await db.collection('guestNotes').add(doc);
+  logger.info('Guest note added', { guestId: input.guestId, noteId: ref.id, kind: doc.kind, assertable: doc.assertable });
+  return ref.id;
+}
+
+/** All notes for one guest, oldest first. */
+export async function listGuestNotes(guestId: string): Promise<GuestNote[]> {
+  const db = await getAdminDb();
+  const snap = await db.collection('guestNotes').where('guestId', '==', guestId).get();
+  return snap.docs
+    .map((d) => ({ id: d.id, ...(d.data() as Omit<GuestNote, 'id'>) }))
+    .sort((a, b) => a.occurredAt.localeCompare(b.occurredAt));
+}
+
+/**
+ * Every note, grouped by guest — the pack-building read. One collection scan, mirroring how the
+ * packs already load guests/bookings/threads.
+ */
+export async function getNotesByGuest(): Promise<Map<string, GuestNote[]>> {
+  const db = await getAdminDb();
+  const snap = await db.collection('guestNotes').get();
+  const byGuest = new Map<string, GuestNote[]>();
+  snap.docs.forEach((d) => {
+    const n = { id: d.id, ...(d.data() as Omit<GuestNote, 'id'>) };
+    if (!n.guestId) return;
+    if (!byGuest.has(n.guestId)) byGuest.set(n.guestId, []);
+    byGuest.get(n.guestId)!.push(n);
+  });
+  byGuest.forEach((arr) => arr.sort((a, b) => a.occurredAt.localeCompare(b.occurredAt)));
+  return byGuest;
+}
+
+export async function deleteGuestNote(noteId: string): Promise<void> {
+  const db = await getAdminDb();
+  await db.collection('guestNotes').doc(noteId).delete();
+  logger.info('Guest note deleted', { noteId });
+}

--- a/src/services/guestService.ts
+++ b/src/services/guestService.ts
@@ -126,6 +126,18 @@ export async function upsertGuestFromBooking(booking: Booking): Promise<string |
         updateData.country = country;
       }
 
+      // A lead just became a guest. The doc id is unchanged, so the WhatsApp thread, the notes and
+      // every prior interaction carry over intact — the conversation that convinced them survives
+      // the transition. A verified booking name also supersedes an unreliable WhatsApp push-name.
+      if (guestData.kind === 'lead') {
+        updateData.kind = 'guest';
+        if (booking.guestInfo.firstName && guestData.nameSource !== 'booking') {
+          updateData.firstName = booking.guestInfo.firstName;
+          updateData.nameSource = 'booking';
+        }
+        logger.info('Lead promoted to guest by booking', { guestId: guestDoc.id, bookingId: booking.id });
+      }
+
       // Track booking sources
       if (source) {
         updateData.sources = FieldValue.arrayUnion(source);

--- a/src/services/leadService.ts
+++ b/src/services/leadService.ts
@@ -1,0 +1,145 @@
+/**
+ * leadService — people who contacted us directly but never stayed.
+ *
+ * A lead is a `guests` doc with `kind: 'lead'`, NOT a parallel collection. Everything downstream —
+ * the WhatsApp thread vault (keyed by guestId), notes, consent, suppression, frequency caps and
+ * executionGateway — already works off a guest doc; a second collection would mean a second code
+ * path through all of it. Keeping one doc also means a lead who eventually books keeps its id, and
+ * with it the entire conversation that convinced them.
+ *
+ * What a lead has instead of a stay is a REQUEST and a reason it went unfilled. Those two fields
+ * carry the weight the booking history carries for a guest: they are what the next message can
+ * honestly be built on, and `requestedPeriods` doubles as demand telemetry for dates we could not
+ * serve — evidence that never becomes a booking record.
+ *
+ * Plain server module (NOT 'use server').
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import { normalizePhone } from '@/lib/sanitize';
+import type { Guest, NonConversionReason, RequestedPeriod } from '@/types';
+
+const logger = loggers.campaign;
+
+const digits = (s: string) => (s || '').replace(/[^0-9]/g, '');
+
+/**
+ * A WhatsApp push-name is not a verified name: it can be a nickname, ALL CAPS, or carry emoji
+ * ("~JOHN 🎩"). Strip the decoration for storage but keep the provenance in `nameSource` so the
+ * copywriter can decide whether it is safe to greet someone by it.
+ */
+export function cleanPushName(raw: string | undefined | null): string {
+  return (raw || '')
+    .replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}]/gu, '')
+    .replace(/^~/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** True when the display name is really just the phone number WhatsApp fell back to. */
+export function isPhoneAsName(name: string, phone: string): boolean {
+  const n = digits(name);
+  return n.length >= 6 && n === digits(phone).slice(-n.length);
+}
+
+/** Find any guest OR lead by phone (last 9 digits — tolerant of formatting differences). */
+export async function findByPhone(phone: string): Promise<Guest | null> {
+  const p9 = digits(phone).slice(-9);
+  if (p9.length < 9) return null;
+  const db = await getAdminDb();
+  const snap = await db.collection('guests').get();
+  const hit = snap.docs.find((d) => {
+    const g = d.data() as Guest;
+    return digits(g.normalizedPhone || g.phone || '').slice(-9) === p9;
+  });
+  return hit ? ({ id: hit.id, ...hit.data() } as Guest) : null;
+}
+
+/**
+ * Create a lead, or return the existing record if this phone is already known (a lead we have
+ * already met, or a real past guest — never shadow one with a duplicate).
+ */
+export async function createLead(input: {
+  phone: string;
+  name?: string;
+  nameSource?: Guest['nameSource'];
+  leadSource?: string;
+  propertyId?: string;
+  firstContactAt?: string;
+  language?: Guest['language'];
+}): Promise<{ id: string; created: boolean; existing?: Guest }> {
+  const existing = await findByPhone(input.phone);
+  if (existing) return { id: existing.id, created: false, existing };
+
+  const db = await getAdminDb();
+  const normalized = normalizePhone(input.phone) || input.phone;
+  const rawName = cleanPushName(input.name);
+  const name = isPhoneAsName(rawName, normalized) ? '' : rawName;
+  const now = FieldValue.serverTimestamp();
+
+  const doc = {
+    kind: 'lead' as const,
+    firstName: name,
+    nameSource: name ? (input.nameSource || 'pushname') : ('unknown' as const),
+    phone: input.phone,
+    normalizedPhone: normalized,
+    language: input.language || 'ro',
+    leadSource: input.leadSource || 'whatsapp',
+    firstContactAt: input.firstContactAt || new Date().toISOString().slice(0, 10),
+    propertyIds: input.propertyId ? [input.propertyId] : [],
+    bookingIds: [] as string[],
+    totalBookings: 0,
+    totalSpent: 0,
+    currency: 'RON' as const,
+    tags: [] as string[],
+    reviewSubmitted: false,
+    unsubscribed: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const ref = await db.collection('guests').add(doc);
+  logger.info('Lead created', { leadId: ref.id, phone: normalized, named: !!name });
+  return { id: ref.id, created: true };
+}
+
+/** Patch lead-specific fields (name, why it did not convert, source, property). */
+export async function updateLead(guestId: string, patch: {
+  firstName?: string;
+  nameSource?: Guest['nameSource'];
+  leadSource?: string;
+  nonConversionReason?: NonConversionReason;
+  propertyId?: string;
+  language?: Guest['language'];
+}): Promise<void> {
+  const db = await getAdminDb();
+  const update: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
+  if (patch.firstName !== undefined) update.firstName = patch.firstName;
+  if (patch.nameSource) update.nameSource = patch.nameSource;
+  if (patch.leadSource) update.leadSource = patch.leadSource;
+  if (patch.nonConversionReason) update.nonConversionReason = patch.nonConversionReason;
+  if (patch.language) update.language = patch.language;
+  if (patch.propertyId) update.propertyIds = FieldValue.arrayUnion(patch.propertyId);
+  await db.collection('guests').doc(guestId).set(update, { merge: true });
+  logger.info('Lead updated', { guestId, fields: Object.keys(update) });
+}
+
+/** Append a requested period. Idempotent on (start, end, askedOn). */
+export async function addRequestedPeriod(guestId: string, period: RequestedPeriod): Promise<void> {
+  const db = await getAdminDb();
+  const ref = db.collection('guests').doc(guestId);
+  const snap = await ref.get();
+  const current = ((snap.data() as Guest | undefined)?.requestedPeriods || []) as RequestedPeriod[];
+  const key = (p: RequestedPeriod) => `${p.start}|${p.end}|${p.askedOn}`;
+  const next = [...current.filter((p) => key(p) !== key(period)), period]
+    .sort((a, b) => a.askedOn.localeCompare(b.askedOn));
+  await ref.set({ requestedPeriods: next, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+  logger.info('Requested period recorded', { guestId, start: period.start, end: period.end, outcome: period.outcome });
+}
+
+export async function listLeads(): Promise<Guest[]> {
+  const db = await getAdminDb();
+  const snap = await db.collection('guests').where('kind', '==', 'lead').get();
+  return snap.docs
+    .map((d) => ({ id: d.id, ...d.data() }) as Guest)
+    .sort((a, b) => String(b.firstContactAt || '').localeCompare(String(a.firstContactAt || '')));
+}

--- a/src/services/whatsappThreadService.ts
+++ b/src/services/whatsappThreadService.ts
@@ -12,8 +12,8 @@
  */
 import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
 import { loggers } from '@/lib/logger';
-import type { Guest, WhatsAppThread, WhatsAppMessage } from '@/types';
-import { mergeMessages } from '@/lib/whatsapp/parse-thread';
+import type { Guest, WhatsAppThread, WhatsAppMessage, WhatsAppThreadImport } from '@/types';
+import { mergeMessages, reconcileAuthoritative, type ReconcileResult } from '@/lib/whatsapp/parse-thread';
 import { resolveGuestLanguage } from '@/lib/growth/language';
 
 const logger = loggers.campaign;
@@ -28,17 +28,21 @@ export async function upsertThreadMessages(input: {
   guestId: string;
   phone: string;
   messages: WhatsAppMessage[];
-  replace?: boolean;   // true = this batch IS the complete, authoritative history (official phone
-                       // export) — overwrite, don't merge. The browser scrape uses minute-precision
-                       // timestamps + text artifacts that would NOT dedupe against a clean export,
-                       // so merging the two double-stores every shared message. Replace avoids that.
-}): Promise<{ added: number; total: number }> {
+  authoritative?: boolean; // true = this batch is an official phone export — the COMPLETE history as
+                           // that device knows it. It supersedes stored duplicates (matched on a
+                           // source-independent loose fingerprint, since the scrape only knows the
+                           // minute while the export carries real seconds), but anything the vault
+                           // holds and the export lacks is RESCUED, not dropped — an export can be
+                           // legitimately short (restored phone, disappearing-messages timer) and a
+                           // blind overwrite would destroy the only surviving copy.
+}): Promise<{ added: number; total: number; reconcile?: ReconcileResult }> {
   const db = await getAdminDb();
   const ref = db.collection('whatsappThreads').doc(input.guestId);
   const snap = await ref.get();
-  const existing = (!input.replace && snap.exists) ? ((snap.data() as WhatsAppThread).messages ?? []) : [];
+  const existing = snap.exists ? ((snap.data() as WhatsAppThread).messages ?? []) : [];
 
-  const merged = mergeMessages(existing, input.messages);   // dedups within the batch + sorts
+  const reconcile = input.authoritative ? reconcileAuthoritative(existing, input.messages) : undefined;
+  const merged = reconcile ? reconcile.messages : mergeMessages(existing, input.messages);
   const added = merged.length - existing.length;
   const lastMessageTs = merged.length ? merged[merged.length - 1].ts : undefined;
   const now = FieldValue.serverTimestamp();
@@ -57,8 +61,44 @@ export async function upsertThreadMessages(input: {
     { merge: true }
   );
 
-  logger.info('WhatsApp thread upserted', { guestId: input.guestId, added, total: merged.length });
-  return { added, total: merged.length };
+  logger.info('WhatsApp thread upserted', {
+    guestId: input.guestId, added, total: merged.length,
+    ...(reconcile ? { rescued: reconcile.rescued.length, superseded: reconcile.supersededCount } : {}),
+  });
+  return { added, total: merged.length, reconcile };
+}
+
+/**
+ * Archive a raw import batch, immutably, before it is folded into a thread.
+ *
+ * The thread doc is a DERIVED view: it is reconciled, deduped and sorted, and reconciliation rules
+ * may change. The archive is the source of record — every batch ever collected, exactly as parsed,
+ * so a thread can always be rebuilt without going back to the phone. That matters most for chats
+ * that no longer exist on any device (disappearing-messages timers, trimmed history), where the
+ * vault is the only surviving copy.
+ */
+export async function archiveImport(input: {
+  guestId: string;
+  phone: string;
+  source: 'export' | 'scrape';
+  label: string;               // the export filename / capture label — provenance
+  messages: WhatsAppMessage[];
+}): Promise<string> {
+  const db = await getAdminDb();
+  const sorted = [...input.messages].sort((a, b) => a.ts.localeCompare(b.ts));
+  const doc: Omit<WhatsAppThreadImport, 'id'> = {
+    guestId: input.guestId,
+    phone: input.phone,
+    source: input.source,
+    label: input.label,
+    messageCount: sorted.length,
+    ...(sorted.length ? { firstTs: sorted[0].ts, lastTs: sorted[sorted.length - 1].ts } : {}),
+    messages: sorted,
+    importedAt: FieldValue.serverTimestamp(),
+  };
+  const ref = await db.collection('whatsappThreadImports').add(doc);
+  logger.info('WhatsApp import archived', { guestId: input.guestId, importId: ref.id, count: sorted.length });
+  return ref.id;
 }
 
 /**
@@ -100,6 +140,7 @@ export interface BackfillQueueItem {
   phone: string;            // E.164 — the number to search in WhatsApp
   hasThread: boolean;
   lastMessageTs?: string;   // present when a thread exists → the incremental cutoff
+  lastFetchedAt?: string;   // when we last CAPTURED it → drives the re-export staleness order
   messageCount: number;
 }
 
@@ -113,6 +154,8 @@ export interface BackfillQueueItem {
 export async function getBackfillQueue(opts?: {
   language?: 'ro' | 'en' | 'all';
   onlyMissing?: boolean;
+  /** Order by capture staleness (oldest `lastFetchedAt` first) — the re-export work-list. */
+  byStaleness?: boolean;
 }): Promise<BackfillQueueItem[]> {
   const db = await getAdminDb();
   const lang = opts?.language ?? 'ro';
@@ -122,10 +165,14 @@ export async function getBackfillQueue(opts?: {
     db.collection('whatsappThreads').get(),
   ]);
 
-  const threads = new Map<string, { lastMessageTs?: string; messageCount: number }>();
+  const threads = new Map<string, { lastMessageTs?: string; lastFetchedAt?: string; messageCount: number }>();
   threadSnap.docs.forEach((d) => {
-    const t = d.data() as WhatsAppThread;
-    threads.set(d.id, { lastMessageTs: t.lastMessageTs, messageCount: t.messageCount ?? (t.messages?.length ?? 0) });
+    const t = d.data() as WhatsAppThread & { lastFetchedAt?: { toDate?: () => Date } };
+    threads.set(d.id, {
+      lastMessageTs: t.lastMessageTs,
+      lastFetchedAt: t.lastFetchedAt?.toDate?.().toISOString().slice(0, 10),
+      messageCount: t.messageCount ?? (t.messages?.length ?? 0),
+    });
   });
 
   const items: BackfillQueueItem[] = [];
@@ -143,10 +190,17 @@ export async function getBackfillQueue(opts?: {
       phone: g.normalizedPhone,
       hasThread: !!th,
       lastMessageTs: th?.lastMessageTs,
+      lastFetchedAt: th?.lastFetchedAt,
       messageCount: th?.messageCount ?? 0,
     });
   });
 
-  items.sort((a, b) => a.name.localeCompare(b.name));
+  if (opts?.byStaleness) {
+    // Never-captured first, then longest-since-capture. This is the "which chats should I export
+    // next" order — without it the export path (unlike the scrape queue) is worked blind.
+    items.sort((a, b) => (a.lastFetchedAt ?? '').localeCompare(b.lastFetchedAt ?? '') || a.name.localeCompare(b.name));
+  } else {
+    items.sort((a, b) => a.name.localeCompare(b.name));
+  }
   return items;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -292,8 +292,49 @@ export interface Booking {
   updatedAt?: SerializableTimestamp;
 }
 
+/**
+ * Why a lead never became a guest. This changes the next message more than almost any other fact,
+ * and the four cases are NOT interchangeable:
+ *   unavailable — we could not serve the dates. Nothing negative happened; a later "that constraint
+ *                 is gone" message is welcome.
+ *   declined    — they chose not to (price, went elsewhere, a quote went quiet). Weak ground: do not
+ *                 re-offer the same terms as though nothing had happened.
+ *   unservable  — a structural mismatch we cannot fix (payment method, capacity, pets). Usually do
+ *                 not re-contact unless the constraint itself changed.
+ *   unresolved  — the conversation simply stopped. Unknown; a light re-open, not a follow-up.
+ */
+export type NonConversionReason = 'unavailable' | 'declined' | 'unservable' | 'unresolved';
+
+/**
+ * A period someone asked for. Doubles as DEMAND TELEMETRY: a request we could not fill is evidence
+ * about pricing and calendar pressure that no booking record can show, because it never became one.
+ */
+export interface RequestedPeriod {
+  start: string;        // 'YYYY-MM-DD'
+  end: string;          // 'YYYY-MM-DD'
+  askedOn: string;      // 'YYYY-MM-DD'
+  outcome: 'unavailable' | 'declined' | 'booked' | 'unresolved';
+  note?: string;
+}
+
 export interface Guest {
   id: string;
+  /**
+   * 'lead' = contacted us directly but never stayed. Absent/'guest' = has stayed (the historical
+   * default). Leads live on this collection rather than a parallel one so that threads, notes,
+   * consent, suppression, frequency caps and the send gateway — all keyed on a guest doc — work
+   * unchanged, and so a lead who books keeps its id, and with it its whole conversation history.
+   */
+  kind?: 'guest' | 'lead';
+  /**
+   * How much to trust `firstName`. WhatsApp hands over a push-name that may be a nickname, all
+   * caps, emoji-laden, or absent entirely — greeting someone by it is a real risk.
+   */
+  nameSource?: 'booking' | 'pushname' | 'manual' | 'unknown';
+  leadSource?: string;                        // 'whatsapp' | 'phone' | 'website' | ...
+  firstContactAt?: string;                    // 'YYYY-MM-DD' — a lead's recency anchor (there is no stay)
+  nonConversionReason?: NonConversionReason;
+  requestedPeriods?: RequestedPeriod[];
   email?: string; // Normalized lowercase (optional for imported guests without email)
   firstName: string;
   lastName?: string;
@@ -458,6 +499,69 @@ export interface WhatsAppThread {
   lastMessageTs?: string;     // ts of the newest captured message — drives incremental top-up
   firstFetchedAt?: SerializableTimestamp;
   lastFetchedAt?: SerializableTimestamp;
+}
+
+/**
+ * One immutable capture of a conversation, exactly as parsed, before reconciliation.
+ * `whatsappThreads/{guestId}` is the derived view; this is the source of record — the insurance
+ * that lets a thread be rebuilt when the chat itself is gone (disappearing timers, trimmed phones).
+ */
+export interface WhatsAppThreadImport {
+  id: string;
+  guestId: string;
+  phone: string;
+  source: 'export' | 'scrape';
+  label: string;              // export filename / capture label
+  messageCount: number;
+  firstTs?: string;
+  lastTs?: string;
+  messages: WhatsAppMessage[];
+  importedAt: SerializableTimestamp;
+}
+
+// ============================================================================
+// Guest notes — the interactions that never touched WhatsApp
+// ============================================================================
+
+/**
+ * `call`/`inperson` are real two-way TOUCHES: they prove engagement and they count against pacing
+ * floors (you must not send a "we haven't spoken in a while" message the day after a phone call).
+ * `observation` is something the owner noticed, not an exchange — context only, never a touch.
+ */
+export type GuestNoteKind = 'call' | 'inperson' | 'observation';
+
+/** A specific claim a note licenses the copywriter to make, tagged as `note:<key>` in factsUsed. */
+export interface GuestNoteFact {
+  key: string;
+  value: string;
+}
+
+/**
+ * One recorded interaction or observation that lives outside the message vault — overwhelmingly a
+ * phone call. Without these, a relationship conducted by phone is invisible: the system reads three
+ * unanswered outbound WhatsApps and concludes "silent — never replied" about someone who was warm
+ * and enthusiastic on the phone. That inversion is the reason this type exists.
+ *
+ * A note is OWNER RECALL, not system truth. It is unverified, it can be wrong, and it goes stale.
+ * So it is truth-tiered: `assertable` decides whether the copywriter may state it at all, `facts`
+ * narrows that to specific claims, and `expiresAt` retires notes whose relevance has a shelf life
+ * ("planning something for October" is worthless in December).
+ */
+export interface GuestNote {
+  id: string;
+  guestId: string;
+  occurredAt: string;          // 'YYYY-MM-DD' — when it HAPPENED, not when it was typed
+  kind: GuestNoteKind;
+  text: string;                // the owner's own words
+  initiatedBy?: 'owner' | 'guest';
+  /** May the copywriter assert this? Default false — a note shapes tone; it does not license claims. */
+  assertable: boolean;
+  /** Specific assertable claims. Only meaningful when `assertable` is true. */
+  facts?: GuestNoteFact[];
+  /** Withheld from packs after this date. */
+  expiresAt?: string;          // 'YYYY-MM-DD'
+  createdAt: SerializableTimestamp;
+  createdBy?: string;
 }
 
 export interface SuppressionEntry {


### PR DESCRIPTION
The engagement layer could only see WhatsApp messages from people who had already stayed. Two blind spots followed, and both produced *wrong* readings rather than merely incomplete ones.

## What was broken

**A system notice became a reply.** WhatsApp renders chat events as messages. "uses a default timer for disappearing messages" parsed as an INBOUND message stamped later than the real conversation, so it sorted last and became the thread's newest message. A real lead who had never written to us read as `state: 'active'` — "replied today". With the notice removed he read as `'silent'` — "messaged, never replied". Both wrong, in opposite directions, about someone who had been warm and enthusiastic on the phone.

**The importer overwrote history.** `replace: true` was right for superseding the lossy browser scrape and wrong for everything else. An export reflects one device at one moment — a restored phone or a disappearing-messages timer yields a legitimately short file, and for a self-erasing chat the vault is the only surviving copy.

**A phone relationship was invisible.** Pacing read WhatsApp outbound only, so the system would happily send "we haven't spoken in a while" the day after a call.

## What changed

- `SYSTEM_NOTICE_RE` drops chat events before they reach a thread; the export parser keeps paragraph breaks and discards bare `[ts] Sender:` artifacts.
- `reconcileAuthoritative()` matches across sources on a loose fingerprint (minute + direction + normalized text — the scrape only ever knew the minute), so duplicates are superseded and anything the export lacks is **rescued**. Every batch is archived to `whatsappThreadImports` first, so threads are rebuildable without the phone.
- `guestNotes`: truth-tiered owner recall. `assertable` gates the copywriter's groundedFacts whitelist, `expiresAt` retires notes with a shelf life, context-only notes shape tone but are never asserted. A logged call counts as engagement AND as a pacing touch.
- `guests.kind='lead'`: leads live on `guests`, never a parallel collection — threads, notes, consent, suppression, caps and the send gateway all key on a guest doc, and a lead who books keeps its id, so the conversation survives promotion. `nonConversionReason`'s four cases license very different messages. `requestedPeriods` doubles as demand telemetry in `situationPack`.
- The copywriter branches on `audienceKind`; `validateDrafts` hard-rejects any draft asserting a past stay for someone who never stayed.
- `/admin/contacts`: the capture surface. Notes only existed behind a CLI, and a note system that needs a terminal never gets filled.

## Verified against production data

Both real leads imported. The phone-first one now reads `state=active, replies=0, calls=1, lastExchangeVia=call`, with `requestedPeriod`, `weCouldNotHost` and `note:openToFuture` as grounded facts, and no invented name.

Truncation test on the real file: a deliberately shortened export (1 message vs 3 stored) left **all 3 intact** with explicit warnings. Under the old behaviour that would have destroyed two messages silently.

375 tests pass (24 new), `npm run build` clean. Firestore rules already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)