### PR TITLE
OTA price parity — a probing system that cannot report a partial run as a whole one

### DIFF
--- a/.claude/skills/ota-parity/SKILL.md
+++ b/.claude/skills/ota-parity/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: ota-parity
+description: >-
+  On-demand price-parity check between the direct website and the OTA listings
+  (Airbnb, Booking.com, VRBO, Travelminit). Reads a deterministic probe pack
+  (scripts/parity-pack.ts), captures each channel's guest-facing total in Chrome,
+  and judges each window on NET economics — not just the headline gap. Use when
+  the owner asks "am I still cheaper than the OTAs", before launching a campaign
+  on a window, or after changing prices on any channel.
+---
+
+# OTA Parity
+
+You are the channel-pricing analyst for a small rental business. Your job is to answer one question
+per window — **"if a guest compares us with the OTAs today, do they book direct, and are we better
+off when they do?"** — and to say plainly where the answer is no.
+
+You **measure and recommend. You never change a price**, on the site or on any channel.
+
+---
+
+## 1. The economics, which are the whole point
+
+The guest-facing gap is not the decision. What matters is what the owner **keeps**.
+
+Commission never happens on a direct booking. At ~18.5% (Airbnb) and ~23% (Booking.com), against ~2.9%
+card costs direct, the owner can charge a guest **meaningfully less** and still earn **more**:
+
+| Channel | Commission | Room to undercut before net is equal |
+|---|---|---|
+| Airbnb | 18.5% | **~16.1%** |
+| Booking.com | 23% | **~20.7%** |
+
+So three numbers matter for every window, all computed by `src/lib/growth/parityMath.ts` — **use it,
+never recompute by hand**:
+
+- **`indifferencePrice`** — the direct price at which the owner earns exactly what the OTA booking
+  would have paid. This is the floor. Below it, you would genuinely be better off letting the OTA
+  have the booking.
+- **`netAdvantage`** — what the owner actually gains at the current direct price.
+- **`headroomPct`** — the structural room, above.
+
+The four verdicts:
+
+- **`losing`** — direct costs the guest *more*. The worst state: the guest books the OTA and the
+  commission comes off the top. Always report these first.
+- **`thin`** — cheaper, but by less than the target. Rarely enough to make anyone switch.
+- **`healthy`** — cheaper by at least the target, and still above indifference.
+- **`overshoot`** — below indifference. Cheap for no reason; money left on the table.
+
+## 2. Promotions: do not reflexively chase them
+
+When a channel is running a promotion, its guest price drops and every window against it looks bad.
+**Matching a deep promo is a choice, not an obligation** — the promo is a deliberate, temporary act on
+that channel, and mechanically undercutting it can wreck the direct rate the rest of the year.
+
+So when a promo is detected (the page shows a struck-through original):
+
+- Report parity against **both** the promo price and the list price (`vsListGapPct`). "Fine when the
+  promo ends, exposed while it runs" is a very different situation from "structurally overpriced".
+- Say whether the promo price still leaves room: as long as direct sits **above `indifferencePrice`**,
+  undercutting the promo still earns more than the OTA booking would. Give the owner that number and
+  let them decide.
+- If a target-sized discount would price **below** indifference, say so explicitly and recommend
+  addressing the promotion on that channel instead of matching it here.
+
+## 3. The probing strategy
+
+### 3.1 Two calendars, and why neither is computed
+
+The windows that decide this property's year **move**: Orthodox Easter swings five weeks, the school
+calendar is re-set by ministerial order each year, and a holiday landing on a Tuesday creates a bridge
+that doesn't exist the next year. So they are **fetched facts, never derived**:
+
+> Deriving Orthodox Easter or the school calendar in code is how you poison every downstream occasion
+> decision. See `scripts/seed-holidays.ts` — every row carries a `source` URL and an `official` flag.
+
+The probe list is the **union of two calendars**, because they answer different questions and are not
+the same set:
+
+| Source | Answers | Notes |
+|---|---|---|
+| **`holidays` collection** (seeded, official, sourced) | *Why* people travel | `type: major` = a real travel window · `school-break` · `bridge-day` · `minor` = a legal day off that historically does not move leisure demand, deliberately skipped. This is the **same source the situation pack reads**, so parity and the brain cannot disagree about what a period is. |
+| **`dateOverrides`** (the property's own pricing) | What the owner charges a *premium* for | Clustered by `reason` **and** adjacency, so Christmas doesn't merge into New Year. |
+
+**Probing only the legal calendar would miss the single most valuable window of the year.** New Year's
+Eve (30–31 Dec) is this property's highest rate — 2,351/night, min-stay 3 — and it is not a public
+holiday, so it appears in `dateOverrides` and nowhere in `holidays`.
+
+Trust the seeded classification rather than second-guessing it, and respect what the rows say about
+themselves. Some carry real uncertainty in their notes — e.g. *"Vacanta mobila: NOT a 3-week break;
+each county picks ONE week inside this window; București's choice is the one that matters for
+Prahova"*. Repeat that caveat in the report instead of implying the whole window is a break.
+
+**When the seeded data runs out, say so.** The pack reports `holidayData.stale` and the date coverage
+ends. Periods past that date are simply not probed — never let that read as "nothing found". Re-seed
+with `npx tsx scripts/seed-holidays.ts`.
+
+### 3.2 Horizon and cadence
+
+**Probe 6–8 months ahead** (the pack defaults to 8). That is far enough that peak pricing is still
+changeable and OTA promotions are visible before they do damage, and near enough that the calendar is
+real rather than speculative.
+
+**Re-run every 4–6 weeks.** Between runs, the peaks stay stable so you can compare like for like, while
+the ordinary-weekend samples deliberately **rotate** — the pack picks a different Friday each run — so
+successive runs broaden coverage instead of re-measuring the same weekend forever. A period beyond the
+horizon on one run (Easter, when you are eight months out from it) simply arrives in a later run.
+
+### 3.3 The coverage matrix
+
+Cover every combination that can behave differently — that is what "all possibilities" means here.
+Three dimensions, sampled rather than exhausted:
+
+**Period type** — each behaves differently and each earns its own probe:
+
+| Type | Why it is probed | Probe shape |
+|---|---|---|
+| **Peaks** (Christmas, New Year, Easter, Rusalii) | Highest rate, longest min-stay, most likely to drift. Christmas was found +22% *dearer* than Airbnb. | Natural length, **both occupancies** |
+| **Bridged holidays** (`punte`) | Exist only in some years; high demand, short window | Natural bridge length |
+| **School breaks** | Families travel, and **midweek becomes sellable** — the only time it is | One **midweek** + one **full week** |
+| **Ordinary weekends** | The baseline volume; one per otherwise-uncovered month | 2 nights, rotated |
+| **Advertised windows** | Losing here costs twice — the click and the commission | Campaign's own dates |
+
+**Length class** — `short` (≤2n) · `mid` (3–4n) · `long` (≥ first LoS tier). The pack guarantees at
+least one of each, because **the length-of-stay discount flips the comparison**: one August period was
+**+24% dearer** at 2 nights and at parity across 7. It also probes deliberately on both sides of the
+tier, which is how the "7 nights costs 669 lei *less* than 6" cliff became visible.
+
+**Occupancy** — two headcounts, on every peak and every flat-rate window. Not optional: holiday
+overrides carry `flatRate: true`, so extra guests are free on those nights while the OTAs charge per
+guest. The same NYE week measured **−8.7%** at 3 guests and **−20%** at 6. **A check that probes one
+occupancy will confidently report the wrong answer.**
+
+But the upper figure must be a headcount **every channel actually offers**, not our `maxGuests`. This
+property's doc says 7 while the Airbnb listing advertises **6 guests · 6 beds** — asking Airbnb for 7
+gets no quote, and the pair would be incomparable. Compare at **3 and 6** here. Set
+`property.channelPricing.compareOccupancies`, or pass `--guests 3,6`; the pack prints which source it
+used and warns when it fell back to `maxGuests`.
+
+*(The 7-vs-6 mismatch between our property record and the Airbnb listing is itself worth reporting —
+a guest searching for 7 never sees the listing, while our own site would happily quote them.)*
+
+**Midweek** — probe it explicitly, not only inside school breaks. Midweek is the hardest inventory to
+sell and the place an OTA promotion does the most damage, because there is no weekend demand to fall
+back on. The pack samples an ordinary Mon–Thu every other month.
+
+### 3.4 The run loop — work the list until it is empty
+
+**This is the part that makes a run complete rather than partial.** The unit of work is a **cell**:
+one (window × occupancy × channel), with a stable id. Every cell is owed an outcome. You do not decide
+when the run is finished — coverage does.
+
+```bash
+# 1. Build the probe list; direct prices are quoted and RECORDED automatically.
+npx tsx scripts/parity-pack.ts <slug> --guests 3,6 --max 24
+
+#    It prints the worklist, the coverage, and every outstanding cell.
+
+# 2. For EACH outstanding cell, capture in Chrome and record it — one write path, always:
+npx tsx scripts/parity-capture.ts --property <slug> --channel airbnb \
+  --in 2026-12-24 --out 2026-12-29 --guests 3 \
+  --total 4298 --list 5603 --promo \
+  --url "<the exact url>" --session "logged out, RON"
+
+#    A channel that will not quote is an OUTCOME, not a gap:
+npx tsx scripts/parity-capture.ts ... --status refused --reason "Airbnb min stay 4 nights"
+#    A failed capture is unfinished work — record it so it gets retried:
+npx tsx scripts/parity-capture.ts ... --status error --reason "bot check"
+
+# 3. Re-render the table FROM THE STORE. Never hand-assemble it.
+npx tsx scripts/parity-report.ts <slug>
+
+# 4. Repeat 2–3 until STATUS: COMPLETE, or until the remaining cells genuinely cannot be captured —
+#    in which case they must be recorded as `refused`/`error` with a reason, never left blank.
+```
+
+**Rules that are not negotiable:**
+
+- **Never hand-type numbers into an ad-hoc script or straight into a message.** They go through
+  `parity-capture.ts`. That is what gives every figure a timestamp, a URL, a session state and a
+  provenance (`api` for the engine, `browser` for a page).
+- **Never present a table you assembled yourself.** `parity-report.ts` renders it, showing `?` for
+  every uncaptured cell and printing `STATUS: INCOMPLETE` with the outstanding list. A partial run
+  must look partial.
+- **Never infer a missing cell** from a neighbouring window, a previous run, or a per-guest fee you
+  worked out. If it wasn't captured, it is `?`.
+- **Report coverage in your summary**, always: `captured/total`, and the oldest observation age.
+- Observations are append-only, so re-running a cell adds a data point rather than erasing one — that
+  is how the 4–6 week cadence turns into drift over time.
+
+Scoping is fine (`--only crăciun`, `--max 12`) — the pack reports what it dropped. Saying "I checked
+the peaks, here is the coverage, these cells remain" is honest. Presenting a subset as the picture is
+not.
+
+## 4. Capturing the OTA side (Chrome)
+
+The pack deliberately does not touch the OTAs — that needs a real browser. Load the
+`claude-in-chrome` skill and note the one non-obvious mechanic:
+
+> **`computer` screenshots, `get_page_text` and `find` all TIME OUT on Airbnb and Booking.com** —
+> those pages never reach `document_idle`. **Use `javascript_tool`**: navigate, `await` ~6–7s, then
+> read `document.body.innerText`.
+
+**Airbnb** — `https://www.airbnb.com/rooms/<id>?check_in=YYYY-MM-DD&check_out=YYYY-MM-DD&adults=N`
+Read: the `"… RON total"` line, any struck-through original, the `"N nights in …"` and date lines
+(**always confirm these match the probe** — a silently ignored parameter is the easiest way to record
+a wrong number), and whether `"This host is offering a discount"` is present.
+
+**Booking.com** — `…?checkin=…&checkout=…&group_adults=N&no_rooms=1&selected_currency=RON`
+Read `"Original price X Current price Y"` and take the **lowest** rate plan. Note if
+`"Sign in to unlock the members-only price"` appears — the real floor is below what you can see.
+
+Rules while capturing:
+
+- **Read only.** Never sign in, never submit a reservation, never enter payment details.
+- If a CAPTCHA or bot check appears, **stop and tell the owner.** Do not attempt to work around it.
+- Record the state you captured in: logged-in or not, currency, and the exact URL.
+- A probe you could not capture is **`unknown`**, never a pass. Say which rows are missing.
+
+## 5. Judging across channels
+
+- The binding constraint is the **cheapest** channel (`bestOffer`), never the average. Averaging hides
+  the one channel that is actually taking the booking.
+- Also report **`channelSpreadPct`** — how far apart the OTAs are on the same nights. A wide spread
+  (one real case: Airbnb 1,476 vs Booking 1,907, a **29%** gap) is its own problem: it drags down the
+  floor direct must beat and looks incoherent to a guest who checks twice. The fix is on the channel,
+  and it is entirely in the owner's control.
+
+## 6. What to produce
+
+**The table is `parity-report.ts`'s output, pasted as-is.** Do not rebuild it, reorder it, or drop its
+`?` rows — those rows are the point.
+
+Around it, worst first:
+
+1. **Coverage line, before anything else** — `captured/total`, oldest observation age, and whether the
+   status is COMPLETE. If it is incomplete, say so in the first sentence, not in a footnote.
+2. **The losing windows, in detail** — for each: the indifference price, the recommended band, and
+   whether the cause is an OTA promotion or the direct price itself. Say which.
+3. **Overshoot windows** — priced below indifference. These cost real money and are easy to miss
+   because the headline gap looks flattering.
+4. **Cross-channel spread**, where two or more channels were captured.
+5. **What could not be measured and why** — refusals with their reason, errors, channels with no
+   listing URL. Never let an absence pass as a finding.
+6. **Recommendations** — separating "change the promotion on channel X" from "change the direct price
+   for window Y". Prefer the former: cutting direct rates to chase a promo burns the best-margin
+   channel to fix a problem created on a worse one.
+
+Cite every number to the cell it came from. Never state a price you did not read or compute, and never
+fill a gap with an estimate.
+
+## 7. Standing constraints
+
+- Compare **guest-facing totals** to guest-facing totals. Mixing a host rate with a guest total is the
+  classic error and will make direct look far better than it is.
+- Airbnb totals may exclude local taxes; treat gaps under ~3% as noise, not as a finding.
+- Never recommend pricing below `indifferencePrice`.
+- The commission rates live in `property.channelPricing` when configured; the pack falls back to
+  documented defaults and **says which** — repeat that caveat in the report if they are not persisted.
+- You never change prices. Recommendations go to the owner.

--- a/docs/ota-parity-system.md
+++ b/docs/ota-parity-system.md
@@ -1,0 +1,224 @@
+# OTA Price Parity — keeping the direct channel the best place to book
+
+**Status:** design agreed 2026-08-07; slice 1 (skill + pack + economics) built. Slices 2–3 to build.
+**Owner rule:** the direct site should be **5–10% under the best OTA offer** — but the real constraint
+is net, not headline (§2).
+
+**Related:** `docs/promotion-system-architecture.md` (the brain this feeds), memory `ota-price-parity`
+(measured state, 2026-08-06).
+
+---
+
+## 0. Why this exists
+
+On 2026-08-06 a live Meta campaign was driving paid traffic to the direct site. A hand check of ten
+windows found:
+
+- **two windows where direct cost the guest MORE than Airbnb** — Christmas (+22%) and Aug 28–30
+  (+24%), the latter *inside the window the campaign was promoting*;
+- only two of ten met the 10% rule;
+- the cause was **promotions running on both OTAs** (11–28% off), invisible from inside the app.
+
+Nothing in the system could have caught this. The ads arm happily promoted a window where Airbnb was
+cheaper. That is the gap this closes.
+
+## 1. The constraint that decides the architecture
+
+Capturing OTA prices needs a **real browser**. On Airbnb and Booking.com the extension's `computer`,
+`get_page_text` and `find` tools all time out — those pages never reach `document_idle`; only
+`javascript_tool` gets through. Cloud Run has no browser, and a headless rebuild means Playwright plus
+proxies plus fighting bot detection: brittle, and on the wrong side of both sites' terms.
+
+Therefore:
+
+> **Capture is episodic and happens where a human browser is (a Claude Code session).
+> Evaluation is continuous and happens in the app.**
+
+Every decision below follows from that split.
+
+## 2. The economics — why "10% under" is the wrong single number
+
+Commission never happens on a direct booking. Against ~2.9% card costs:
+
+| Channel | Commission | Room to undercut before net is equal |
+|---|---|---|
+| Airbnb | 18.5% | **~16.1%** |
+| Booking.com | 23% | **~20.7%** |
+
+So a flat 10% is arbitrary in both directions — timid where commission is high, and potentially
+loss-making against a deep promotion. `src/lib/growth/parityMath.ts` computes what actually matters:
+
+- **`indifferencePrice`** — where owner net is identical either way. **The floor.**
+- **`netAdvantage`** — what the owner gains at the current direct price.
+- **`headroomPct`** — the structural advantage, independent of price.
+- **Verdicts**: `losing` · `thin` · `healthy` · `overshoot` (the last = cheaper than necessary).
+
+Worked example (real numbers, Aug 28–30): Airbnb guest total 1,476. Indifference is **1,239**. Price
+direct at 1,402 (5% under) and the guest saves 74 lei while the owner keeps **~158 more** than the
+Airbnb booking would have paid. Both sides win — which is the whole argument for the direct channel.
+
+**Promotions are not obligations.** A promo is a deliberate, temporary act on that channel; chasing it
+mechanically can wreck the direct rate year-round. So parity is reported against **both** the promo
+price and the list price, and the recommendation distinguishes "fix the promo on that channel" from
+"the direct price is wrong". When a target-sized discount would fall below indifference, the system
+says so and recommends **not** matching.
+
+## 3. Two rules, not one
+
+- **R1 — margin.** `direct ≤ min(channels) × (1 − target)`. Against the **minimum**, never the
+  average: Airbnb was cheapest in 3 of 4 cross-checked windows, and averaging would have hidden the
+  Christmas failure.
+- **R2 — channel spread.** `max/min − 1` across channels for the same nights. One measured case:
+  Airbnb 1,476 vs Booking 1,907 — a **29% spread**. That is a channel-management problem: it drags
+  down the floor direct must beat, and looks incoherent to a guest who checks twice. It is also
+  entirely within the owner's control, which often makes it the more actionable of the two.
+
+## 4. The probing strategy
+
+### 4.1 Fetched facts, and two calendars
+
+The windows that decide the year **move**: Orthodox Easter swings five weeks, the school calendar is
+re-set by ministerial order annually (and the February break varies by county), and a holiday landing
+on a Tuesday creates a bridge that doesn't exist the next year.
+
+They are therefore **fetched, never computed** — the doctrine already established by
+`scripts/seed-holidays.ts`, which records a source URL and an `official` flag per row: *"deriving
+either in code is how you poison every downstream occasion decision."* This was proven during the
+build: a computed version got **every school break wrong** (autumn Oct 30–Nov 8 vs the official
+Oct 24–Nov 1; winter Dec 20–Jan 8 vs Dec 23–Jan 10) and invented a fixed February ski week where the
+official row says one week is chosen per county from a three-week window.
+
+The probe list is the **union of two calendars**, which are not the same set:
+
+| Source | Answers | |
+|---|---|---|
+| `holidays` (seeded, official) | *Why* people travel | `major` / `school-break` / `bridge-day` used; `minor` deliberately skipped. Same source the situation pack reads, so parity and the brain agree on what a period is. |
+| `dateOverrides` (own pricing) | What the owner charges a premium for | Clustered by `reason` + adjacency so Christmas ≠ New Year. |
+
+**Both are needed.** New Year's Eve (30–31 Dec) is the property's highest rate of the year — 2,351/night,
+min-stay 3 — and is *not* a public holiday. It exists only in `dateOverrides`. Probing the legal
+calendar alone would skip the single most valuable window of the year.
+
+When the seeded data runs out the pack reports `holidayData.stale` plus the coverage end date, so an
+un-probed period never reads as "nothing found".
+
+### 4.2 Horizon and cadence
+
+**6–8 months ahead** (default 8): far enough that peak pricing is still changeable and OTA promos are
+visible before they do damage; near enough that the calendar is real. **Re-run every 4–6 weeks** —
+peaks stay stable so runs are comparable, while ordinary-weekend samples **rotate deterministically**
+so coverage broadens instead of re-measuring one weekend forever. Periods beyond the horizon simply
+arrive in a later run.
+
+### 4.3 The coverage matrix
+
+Three dimensions, sampled rather than exhausted:
+
+| Period type | Why | Shape |
+|---|---|---|
+| Peaks (Christmas, New Year, Easter, Rusalii) | Highest rate; Christmas was found +22% *dearer* than Airbnb | Natural length, **both occupancies** |
+| Bridged holidays (`punte`) | Exist only in some years; high demand | Natural bridge |
+| School breaks | Families travel — **midweek becomes sellable** | Midweek + full week |
+| Ordinary weekends | Baseline volume; one per uncovered month | 2 nights, rotated |
+| Advertised windows (`adCampaigns`) | Losing here costs twice: click and commission | Campaign dates |
+
+**Length class** — `short` / `mid` / `long`, at least one of each guaranteed, and deliberately probed
+on both sides of the LoS tier. That is how "7 nights costs 669 lei *less* than 6" surfaced.
+
+**Occupancy** — `baseOccupancy` always, `maxGuests` on every peak and flat-rate window. Not optional:
+`flatRate: true` makes extra guests free while OTAs charge per guest, so the same NYE week reads
+**−8.7%** at 3 guests and **−20%** at 6.
+
+Practical guards: the run is capped (`--max`, default 24) and drops lower-priority rows first while
+reporting how many; partly-booked periods slide to the first sellable window inside them; a window
+reached from two directions keeps the higher-signal label (ADVERTISED beats "summer break").
+
+**Sentinels (slice 2):** probe a handful often, the long tail rarely. When a sentinel moves, a promo
+changed — trigger a wider sweep. Coverage without volume.
+
+## 5. Observations calibrate a model; the model does the watching
+
+Fresh OTA prices are not needed to know there is a problem. Each observation teaches the *relationship*
+between a channel's guest total and ours for that window shape. Fit a small per-channel model from
+those, and the app can then watch **continuously and for free**: change a season, add an override, or
+tip a LoS tier, and it recomputes predicted parity across the whole calendar and says *"Christmas is
+now 22% above predicted Airbnb — go re-measure."*
+
+Scraping stops being the monitoring mechanism and becomes the **calibration** mechanism: rare, cheap,
+honest.
+
+## 6. Honesty rules (where systems like this rot)
+
+- Every observation stores `capturedAt`, channel, login state, promo-banner presence, **both** the
+  struck-through original and the current price, and the exact URL.
+- A stale or failed probe is **`unknown`**, never `pass`. A dashboard that reads green because a
+  capture broke is worse than no dashboard.
+- Confidence decays with age — a 40-day-old Christmas observation is a hypothesis.
+- Record promo state explicitly: the entire root cause was promotions nobody was tracking, and a
+  system that stores only the final number cannot explain *why*.
+- Read-only, always. Never sign in, never complete a reservation. On a CAPTCHA, stop and report.
+
+## 7. Where it plugs in
+
+1. **Situation pack** → the analyst can raise *"you are advertising Aug 23–Sep 7, and Aug 28–30 is 24%
+   cheaper on Airbnb"* as a flag with money attached — the exact mistake the system could not see.
+2. **Ads guard** → `validateAdPlan` already enforces spend cap and geo. Add a parity check so the
+   system refuses to promote, or loudly warns about, a window an OTA undercuts. Paying for traffic to
+   your dearer channel is a bug worth encoding as one.
+
+## 8. The closed loop — why a run cannot be silently partial
+
+The first run of this system produced a table with holes in it, hand-assembled from numbers that were
+read off pages and retyped. Nothing was lying, but the gaps were invisible: an uncaptured cell simply
+had no row, so the reader saw a tidy grid and reasonably took it for the whole picture. Two rows even
+mixed capture dates a day apart, because nothing carried a timestamp.
+
+The fix is that **the unit of work is a cell**, not a window: one `(window × occupancy × channel)`,
+with a stable id (`propertyId|checkIn|checkOut|guests|channel`). Every cell is owed an outcome.
+
+| Piece | Role |
+|---|---|
+| `src/lib/growth/parityWorklist.ts` | Cell ids, `buildWorklist`, `computeCoverage`, `outstandingCells`. Pure, 13 tests. |
+| `src/services/growth/parityObservations.ts` | Append-only writes to `channelPriceObservations`; newest-per-cell reads. |
+| `scripts/parity-pack.ts` | Builds probes, quotes direct, **records the direct cells itself**, prints coverage + outstanding. |
+| `scripts/parity-capture.ts` | The single write path for a browser capture. |
+| `scripts/parity-report.ts` | Renders the table **from the store**. |
+
+Enforced properties:
+
+- A cell with no observation prints **`?`**, counts as `missing`, and appears in the outstanding list.
+- A channel refusing to quote (Airbnb's 4-night minimum on 26–29 Oct) is a **recorded outcome with a
+  reason** — `parity-capture.ts` rejects a non-`captured` status that has no reason.
+- An **errored** capture blocks `complete`; it is unfinished work, not an answer.
+- Observations older than the freshness budget are **stale** and re-queued, so a 4–6 week cadence
+  never quietly reports last quarter's prices.
+- `complete` requires *nothing missing, nothing errored, nothing stale*. Anything else prints
+  `STATUS: INCOMPLETE — do NOT treat this table as the whole picture.`
+- Append-only storage means re-running a cell **adds** a data point. Cell ids are stable across runs,
+  so the cadence produces drift history rather than disconnected snapshots.
+- Direct prices are recorded with `source: 'api'` — provenance matters, because the engine's number is
+  not automatically what a browser renders (this site once showed `US$401` where the engine said
+  `1,838 lei`).
+
+## 9. Build order
+
+- **Slice 1 — on-demand skill. ✅ BUILT.** `parityMath.ts` (14 tests), `parityWorklist.ts` (13 tests),
+  `parityObservations.ts`, the three CLIs, `channelPriceObservations` + rules, and the skill.
+- **Slice 2 — the evaluator in-app.** `channelPricing` persisted per property (rates are currently
+  documented defaults); the fitted per-channel model; R1/R2 recomputed continuously against the live
+  calendar; a `/admin` surface showing coverage and staleness. Sentinels here.
+- **Slice 3 — the two integrations** in §7.
+
+The model cannot be fitted before there are observations to fit it to — which is exactly what slice 1
+now produces, durably.
+
+## 9. Open judgement calls
+
+- **Per-channel targets rather than one global number.** Beating Booking by 10% is cheap (it is rarely
+  the floor); beating Airbnb by 10% during a 28% promo may be impossible without destroying margin.
+- **Persist `property.channelPricing`.** Commission rates are currently documented defaults
+  (18.5% / 23% / 2.9%) and the pack says so. Until persisted, every report carries that caveat.
+- **The flat-rate group cliff is an unexploited asset.** For six guests at NYE, direct is 20–26%
+  cheaper than the OTAs, and nothing on the site says so. That is a marketing decision, not a pricing
+  bug — but it is worth deciding deliberately, because the same flag means a 7-person holiday booking
+  earns no more than a 3-person one.

--- a/firestore.rules
+++ b/firestore.rules
@@ -285,6 +285,13 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only (page-posts server actions)
     }
 
+    match /channelPriceObservations/{observationId} {
+      // Append-only record of what each channel quoted for a given window/occupancy — the evidence
+      // the parity report is built from. Append-only so a cell's history IS its price history.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (parity-capture / parity-pack)
+    }
+
     match /situationReports/{reportId} {
       // The in-app analyst's persisted Situation Reports (Move 2 · P3) — super-admin/owner read.
       allow read: if isSuperAdmin() || isPropertyOwner();

--- a/scripts/parity-capture.ts
+++ b/scripts/parity-capture.ts
@@ -1,0 +1,69 @@
+/**
+ * parity-capture — record ONE observation into `channelPriceObservations`.
+ *
+ * The single write path. It exists so captured numbers go from the page into storage through one
+ * validated door, instead of being retyped into a throwaway script — which is how a run ends up
+ * partial, undated and unverifiable.
+ *
+ * A non-`captured` status REQUIRES a reason. "Airbnb enforces a 4-night minimum" is an outcome; a
+ * blank is not.
+ *
+ *   npx tsx scripts/parity-capture.ts \
+ *     --property prahova-mountain-chalet --channel airbnb \
+ *     --in 2026-12-24 --out 2026-12-29 --guests 3 \
+ *     --total 4298 --list 5603 --promo \
+ *     --url "https://www.airbnb.com/rooms/43265214?..." --session "logged out, RON"
+ *
+ *   # a channel that will not quote:
+ *   ... --status refused --reason "min stay 4 nights"
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { cellId, type ObservationStatus } from '@/lib/growth/parityWorklist';
+import { recordObservation } from '@/services/growth/parityObservations';
+
+const arg = (name: string): string | null => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > -1 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--') ? process.argv[i + 1] : null;
+};
+const flag = (name: string) => process.argv.includes(`--${name}`);
+
+(async () => {
+  const propertyId = arg('property') ?? 'prahova-mountain-chalet';
+  const channel = arg('channel');
+  const checkIn = arg('in');
+  const checkOut = arg('out');
+  const guests = Number(arg('guests'));
+  const status = (arg('status') ?? 'captured') as ObservationStatus;
+  const total = arg('total');
+  const list = arg('list');
+  const reason = arg('reason') ?? undefined;
+
+  if (!channel || !checkIn || !checkOut || !guests) {
+    console.error('required: --channel --in YYYY-MM-DD --out YYYY-MM-DD --guests N');
+    process.exit(1);
+  }
+
+  const nights = Math.round((Date.parse(checkOut) - Date.parse(checkIn)) / 86_400_000);
+  const id = cellId(propertyId, checkIn, checkOut, guests, channel);
+
+  try {
+    await recordObservation({
+      propertyId, cellId: id, checkIn, checkOut, nights, guests, channel, status,
+      guestTotal: total !== null ? Number(total) : null,
+      listTotal: list !== null ? Number(list) : null,
+      promoActive: flag('promo'),
+      reason,
+      source: channel === 'direct' ? 'api' : 'browser',
+      url: arg('url') ?? undefined,
+      sessionState: arg('session') ?? undefined,
+      capturedBy: arg('by') ?? 'ota-parity skill',
+    });
+    console.log(`recorded ${status.padEnd(11)} ${channel.padEnd(12)} ${checkIn}→${checkOut} ${guests}g` +
+                (total ? `  ${total} RON` : '') + (reason ? `  (${reason})` : ''));
+  } catch (e) {
+    console.error(`REFUSED: ${(e as Error).message}`);
+    process.exit(1);
+  }
+})();

--- a/scripts/parity-pack.ts
+++ b/scripts/parity-pack.ts
@@ -1,0 +1,498 @@
+/**
+ * parity-pack — the deterministic half of the OTA parity check.
+ *
+ * Builds the PROBE LIST (which windows are worth comparing, and at which occupancies) and attaches a
+ * live direct quote to each. It never touches an OTA: capturing those needs a real browser, which is
+ * what the `ota-parity` skill is for. Facts here, judgement there — the same split as situation-pack.
+ *
+ * The probe list is DERIVED, not hardcoded: date overrides, length-of-stay tiers, occupancy bounds and
+ * live campaigns all come from the property's own configuration, so it works for any property.
+ *
+ *   npx tsx scripts/parity-pack.ts [propertySlug] [--json] [--months N] [--only <substring>]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { headroomPct, type ChannelEconomics, type DirectEconomics } from '@/lib/growth/parityMath';
+import { buildWorklist, computeCoverage, outstandingCells } from '@/lib/growth/parityWorklist';
+import { latestByCell, recordObservation } from '@/services/growth/parityObservations';
+import { cellId } from '@/lib/growth/parityWorklist';
+
+const SLUG = process.argv[2]?.startsWith('--') ? 'prahova-mountain-chalet' : (process.argv[2] ?? 'prahova-mountain-chalet');
+const AS_JSON = process.argv.includes('--json');
+const ONLY = (() => { const i = process.argv.indexOf('--only'); return i > -1 ? process.argv[i + 1] : null; })();
+const MONTHS = (() => { const i = process.argv.indexOf('--months'); return i > -1 ? Number(process.argv[i + 1]) : 8; })();
+const MAX_PROBES = (() => { const i = process.argv.indexOf('--max'); return i > -1 ? Number(process.argv[i + 1]) : 24; })();
+const GUESTS_ARG = (() => {
+  const i = process.argv.indexOf('--guests');
+  return i > -1 ? process.argv[i + 1].split(',').map(Number).filter((n) => n > 0) : null;
+})();
+const BASE = process.env.PARITY_BASE_URL ?? 'https://prahova-chalet.ro';
+
+/** Rates the owner actually pays. Overridable per property via `property.channelPricing`. */
+const DEFAULT_CHANNELS: ChannelEconomics[] = [
+  { channel: 'airbnb', commissionPct: 0.185 },
+  { channel: 'booking.com', commissionPct: 0.23 },
+];
+const DEFAULT_DIRECT: DirectEconomics = { paymentCostPct: 0.029 };
+
+const iso = (d: Date) => d.toISOString().slice(0, 10);
+const addDays = (d: Date, n: number) => { const x = new Date(d); x.setUTCDate(x.getUTCDate() + n); return x; };
+const parse = (s: string) => new Date(s + 'T00:00:00Z');
+const DOW = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+type ProbeReason =
+  | 'peak' | 'long-weekend' | 'school-break' | 'advertised'
+  | 'los-threshold' | 'ordinary-weekend' | 'midweek' | 'occupancy-variant';
+
+/** Short / mid / long — the comparison flips across the length-of-stay tier, so all three are covered. */
+type LengthClass = 'short' | 'mid' | 'long';
+
+interface Probe {
+  label: string;
+  /** Why this window is in the list — so a human can tell signal from routine. */
+  reason: ProbeReason;
+  checkIn: string;
+  checkOut: string;
+  nights: number;
+  guests: number;
+  priority: 'high' | 'normal';
+  lengthClass: LengthClass;
+  /** Set when the window's dates are a rule of thumb (school breaks) rather than published. */
+  approximate?: boolean;
+}
+
+async function quoteDirect(propertyId: string, checkIn: string, checkOut: string, guests: number) {
+  try {
+    const r = await fetch(`${BASE}/api/check-pricing`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ propertyId, checkIn, checkOut, guests }),
+    });
+    const j: any = await r.json();
+    const p = j?.pricing ?? j;
+    const total = p?.total ?? p?.totalPrice;
+    if (typeof total !== 'number') return { ok: false as const, error: String(p?.error ?? p?.reason ?? 'no quote') };
+    return {
+      ok: true as const,
+      total,
+      cleaningFee: p?.cleaningFee ?? null,
+      losDiscountPct: p?.lengthOfStayDiscount?.discountPercentage ?? 0,
+    };
+  } catch (e) {
+    return { ok: false as const, error: (e as Error).message };
+  }
+}
+
+(async () => {
+  const db = await getAdminDb();
+  const propDoc = await db.collection('properties').doc(SLUG).get();
+  if (!propDoc.exists) throw new Error(`property ${SLUG} not found`);
+  const prop: any = propDoc.data();
+
+  const baseOccupancy = prop.baseOccupancy ?? 2;
+  const maxGuests = prop.maxGuests ?? baseOccupancy;
+  const losTiers: number[] = (prop.pricingConfig?.lengthOfStayDiscounts ?? [])
+    .filter((t: any) => t.enabled).map((t: any) => t.nightsThreshold).sort((a: number, b: number) => a - b);
+
+  // Channel economics + listing URLs: configured on the property, or the documented defaults.
+  const configured = prop.channelPricing ?? null;
+  const channels: ChannelEconomics[] = configured?.channels ?? DEFAULT_CHANNELS;
+  const direct: DirectEconomics = configured?.direct ?? DEFAULT_DIRECT;
+  const listingUrls: Record<string, string> = configured?.listingUrls ?? {};
+
+  // Airbnb's listing id is recoverable from the iCal feed even when nothing else is configured.
+  if (!listingUrls.airbnb) {
+    const feeds = await db.collection('icalFeeds').where('propertyId', '==', SLUG).get();
+    const ab = feeds.docs.map((d) => d.data() as any).find((f) => /airbnb/i.test(f.name ?? ''));
+    const id = ab?.url?.match(/\/ical\/(\d+)\.ics/)?.[1];
+    if (id) listingUrls.airbnb = `https://www.airbnb.com/rooms/${id}`;
+  }
+
+  const today = parse(iso(new Date()));
+  const horizon = addDays(today, MONTHS * 30);
+  // Published school-break dates, when the owner has recorded them (they beat the approximations).
+  const schoolBreakOverrides: SpecialPeriodOptions | undefined = prop.channelPricing?.schoolBreaks
+    ? { schoolBreaks: prop.channelPricing.schoolBreaks }
+    : undefined;
+
+  // ---- minimum stay per date, so a probe is never rejected by our own booking rules ----
+  const calCache = new Map<string, any>();
+  const calDoc = async (ym: string) => {
+    if (!calCache.has(ym)) {
+      const d = await db.collection('priceCalendars').doc(`${SLUG}_${ym}`).get();
+      calCache.set(ym, d.exists ? d.data() : null);
+    }
+    return calCache.get(ym);
+  };
+  const minStayOn = async (d: Date): Promise<number> => {
+    const c = await calDoc(iso(d).slice(0, 7));
+    return Number(c?.days?.[d.getUTCDate()]?.minimumStay ?? 1) || 1;
+  };
+
+  // ---- availability, so we never probe a window that cannot be sold anyway ----
+  const monthCache = new Map<string, any>();
+  const monthDoc = async (ym: string) => {
+    if (!monthCache.has(ym)) {
+      const d = await db.collection('availability').doc(`${SLUG}_${ym}`).get();
+      monthCache.set(ym, d.exists ? d.data() : null);
+    }
+    return monthCache.get(ym);
+  };
+  const isFree = async (d: Date) => {
+    const a = await monthDoc(iso(d).slice(0, 7));
+    if (!a) return true; // no doc = nothing booked that month
+    const day = d.getUTCDate();
+    return a.available?.[day] !== false && !a.holds?.[day];
+  };
+  const windowFree = async (ci: Date, nights: number) => {
+    for (let i = 0; i < nights; i++) if (!(await isFree(addDays(ci, i)))) return false;
+    return true;
+  };
+  /**
+   * First sellable start for `nights` inside [from, until). A period that is partly booked is still
+   * worth comparing on the part that can actually be sold — probing nights nobody can book just
+   * spends a human's browser time for nothing.
+   */
+  const firstFreeWithin = async (from: Date, until: Date, nights: number): Promise<Date | null> => {
+    for (let d = from; addDays(d, nights) <= until; d = addDays(d, 1)) {
+      if (await windowFree(d, nights)) return d;
+    }
+    return null;
+  };
+
+  const soonest = addDays(today, 1); // never probe a date the booking engine will reject
+  const probes: Probe[] = [];
+  const classify = (nights: number): LengthClass =>
+    nights >= (losTiers[0] ?? 7) ? 'long' : nights <= 2 ? 'short' : 'mid';
+  const push = (p: Omit<Probe, 'lengthClass'> & { lengthClass?: LengthClass }) => {
+    const probe: Probe = { ...p, lengthClass: p.lengthClass ?? classify(p.nights) };
+    const existing = probes.find((x) => x.checkIn === probe.checkIn && x.checkOut === probe.checkOut && x.guests === probe.guests);
+    if (!existing) { probes.push(probe); return; }
+    // Same window reached from two directions (a school break that happens to be the window we are
+    // advertising). Keep one probe, but let the higher-signal reason win the label — "ADVERTISED"
+    // tells the reader why this row matters far better than "summer break" does.
+    if (existing.priority !== 'high' && probe.priority === 'high') {
+      existing.label = probe.label;
+      existing.reason = probe.reason;
+      existing.priority = 'high';
+    }
+  };
+  /**
+   * Occupancies to compare at. NOT simply [base, maxGuests]: a comparison is only meaningful at a
+   * headcount every channel actually offers. This property's doc says maxGuests 7 while the Airbnb
+   * listing advertises 6 — probing 7 asks for a quote Airbnb will never give, so the pair would be
+   * incomparable. Configure `channelPricing.compareOccupancies`, or pass --guests 3,6.
+   */
+  const compareOccupancies: number[] = (GUESTS_ARG ?? configured?.compareOccupancies ?? [baseOccupancy, maxGuests])
+    .filter((n: number) => n >= 1)
+    .sort((a: number, b: number) => a - b);
+  const occupancyNote = GUESTS_ARG
+    ? 'from --guests'
+    : configured?.compareOccupancies
+      ? 'from property.channelPricing.compareOccupancies'
+      : `DERIVED [baseOccupancy, maxGuests] — check this matches what the OTA listings actually offer`;
+  /** Peaks and flat-rate windows get BOTH ends — the gap can differ by 12+ points. */
+  const occupancies = (both: boolean) => (both ? compareOccupancies : [compareOccupancies[0]]);
+
+  // ---- 1. Special periods, read from the `holidays` collection. ----
+  // NOT computed. Romania uses Orthodox (Julian) Easter and the school calendar is set by ministerial
+  // order — deriving either in code poisons every downstream decision (see scripts/seed-holidays.ts,
+  // which records a source URL per row). This is the SAME source the situation pack reads, so the
+  // parity check and the brain cannot disagree about what a "period" is.
+  const holSnap = await db.collection('holidays').get();
+  const holidays = holSnap.docs
+    .map((d) => d.data() as any)
+    .filter((h) => h.endDate >= iso(today) && h.startDate <= iso(horizon))
+    .sort((a, b) => String(a.startDate).localeCompare(String(b.startDate)));
+
+  const holidayCoverageEnd = holSnap.docs
+    .map((d) => String((d.data() as any).endDate ?? ''))
+    .sort()
+    .pop() ?? null;
+
+  for (const h of holidays) {
+    const rawStart = parse(h.startDate);
+    const ci0 = rawStart < soonest ? soonest : rawStart;
+    // `endDate` is the last day OFF, so the sellable window runs one night past it.
+    const periodEnd = addDays(parse(h.endDate), 1);
+    const remaining = Math.round((periodEnd.getTime() - ci0.getTime()) / 86_400_000);
+    if (remaining < 2) continue;
+
+    if (h.type === 'major') {
+      // A `major` row is a real travel window. Widen to the adjacent weekend where that is free —
+      // people take the Friday before a Monday holiday, and that is the window actually sold.
+      let ci = ci0;
+      for (let back = 0; back <= 4; back++) {
+        const cand = addDays(ci0, -back);
+        if (cand >= soonest && cand.getUTCDay() === 5) { ci = cand; break; }
+      }
+      const span = Math.round((periodEnd.getTime() - ci.getTime()) / 86_400_000);
+      // Respect our OWN minimum stay: Christmas carries minStay 3, so a 2-night probe is rejected by
+      // the booking engine before it ever reaches a price.
+      const natural = Math.max(2, await minStayOn(ci), Math.min(span, 7));
+      const start = (await windowFree(ci, natural)) ? ci : await firstFreeWithin(ci, periodEnd, natural);
+      if (start) {
+        for (const g of occupancies(true)) {
+          push({ label: h.name, reason: 'peak', checkIn: iso(start), checkOut: iso(addDays(start, natural)),
+                 nights: natural, guests: g, priority: 'high', approximate: !h.official });
+        }
+      }
+    } else if (h.type === 'school-break') {
+      // Breaks earn two probes: families travel MIDWEEK (otherwise unsellable), and the break is long
+      // enough that the length-of-stay tier becomes reachable.
+      const firstMonday = (() => { let d = ci0; for (let i = 0; i < 7 && d.getUTCDay() !== 1; i++) d = addDays(d, 1); return d; })();
+      const mid = await firstFreeWithin(firstMonday, periodEnd, 3);
+      if (mid) {
+        push({ label: `${h.name} — midweek`, reason: 'midweek', checkIn: iso(mid), checkOut: iso(addDays(mid, 3)),
+               nights: 3, guests: compareOccupancies[0], priority: 'normal', approximate: !h.official });
+      }
+      const tier = losTiers[0] ?? 7;
+      if (remaining >= tier) {
+        const wk = await firstFreeWithin(ci0, periodEnd, tier);
+        if (wk) {
+          push({ label: `${h.name} — full week`, reason: 'school-break', checkIn: iso(wk), checkOut: iso(addDays(wk, tier)),
+                 nights: tier, guests: baseOccupancy, priority: 'normal', approximate: !h.official });
+        }
+      }
+    } else if (h.type === 'bridge-day') {
+      const natural = Math.max(2, await minStayOn(ci0), Math.min(remaining, 4));
+      const start = (await windowFree(ci0, natural)) ? ci0 : await firstFreeWithin(ci0, periodEnd, natural);
+      if (start) {
+        push({ label: h.name, reason: 'long-weekend', checkIn: iso(start), checkOut: iso(addDays(start, natural)),
+               nights: natural, guests: baseOccupancy, priority: 'high', approximate: !h.official });
+      }
+    }
+    // `minor` rows are legal days off that historically do not move leisure demand on their own —
+    // seed-holidays.ts classifies them deliberately, so we trust that and skip them.
+  }
+
+  // ---- 1b. The property's OWN pricing peaks (dateOverrides). ----
+  // The legal calendar says why people travel; the override calendar says what the owner charges a
+  // premium for. They are NOT the same set: New Year's Eve (30-31 Dec) is the year's highest rate here
+  // but is not a public holiday, so it appears in `dateOverrides` and nowhere in `holidays`. Probing
+  // only the legal calendar would skip the single most valuable window of the year.
+  const ovSnap2 = await db.collection('dateOverrides').where('propertyId', '==', SLUG).get();
+  const ovRows = ovSnap2.docs.map((d) => d.data() as any)
+    .filter((o) => o.date && o.date >= iso(today) && o.date <= iso(horizon))
+    .sort((a, b) => a.date.localeCompare(b.date));
+  const ovClusters: Array<{ reason: string; dates: string[] }> = [];
+  for (const o of ovRows) {
+    const reason = String(o.reason ?? 'special rate');
+    const last = ovClusters[ovClusters.length - 1];
+    const contiguous = last && iso(addDays(parse(last.dates[last.dates.length - 1]), 1)) === o.date;
+    // Split on reason as well as adjacency — Christmas runs into New Year on the calendar, but they
+    // are separate commercial decisions with different prices and different competitors.
+    if (contiguous && last.reason === reason) last.dates.push(o.date);
+    else ovClusters.push({ reason, dates: [o.date] });
+  }
+  for (const c of ovClusters) {
+    const ci = parse(c.dates[0]);
+    if (ci < soonest) continue;
+    const span = c.dates.length + 1;
+    const nights = Math.max(2, await minStayOn(ci), Math.min(span, 7));
+    const end = addDays(ci, nights);
+    const start = (await windowFree(ci, nights)) ? ci : await firstFreeWithin(ci, end, nights);
+    if (!start) continue;
+    for (const g of occupancies(true)) {
+      push({ label: `${c.reason} (own rate)`, reason: 'peak', checkIn: iso(start),
+             checkOut: iso(addDays(start, nights)), nights, guests: g, priority: 'high' });
+    }
+  }
+
+  // ---- 2. Windows we are actively paying to advertise. Losing here costs twice. ----
+  const adSnap = await db.collection('adCampaigns').where('propertyId', '==', SLUG).get();
+  for (const d of adSnap.docs) {
+    const x: any = d.data();
+    if (!['pushed', 'active', 'approved'].includes(String(x.status))) continue;
+    const occ = x.proposal?.occasion;
+    if (!occ?.start) continue;
+    const ci = parse(occ.start);
+    if (iso(ci) < iso(today)) continue;
+    const nights = Math.min(3, Math.max(2, Number(occ.nights) || 2));
+    push({ label: `ADVERTISED: ${String(occ.name ?? d.id).slice(0, 44)}`, reason: 'advertised',
+           checkIn: iso(ci), checkOut: iso(addDays(ci, nights)), nights, guests: baseOccupancy, priority: 'high' });
+  }
+
+  // ---- 3. Either side of the first length-of-stay tier: the discount flips the comparison. ----
+  if (losTiers.length) {
+    const tier = losTiers[0];
+    let ci = addDays(today, 21);
+    for (let tries = 0; tries < 90 && !(await windowFree(ci, tier)); tries++) ci = addDays(ci, 1);
+    if (await windowFree(ci, tier)) {
+      push({ label: `just under the ${tier}-night discount`, reason: 'los-threshold', checkIn: iso(ci),
+             checkOut: iso(addDays(ci, tier - 1)), nights: tier - 1, guests: baseOccupancy, priority: 'normal' });
+      push({ label: `at the ${tier}-night discount`, reason: 'los-threshold', checkIn: iso(ci),
+             checkOut: iso(addDays(ci, tier)), nights: tier, guests: baseOccupancy, priority: 'normal' });
+    }
+  }
+
+  // ---- 4. Ordinary months must not be blind spots. One open weekend per month with no special
+  //         period, ROTATED by run so consecutive runs sample different weekends. ----
+  const monthsCovered = new Set(probes.map((p) => p.checkIn.slice(0, 7)));
+  for (let m = 0; m < MONTHS; m++) {
+    const monthStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + m, 1));
+    const ym = iso(monthStart).slice(0, 7);
+    if (monthsCovered.has(ym)) continue;
+    const fridays: Date[] = [];
+    for (let d = monthStart; iso(d).slice(0, 7) === ym; d = addDays(d, 1)) if (d.getUTCDay() === 5 && d > today) fridays.push(d);
+    if (!fridays.length) continue;
+    // Deterministic rotation: the run's week number picks which Friday, so a 4-6 week cadence walks
+    // across the month instead of re-measuring the same weekend forever.
+    const weekOfYear = Math.floor((today.getTime() - Date.UTC(today.getUTCFullYear(), 0, 1)) / (7 * 86_400_000));
+    for (const f of [fridays[(weekOfYear + m) % fridays.length], ...fridays]) {
+      if (await windowFree(f, 2)) {
+        push({ label: `ordinary weekend ${iso(f)}`, reason: 'ordinary-weekend', checkIn: iso(f),
+               checkOut: iso(addDays(f, 2)), nights: 2, guests: compareOccupancies[0], priority: 'normal' });
+        break;
+      }
+    }
+  }
+
+  // ---- 4b. Ordinary MIDWEEK. The hardest inventory to sell, and where an OTA promo does the most
+  //          damage because there is no weekend demand to fall back on. Sampled every other month so
+  //          it earns coverage without doubling the run. ----
+  for (let m = 0; m < MONTHS; m += 2) {
+    const monthStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + m, 1));
+    const ym = iso(monthStart).slice(0, 7);
+    const mondays: Date[] = [];
+    for (let d = monthStart; iso(d).slice(0, 7) === ym; d = addDays(d, 1)) if (d.getUTCDay() === 1 && d > soonest) mondays.push(d);
+    if (!mondays.length) continue;
+    const weekOfYear = Math.floor((today.getTime() - Date.UTC(today.getUTCFullYear(), 0, 1)) / (7 * 86_400_000));
+    for (const mo of [mondays[(weekOfYear + m) % mondays.length], ...mondays]) {
+      if (await windowFree(mo, 3)) {
+        push({ label: `ordinary midweek ${iso(mo)}`, reason: 'midweek', checkIn: iso(mo),
+               checkOut: iso(addDays(mo, 3)), nights: 3, guests: compareOccupancies[0], priority: 'normal' });
+        break;
+      }
+    }
+  }
+
+  // ---- 5. Guarantee every length class is represented, whatever the calendar happened to yield. ----
+  for (const cls of ['short', 'mid', 'long'] as LengthClass[]) {
+    if (probes.some((p) => p.lengthClass === cls)) continue;
+    const nights = cls === 'short' ? 2 : cls === 'mid' ? 4 : (losTiers[0] ?? 7);
+    let ci = addDays(today, 14);
+    for (let tries = 0; tries < 120 && !(await windowFree(ci, nights)); tries++) ci = addDays(ci, 1);
+    if (await windowFree(ci, nights)) {
+      push({ label: `${cls}-stay coverage`, reason: 'los-threshold', checkIn: iso(ci),
+             checkOut: iso(addDays(ci, nights)), nights, guests: baseOccupancy, priority: 'normal' });
+    }
+  }
+
+  // ---- 6. Occupancy variant on the longest non-peak window — flat-rate nights make this decisive. ----
+  const upper = compareOccupancies[compareOccupancies.length - 1];
+  const biggest = probes.filter((p) => p.reason !== 'peak' && p.guests === compareOccupancies[0]).sort((a, b) => b.nights - a.nights)[0];
+  if (biggest && upper > compareOccupancies[0]) {
+    push({ ...biggest, label: `${biggest.label} @ ${upper} guests`, reason: 'occupancy-variant', guests: upper });
+  }
+
+  const scoped = ONLY ? probes.filter((p) => p.label.toLowerCase().includes(ONLY.toLowerCase())) : probes;
+  // Each probe costs a human a couple of page loads in the browser, so cap the run — high
+  // priority (peaks, bridged holidays, advertised windows) survives the cut first.
+  const ordered = [...scoped].sort((a, b) =>
+    (a.priority === b.priority ? 0 : a.priority === 'high' ? -1 : 1) || a.checkIn.localeCompare(b.checkIn));
+  const selected = ordered.slice(0, MAX_PROBES);
+  const dropped = ordered.length - selected.length;
+
+  // ---- attach live direct quotes ----
+  const rows = [];
+  for (const p of selected) {
+    const q = await quoteDirect(SLUG, p.checkIn, p.checkOut, p.guests);
+    const free = await windowFree(parse(p.checkIn), p.nights);
+    rows.push({ ...p, bookableDirect: free, direct: q });
+  }
+
+  // ---- the worklist: one cell per window × occupancy × channel, each owed an outcome ----
+  const channelNames = channels.map((c) => c.channel);
+  const worklist = buildWorklist(SLUG, rows.map((r) => ({
+    label: r.label, checkIn: r.checkIn, checkOut: r.checkOut, nights: r.nights, guests: r.guests, priority: r.priority,
+  })), channelNames);
+
+  // The direct price comes from OUR engine, so record it here rather than making a human retype it.
+  // `source: 'api'` is deliberate provenance: it is what the engine computes, which is not automatically
+  // what a browser renders (this site once showed USD while the engine returned RON).
+  if (!process.argv.includes('--no-record')) {
+    const stamp = new Date().toISOString();
+    for (const r of rows) {
+      const id = cellId(SLUG, r.checkIn, r.checkOut, r.guests, 'direct');
+      await recordObservation({
+        propertyId: SLUG, cellId: id, checkIn: r.checkIn, checkOut: r.checkOut,
+        nights: r.nights, guests: r.guests, channel: 'direct',
+        status: r.direct.ok ? 'captured' : (r.bookableDirect ? 'error' : 'unavailable'),
+        guestTotal: r.direct.ok ? Math.round(r.direct.total) : null,
+        reason: r.direct.ok ? undefined : (r.bookableDirect ? `engine: ${r.direct.error}` : 'dates not bookable direct'),
+        source: 'api', url: `${BASE}/api/check-pricing`, capturedBy: 'parity-pack', capturedAt: stamp,
+      });
+    }
+  }
+
+  const observed = [...(await latestByCell(SLUG)).values()];
+  const coverage = computeCoverage(worklist, observed, { freshnessDays: 42 });
+  const todo = outstandingCells(worklist, observed, { freshnessDays: 42 });
+
+  const pack = {
+    meta: { propertySlug: SLUG, generatedAt: new Date().toISOString(), baseUrl: BASE, monthsAhead: MONTHS },
+    economics: {
+      direct,
+      channels: channels.map((c) => ({ ...c, headroomPct: Number(headroomPct(c, direct).toFixed(4)) })),
+      configured: !!configured,
+      note: configured
+        ? 'rates read from property.channelPricing'
+        : 'rates are the documented DEFAULTS — persist them on property.channelPricing to make this authoritative',
+    },
+    listingUrls,
+    property: { baseOccupancy, maxGuests, compareOccupancies, occupancyNote, cleaningFee: prop.cleaningFee ?? null, extraGuestFee: prop.extraGuestFee ?? null, losTiers },
+    probes: rows,
+    worklist,
+    coverage,
+    outstanding: todo,
+    holidayData: {
+      source: '`holidays` collection (scripts/seed-holidays.ts — fetched facts, per-row source URLs)',
+      rowsInHorizon: holidays.length,
+      coverageEnds: holidayCoverageEnd,
+      stale: holidayCoverageEnd ? holidayCoverageEnd < iso(horizon) : true,
+    },
+  };
+
+  if (AS_JSON) { console.log(JSON.stringify(pack, null, 2)); return; }
+
+  console.log(`\nPARITY PACK — ${SLUG}   (${rows.length} probes, ${MONTHS}mo horizon)`);
+  console.log(`economics: ${pack.economics.configured ? 'configured' : 'DEFAULTS (not yet persisted)'}  ·  direct card cost ${(direct.paymentCostPct * 100).toFixed(1)}%`);
+  for (const c of pack.economics.channels) {
+    console.log(`  ${c.channel.padEnd(12)} commission ${(c.commissionPct * 100).toFixed(1)}%  → you can go ${(c.headroomPct * 100).toFixed(1)}% under its guest price and still net the same`);
+  }
+  if (pack.holidayData.stale) {
+    console.log(`\n!! holidays data ends ${pack.holidayData.coverageEnds ?? 'nowhere — collection empty'}, before the ${MONTHS}-month horizon.`);
+    console.log('   Periods past that date are NOT probed. Re-seed: npx tsx scripts/seed-holidays.ts');
+  }
+  console.log(`comparing at ${compareOccupancies.join(' and ')} guests (${occupancyNote})`);
+  console.log(`listing urls: ${Object.entries(listingUrls).map(([k, v]) => `${k}=${v}`).join('  ') || '(none configured)'}`);
+  console.log('\n' + 'window'.padEnd(46) + 'dates'.padEnd(26) + 'n  g   direct');
+  console.log('-'.repeat(104));
+  for (const r of [...rows].sort((a, b) => a.checkIn.localeCompare(b.checkIn))) {
+    const d = r.direct.ok
+      ? `${String(Math.round(r.direct.total)).padStart(6)} RON${r.direct.losDiscountPct ? ` (LoS -${r.direct.losDiscountPct}%)` : ''}`
+      : `— ${r.direct.error}`;
+    const flag = r.priority === 'high' ? '*' : ' ';
+    console.log(
+      `${flag}${r.label.slice(0, 44).padEnd(45)}` +
+      `${r.checkIn} ${DOW[parse(r.checkIn).getUTCDay()]} → ${r.checkOut}`.padEnd(26) +
+      `${String(r.nights).padStart(2)} ${String(r.guests).padStart(2)}   ${d}` +
+      (r.bookableDirect ? '' : '   [BLOCKED direct]')
+    );
+  }
+  console.log(`\nWORKLIST: ${worklist.length} cells (${rows.length} windows × ${channelNames.length + 1} sources)`);
+  console.log(`COVERAGE: ${coverage.captured} captured · ${coverage.refused} refused · ${coverage.unavailable} unavailable · ` +
+              `${coverage.errored} error · ${coverage.missing} MISSING  →  ${(coverage.resolvedPct * 100).toFixed(0)}% resolved` +
+              (coverage.oldestAgeDays !== null ? `, oldest ${coverage.oldestAgeDays}d` : ''));
+  console.log(coverage.complete ? 'STATUS: complete' : `STATUS: INCOMPLETE — ${todo.length} cell(s) still owed. Run the ota-parity skill to capture them.`);
+  if (todo.length) {
+    console.log('\nOutstanding (first 20):');
+    todo.slice(0, 20).forEach((c) => console.log(`  ${c.channel.padEnd(12)} ${c.checkIn}→${c.checkOut}  ${c.guests}g  ${c.window.slice(0, 40)}`));
+    if (todo.length > 20) console.log(`  … and ${todo.length - 20} more`);
+  }
+  if (dropped > 0) console.log(`\nNOTE: ${dropped} lower-priority probe(s) dropped by --max ${MAX_PROBES} — raise it for fuller coverage.`);
+  console.log('\n* = high priority (a peak, bridged holiday, or a window you are advertising)');
+  console.log('Next: the `ota-parity` skill captures the OTA side in Chrome and evaluates each row.');
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/parity-report.ts
+++ b/scripts/parity-report.ts
@@ -1,0 +1,127 @@
+/**
+ * parity-report — render the comparison table FROM THE STORE, never by hand.
+ *
+ * The rule this enforces: every worklist cell appears. A cell with no observation prints `?`, counts
+ * against coverage, and is listed at the bottom as outstanding. A report can only call itself COMPLETE
+ * when nothing is missing, nothing errored, and nothing is stale — so a partial run announces itself
+ * instead of looking like a finished one.
+ *
+ *   npx tsx scripts/parity-report.ts [propertySlug] [--target 0.075] [--fresh-days 42] [--json]
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { buildWorklist, computeCoverage, outstandingCells, cellId, type ProbeInput } from '@/lib/growth/parityWorklist';
+import { latestByCell, type ObservationRecord } from '@/services/growth/parityObservations';
+import { evaluateParity, bestOffer, channelSpreadPct, type ChannelEconomics, type DirectEconomics } from '@/lib/growth/parityMath';
+
+const SLUG = process.argv[2]?.startsWith('--') ? 'prahova-mountain-chalet' : (process.argv[2] ?? 'prahova-mountain-chalet');
+const AS_JSON = process.argv.includes('--json');
+const num = (n: string, d: number) => { const i = process.argv.indexOf(`--${n}`); return i > -1 ? Number(process.argv[i + 1]) : d; };
+const TARGET = num('target', 0.075);
+const FRESH_DAYS = num('fresh-days', 42);
+
+const DEFAULT_CHANNELS: ChannelEconomics[] = [
+  { channel: 'airbnb', commissionPct: 0.185 },
+  { channel: 'booking.com', commissionPct: 0.23 },
+];
+const DEFAULT_DIRECT: DirectEconomics = { paymentCostPct: 0.029 };
+
+const pct = (x: number) => `${x >= 0 ? '+' : ''}${(x * 100).toFixed(1)}%`;
+const LABEL: Record<string, string> = { losing: 'LOSING', thin: 'thin', healthy: 'OK', overshoot: 'TOO LOW' };
+
+(async () => {
+  const db = await getAdminDb();
+  const prop = (await db.collection('properties').doc(SLUG).get()).data() as any;
+  const configured = prop?.channelPricing ?? null;
+  const channels: ChannelEconomics[] = configured?.channels ?? DEFAULT_CHANNELS;
+  const direct: DirectEconomics = configured?.direct ?? DEFAULT_DIRECT;
+
+  const observations = [...(await latestByCell(SLUG)).values()];
+  if (!observations.length) {
+    console.log('No observations yet. Run: npx tsx scripts/parity-pack.ts ' + SLUG);
+    return;
+  }
+
+  // The worklist is reconstructed from the observations' own windows, so the report covers exactly
+  // what was asked for — including cells nobody ever captured.
+  const seen = new Map<string, ProbeInput>();
+  for (const o of observations) {
+    const key = `${o.checkIn}|${o.checkOut}|${o.guests}`;
+    if (!seen.has(key)) {
+      seen.set(key, { label: `${o.checkIn} → ${o.checkOut}`, checkIn: o.checkIn, checkOut: o.checkOut, nights: o.nights, guests: o.guests, priority: 'normal' });
+    }
+  }
+  const probes = [...seen.values()].sort((a, b) => a.checkIn.localeCompare(b.checkIn) || a.guests - b.guests);
+  const channelNames = channels.map((c) => c.channel);
+  const worklist = buildWorklist(SLUG, probes, channelNames);
+  const coverage = computeCoverage(worklist, observations, { freshnessDays: FRESH_DAYS });
+  const todo = outstandingCells(worklist, observations, { freshnessDays: FRESH_DAYS });
+  const byCell = new Map(observations.map((o) => [o.cellId, o]));
+
+  const get = (p: ProbeInput, channel: string): ObservationRecord | undefined =>
+    byCell.get(cellId(SLUG, p.checkIn, p.checkOut, p.guests, channel));
+  const show = (o?: ObservationRecord) => {
+    if (!o) return '     ?';
+    if (o.status === 'captured') return String(Math.round(o.guestTotal!)).padStart(6);
+    if (o.status === 'refused') return '   n/a';
+    if (o.status === 'unavailable') return '  full';
+    return '   ERR';
+  };
+
+  const lines: any[] = [];
+  for (const p of probes) {
+    const d = get(p, 'direct');
+    const offers = channels
+      .map((c) => ({ econ: c, o: get(p, c.channel) }))
+      .filter((x) => x.o?.status === 'captured')
+      .map((x) => ({ channel: x.econ.channel, otaTotal: x.o!.guestTotal!, list: x.o!.listTotal ?? undefined, econ: x.econ }));
+
+    let verdict = '', gap = '', floor = '', spread = '';
+    if (d?.status === 'captured' && offers.length) {
+      const best = bestOffer(offers)!;
+      const v = evaluateParity({ directTotal: d.guestTotal!, otaTotal: best.otaTotal, otaListTotal: best.list, channel: best.econ, direct, targetDiscountPct: TARGET });
+      verdict = LABEL[v.status]; gap = pct(v.guestGapPct); floor = String(Math.round(v.indifferencePrice));
+      const sp = channelSpreadPct(offers);
+      spread = sp !== null ? `${(sp * 100).toFixed(0)}%` : '—';
+    } else {
+      verdict = 'no verdict'; gap = '—'; floor = '—'; spread = '—';
+    }
+    lines.push({ p, d, cells: channels.map((c) => get(p, c.channel)), verdict, gap, floor, spread });
+  }
+
+  if (AS_JSON) {
+    console.log(JSON.stringify({ propertyId: SLUG, coverage, outstanding: todo, rows: lines }, null, 2));
+    return;
+  }
+
+  const W = 118;
+  console.log('\n' + '='.repeat(W));
+  console.log(`DIRECT vs ${channelNames.map((c) => c.toUpperCase()).join(' vs ')} — ${SLUG}`);
+  console.log(`target: direct ≥${(TARGET * 100).toFixed(1)}% under the cheapest channel · ` +
+              channels.map((c) => `${c.channel} ${(c.commissionPct * 100).toFixed(1)}%`).join(' · ') +
+              ` · cards ${(direct.paymentCostPct * 100).toFixed(1)}%` + (configured ? '' : '  [RATES ARE DEFAULTS]'));
+  console.log('='.repeat(W));
+  console.log('dates                        n  g  direct ' + channelNames.map((c) => c.slice(0, 7).padStart(7)).join(' ') + ' | gap      verdict   floor spread');
+  console.log('-'.repeat(W));
+  for (const l of lines) {
+    console.log(
+      `${(l.p.checkIn + '→' + l.p.checkOut).padEnd(26)} ${String(l.p.nights).padStart(2)} ${l.p.guests} ` +
+      `${show(l.d)} ${l.cells.map(show).join(' ')} | ${l.gap.padStart(7)}  ${l.verdict.padEnd(10)} ${l.floor.padStart(5)} ${l.spread.padStart(5)}`
+    );
+  }
+  console.log('-'.repeat(W));
+  console.log(`? = never captured · n/a = channel refuses to quote · full = dates taken · ERR = capture failed`);
+  console.log(`\nCOVERAGE  ${coverage.captured} captured · ${coverage.refused} refused · ${coverage.unavailable} full · ` +
+              `${coverage.errored} error · ${coverage.missing} MISSING  of ${coverage.total} cells  (${(coverage.resolvedPct * 100).toFixed(0)}% resolved)` +
+              (coverage.oldestAgeDays !== null ? ` · oldest ${coverage.oldestAgeDays}d` : ''));
+  console.log(coverage.complete
+    ? 'STATUS: COMPLETE — every cell resolved and fresh.'
+    : `STATUS: INCOMPLETE — do NOT treat this table as the whole picture. ${todo.length} cell(s) still owed.`);
+  if (todo.length) {
+    console.log('\nOutstanding:');
+    todo.slice(0, 30).forEach((c) => console.log(`  ${c.channel.padEnd(12)} ${c.checkIn}→${c.checkOut} ${c.guests}g`));
+    if (todo.length > 30) console.log(`  … and ${todo.length - 30} more`);
+  }
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/src/lib/growth/__tests__/parityMath.test.ts
+++ b/src/lib/growth/__tests__/parityMath.test.ts
@@ -1,0 +1,107 @@
+/** @jest-environment node */
+
+import {
+  evaluateParity, indifferencePrice, headroomPct, netFromDirect, netFromOta,
+  bestOffer, channelSpreadPct, type ChannelEconomics, type DirectEconomics,
+} from '../parityMath';
+
+// The owner's stated rates (2026-08): ~18.5% Airbnb, ~23% Booking.com, card fees ~2.9%.
+const AIRBNB: ChannelEconomics = { channel: 'airbnb', commissionPct: 0.185 };
+const BOOKING: ChannelEconomics = { channel: 'booking.com', commissionPct: 0.23 };
+const DIRECT: DirectEconomics = { paymentCostPct: 0.029 };
+
+describe('the structural advantage of booking direct', () => {
+  it('is ~16% on Airbnb and ~21% on Booking.com, independent of price', () => {
+    expect(headroomPct(AIRBNB, DIRECT)).toBeCloseTo(0.1610, 3);
+    expect(headroomPct(BOOKING, DIRECT)).toBeCloseTo(0.2070, 3);
+  });
+
+  it('means a 10% target uses only about two-thirds of the available room', () => {
+    expect(headroomPct(AIRBNB, DIRECT)).toBeGreaterThan(0.10);
+  });
+});
+
+describe('indifference price', () => {
+  it('is where the owner earns the same either way (real Aug 28-30 numbers)', () => {
+    // Airbnb showed 1,476 for those nights.
+    const p = indifferencePrice(1476, AIRBNB, DIRECT);
+    expect(Math.round(p)).toBe(1239);
+    expect(netFromDirect(p, DIRECT)).toBeCloseTo(netFromOta(1476, AIRBNB), 6);
+  });
+
+  it('is lower on the higher-commission channel — more room against Booking.com', () => {
+    expect(indifferencePrice(1000, BOOKING, DIRECT)).toBeLessThan(indifferencePrice(1000, AIRBNB, DIRECT));
+  });
+});
+
+describe('evaluateParity — the states that matter', () => {
+  const base = { channel: AIRBNB, direct: DIRECT, targetDiscountPct: 0.05 };
+
+  it('flags LOSING when direct costs the guest more (the real Aug 28-30 case)', () => {
+    const v = evaluateParity({ ...base, directTotal: 1838, otaTotal: 1476, otaListTotal: 1940 });
+    expect(v.status).toBe('losing');
+    expect(v.guestGapPct).toBeCloseTo(0.245, 2);
+    expect(v.netAdvantage).toBeGreaterThan(0); // NB: it would pay more IF anyone booked it — nobody will
+    expect(v.promoDriven).toBe(true);
+  });
+
+  it('confirms the owner\'s point: undercutting a promo still earns more net', () => {
+    // Price direct 5% under Airbnb's promo price.
+    const v = evaluateParity({ ...base, directTotal: 1476 * 0.95, otaTotal: 1476, otaListTotal: 1940 });
+    expect(v.status).toBe('healthy');
+    expect(v.netAdvantage).toBeGreaterThan(0);
+    // The guest saves ~74 lei and the owner still keeps ~158 more than the Airbnb booking.
+    expect(Math.round(v.netAdvantage)).toBeGreaterThan(140);
+  });
+
+  it('flags OVERSHOOT below indifference — cheaper than it needs to be', () => {
+    const v = evaluateParity({ ...base, directTotal: 1100, otaTotal: 1476 });
+    expect(v.status).toBe('overshoot');
+    expect(v.netAdvantage).toBeLessThan(0);
+    expect(v.notes.join(' ')).toMatch(/indifference/i);
+  });
+
+  it('flags THIN when cheaper but not by the target', () => {
+    const v = evaluateParity({ ...base, directTotal: 1450, otaTotal: 1476, targetDiscountPct: 0.10 });
+    expect(v.status).toBe('thin');
+  });
+
+  it('says so when a target would price below indifference (deep promo)', () => {
+    // A 25% target against an already-promoted price undercuts the owner's own economics.
+    const v = evaluateParity({ ...base, directTotal: 1200, otaTotal: 1476, targetDiscountPct: 0.25 });
+    expect(v.recommendedBand).toBeNull();
+    expect(v.notes.join(' ')).toMatch(/too low to undercut profitably/i);
+  });
+
+  it('reports parity against the list price separately from the promo price', () => {
+    const v = evaluateParity({ ...base, directTotal: 1838, otaTotal: 1476, otaListTotal: 1940 });
+    expect(v.vsListGapPct).toBeCloseTo(-0.0526, 3); // 5.3% under list, while 24.5% over the promo
+  });
+
+  it('recommends a band that is both attractive and profitable', () => {
+    const v = evaluateParity({ ...base, directTotal: 1400, otaTotal: 1476, targetDiscountPct: 0.05 });
+    expect(v.recommendedBand).not.toBeNull();
+    expect(Math.round(v.recommendedBand!.min)).toBe(1239);
+    expect(Math.round(v.recommendedBand!.max)).toBe(1402);
+    expect(v.status).toBe('healthy');
+  });
+});
+
+describe('across channels', () => {
+  it('takes the CHEAPEST channel as the one to beat, never the average', () => {
+    const offers = [
+      { channel: 'airbnb', otaTotal: 1476 },
+      { channel: 'booking.com', otaTotal: 1907 },
+    ];
+    expect(bestOffer(offers)!.channel).toBe('airbnb');
+  });
+
+  it('measures the spread between channels — the "OTAs disagree" problem', () => {
+    // Real Aug 28-30: Airbnb 1,476 vs Booking 1,907 on the same nights.
+    expect(channelSpreadPct([{ otaTotal: 1476 }, { otaTotal: 1907 }])).toBeCloseTo(0.292, 2);
+  });
+
+  it('has no spread to report for a single channel', () => {
+    expect(channelSpreadPct([{ otaTotal: 1476 }])).toBeNull();
+  });
+});

--- a/src/lib/growth/__tests__/parityWorklist.test.ts
+++ b/src/lib/growth/__tests__/parityWorklist.test.ts
@@ -1,0 +1,136 @@
+/** @jest-environment node */
+
+import {
+  buildWorklist, cellId, computeCoverage, outstandingCells,
+  type Observation, type ProbeInput,
+} from '../parityWorklist';
+
+const P = 'prahova-mountain-chalet';
+const NOW = new Date('2026-08-07T12:00:00Z');
+
+const PROBES: ProbeInput[] = [
+  { label: 'Crăciun', checkIn: '2026-12-24', checkOut: '2026-12-29', nights: 5, guests: 3, priority: 'high' },
+  { label: 'Crăciun', checkIn: '2026-12-24', checkOut: '2026-12-29', nights: 5, guests: 6, priority: 'high' },
+  { label: 'ordinary weekend', checkIn: '2027-03-19', checkOut: '2027-03-21', nights: 2, guests: 3, priority: 'normal' },
+];
+const CHANNELS = ['airbnb', 'booking.com'];
+
+const obs = (id: string, over: Partial<Observation> = {}): Observation => ({
+  cellId: id, status: 'captured', guestTotal: 1000,
+  capturedAt: '2026-08-07T10:00:00Z', source: 'browser', ...over,
+});
+
+describe('buildWorklist', () => {
+  it('creates one cell per window × occupancy × channel, plus a direct cell', () => {
+    const cells = buildWorklist(P, PROBES, CHANNELS);
+    expect(cells).toHaveLength(3 * 3); // 3 probes × (direct + 2 channels)
+    expect(cells.filter((c) => c.channel === 'direct')).toHaveLength(3);
+  });
+
+  it('records the direct price as an observation too, so it carries provenance', () => {
+    // The direct number is not a given — it comes from the engine or from a page, and which one
+    // matters (the site once rendered USD while the engine returned RON).
+    const cells = buildWorklist(P, PROBES, CHANNELS);
+    expect(cells.some((c) => c.channel === 'direct')).toBe(true);
+  });
+
+  it('gives a cell the same id across runs so drift can be measured', () => {
+    const a = buildWorklist(P, PROBES, CHANNELS)[0].cellId;
+    const b = buildWorklist(P, PROBES, CHANNELS)[0].cellId;
+    expect(a).toBe(b);
+    expect(a).toBe(cellId(P, '2026-12-24', '2026-12-29', 3, 'direct'));
+  });
+
+  it('keeps occupancy variants distinct', () => {
+    const cells = buildWorklist(P, PROBES, CHANNELS);
+    const three = cells.find((c) => c.guests === 3 && c.channel === 'airbnb')!;
+    const six = cells.find((c) => c.guests === 6 && c.channel === 'airbnb')!;
+    expect(three.cellId).not.toBe(six.cellId);
+  });
+});
+
+describe('computeCoverage — the anti-partial-report guard', () => {
+  const cells = buildWorklist(P, PROBES, CHANNELS);
+
+  it('counts uncaptured cells as MISSING rather than ignoring them', () => {
+    // This is the exact failure mode: two cells captured, seven silently absent, and a hand-made
+    // table that looks complete.
+    const cov = computeCoverage(cells, [obs(cells[0].cellId), obs(cells[1].cellId)], { now: NOW });
+    expect(cov.total).toBe(9);
+    expect(cov.captured).toBe(2);
+    expect(cov.missing).toBe(7);
+    expect(cov.complete).toBe(false);
+    expect(cov.missingCellIds).toHaveLength(7);
+  });
+
+  it('treats a channel REFUSING to quote as resolved, with its reason', () => {
+    // Airbnb enforcing a 4-night minimum is an answer, not a gap.
+    const all = cells.map((c) =>
+      c.channel === 'airbnb'
+        ? obs(c.cellId, { status: 'refused', guestTotal: null, reason: 'min stay 4 nights' })
+        : obs(c.cellId));
+    const cov = computeCoverage(cells, all, { now: NOW });
+    expect(cov.refused).toBe(3);
+    expect(cov.missing).toBe(0);
+    expect(cov.complete).toBe(true);
+  });
+
+  it('does NOT count an errored capture as complete — it is unfinished work', () => {
+    const all = cells.map((c, i) =>
+      i === 0 ? obs(c.cellId, { status: 'error', guestTotal: null, reason: 'bot check' }) : obs(c.cellId));
+    const cov = computeCoverage(cells, all, { now: NOW });
+    expect(cov.errored).toBe(1);
+    expect(cov.complete).toBe(false);
+  });
+
+  it('flags stale observations and reports the oldest age', () => {
+    const all = cells.map((c, i) =>
+      obs(c.cellId, { capturedAt: i === 0 ? '2026-07-20T10:00:00Z' : '2026-08-07T10:00:00Z' }));
+    const cov = computeCoverage(cells, all, { now: NOW, freshnessDays: 7 });
+    expect(cov.oldestAgeDays).toBe(18);
+    expect(cov.staleCellIds).toHaveLength(1);
+    expect(cov.complete).toBe(false); // stale data cannot claim completeness
+  });
+
+  it('uses the newest observation when a cell was captured more than once', () => {
+    const id = cells[0].cellId;
+    const cov = computeCoverage([cells[0]], [
+      obs(id, { capturedAt: '2026-08-01T10:00:00Z', guestTotal: 999 }),
+      obs(id, { capturedAt: '2026-08-07T10:00:00Z', guestTotal: 1234 }),
+    ], { now: NOW });
+    expect(cov.captured).toBe(1);
+    expect(cov.complete).toBe(true);
+  });
+
+  it('is complete only when every cell is resolved and fresh', () => {
+    const cov = computeCoverage(cells, cells.map((c) => obs(c.cellId)), { now: NOW });
+    expect(cov.resolvedPct).toBe(1);
+    expect(cov.complete).toBe(true);
+  });
+});
+
+describe('outstandingCells', () => {
+  const cells = buildWorklist(P, PROBES, CHANNELS);
+
+  it('returns exactly the work still owed, high priority first', () => {
+    const done = [obs(cells[0].cellId)];
+    const todo = outstandingCells(cells, done, { now: NOW });
+    expect(todo).toHaveLength(8);
+    expect(todo[0].priority).toBe('high');
+  });
+
+  it('re-queues errored and stale cells, not just missing ones', () => {
+    const all = cells.map((c, i) => {
+      if (i === 0) return obs(c.cellId, { status: 'error', guestTotal: null, reason: 'timeout' });
+      if (i === 1) return obs(c.cellId, { capturedAt: '2026-06-01T10:00:00Z' });
+      return obs(c.cellId);
+    });
+    const todo = outstandingCells(cells, all, { now: NOW, freshnessDays: 7 });
+    expect(todo.map((c) => c.cellId)).toEqual(expect.arrayContaining([cells[0].cellId, cells[1].cellId]));
+    expect(todo).toHaveLength(2);
+  });
+
+  it('returns nothing when the run is genuinely finished', () => {
+    expect(outstandingCells(cells, cells.map((c) => obs(c.cellId)), { now: NOW })).toEqual([]);
+  });
+});

--- a/src/lib/growth/parityMath.ts
+++ b/src/lib/growth/parityMath.ts
@@ -1,0 +1,209 @@
+/**
+ * Direct-vs-OTA parity economics.
+ *
+ * THE POINT: the guest-facing gap is not the decision. What matters is what the owner KEEPS. At an
+ * ~18.5% Airbnb commission and ~23% on Booking.com, a direct booking can be meaningfully cheaper for
+ * the guest AND still pay the owner more — because the commission never happens. So a flat "be 10%
+ * under" rule is arbitrary in both directions: too timid where commission is high, and potentially
+ * loss-making if an OTA runs a deep promotion.
+ *
+ * This module computes the band that actually matters:
+ *
+ *   indifference ─────────── recommended ─────────── OTA guest price
+ *   (net equal)              (guest sees a real      (above this you simply
+ *                            saving, owner earns      lose the booking)
+ *                            strictly more)
+ *
+ * Everything is a pure function of prices + configured rates. No clock, no fetch, no I/O — the same
+ * maths backs the on-demand skill and (later) the in-app evaluator, so the two cannot disagree.
+ */
+
+/** Per-channel take. `commissionPct` is what the platform keeps from the host. */
+export interface ChannelEconomics {
+  channel: string;
+  /** Host commission, as a fraction: 0.185 = 18.5%. */
+  commissionPct: number;
+  /**
+   * Fraction of the guest-facing total that never reaches the host at all — a separate guest service
+   * fee (Airbnb's split-fee model). Leave 0 for host-only-fee listings, where the guest total IS the
+   * host's base. Getting this wrong inflates the apparent OTA net, so record which model each listing
+   * actually uses rather than assuming.
+   */
+  guestFeePct?: number;
+}
+
+/** What a direct booking costs the owner to take (card fees, mainly). */
+export interface DirectEconomics {
+  /** Payment processing as a fraction of the total: 0.029 = 2.9%. */
+  paymentCostPct: number;
+}
+
+export interface ParityInput {
+  directTotal: number;
+  /** Guest-facing OTA total as displayed right now — possibly promo-reduced. */
+  otaTotal: number;
+  /** Guest-facing total BEFORE the channel's promotion, when the page shows a struck-through price. */
+  otaListTotal?: number;
+  channel: ChannelEconomics;
+  direct: DirectEconomics;
+  /** How much cheaper direct should look to the guest: 0.05 = 5%. */
+  targetDiscountPct: number;
+}
+
+export type ParityStatus =
+  /** Direct costs the guest MORE than the OTA — the worst state: you lose the booking and pay commission. */
+  | 'losing'
+  /** Cheaper than the OTA, but by less than the target — not a compelling reason to book direct. */
+  | 'thin'
+  /** Cheaper by at least the target, and still paying the owner more than the OTA would. */
+  | 'healthy'
+  /** So cheap that the owner nets LESS than simply taking the OTA booking. Money left on the table. */
+  | 'overshoot';
+
+export interface ParityVerdict {
+  status: ParityStatus;
+  /** Guest-facing gap; negative means direct is cheaper. -0.138 = direct is 13.8% cheaper. */
+  guestGapPct: number;
+  netDirect: number;
+  netOta: number;
+  /** netDirect − netOta at the CURRENT direct price. Positive = direct booking is worth more. */
+  netAdvantage: number;
+  /** The direct price at which the owner is exactly indifferent. Never price below this. */
+  indifferencePrice: number;
+  /** How far under the OTA price you could go before hitting indifference. The real room you have. */
+  headroomPct: number;
+  /** Where to price: at least a target-sized saving for the guest, never below indifference. */
+  recommendedBand: { min: number; max: number } | null;
+  /** True when the current OTA price is promotion-driven (a list price was supplied and is higher). */
+  promoDriven: boolean;
+  /** Parity against the channel's LIST price — "am I fine when the promo ends?" */
+  vsListGapPct: number | null;
+  notes: string[];
+}
+
+/** What the owner keeps from a direct booking. */
+export function netFromDirect(directTotal: number, direct: DirectEconomics): number {
+  return directTotal * (1 - direct.paymentCostPct);
+}
+
+/** What the owner keeps from an OTA booking at a given guest-facing total. */
+export function netFromOta(otaTotal: number, channel: ChannelEconomics): number {
+  const hostBase = otaTotal * (1 - (channel.guestFeePct ?? 0));
+  return hostBase * (1 - channel.commissionPct);
+}
+
+/**
+ * The direct price whose net exactly equals the net of the same booking taken through the channel.
+ * Below this the owner would genuinely be better off letting the OTA have it.
+ */
+export function indifferencePrice(
+  otaTotal: number,
+  channel: ChannelEconomics,
+  direct: DirectEconomics,
+): number {
+  return netFromOta(otaTotal, channel) / (1 - direct.paymentCostPct);
+}
+
+/**
+ * Fraction below the OTA's guest price that the owner could go while still netting at least as much.
+ * Depends only on the rates, not on the price — this is the structural advantage of booking direct
+ * (~16% against an 18.5% Airbnb commission, ~21% against 23% on Booking.com).
+ */
+export function headroomPct(channel: ChannelEconomics, direct: DirectEconomics): number {
+  return 1 - (1 - (channel.guestFeePct ?? 0)) * (1 - channel.commissionPct) / (1 - direct.paymentCostPct);
+}
+
+export function evaluateParity(input: ParityInput): ParityVerdict {
+  const { directTotal, otaTotal, otaListTotal, channel, direct, targetDiscountPct } = input;
+  const notes: string[] = [];
+
+  const guestGapPct = otaTotal > 0 ? directTotal / otaTotal - 1 : 0;
+  const netDirect = netFromDirect(directTotal, direct);
+  const netOta = netFromOta(otaTotal, channel);
+  const indifference = indifferencePrice(otaTotal, channel, direct);
+  const room = headroomPct(channel, direct);
+
+  const targetPrice = otaTotal * (1 - targetDiscountPct);
+  const recommendedBand = targetPrice >= indifference
+    ? { min: indifference, max: targetPrice }
+    : null;
+
+  const promoDriven = typeof otaListTotal === 'number' && otaListTotal > otaTotal;
+  const vsListGapPct = typeof otaListTotal === 'number' && otaListTotal > 0
+    ? directTotal / otaListTotal - 1
+    : null;
+
+  let status: ParityStatus;
+  if (directTotal >= otaTotal) {
+    status = 'losing';
+    notes.push(
+      `Direct costs the guest ${Math.round((guestGapPct) * 1000) / 10}% MORE than ${channel.channel}. ` +
+      `A guest who checks both books there, and the commission comes off the top.`
+    );
+  } else if (directTotal < indifference) {
+    status = 'overshoot';
+    notes.push(
+      `Direct is below the indifference price (${Math.round(indifference)}). Taking the ${channel.channel} ` +
+      `booking would actually pay more — this is cheaper than it needs to be.`
+    );
+  } else if (directTotal > targetPrice) {
+    status = 'thin';
+    notes.push(
+      `Cheaper than ${channel.channel}, but by under the ${Math.round(targetDiscountPct * 100)}% target — ` +
+      `probably not enough for a guest to switch.`
+    );
+  } else {
+    status = 'healthy';
+  }
+
+  if (recommendedBand === null) {
+    notes.push(
+      `A ${Math.round(targetDiscountPct * 100)}% saving would price below indifference — this channel's ` +
+      `current price is too low to undercut profitably. Address the price on ${channel.channel} rather ` +
+      `than matching it here.`
+    );
+  }
+
+  if (promoDriven) {
+    notes.push(
+      `${channel.channel}'s price is promotion-driven (list ${Math.round(otaListTotal!)}). Chasing a promo ` +
+      `down is optional — but note the commission still makes a direct booking worth more at any price ` +
+      `above ${Math.round(indifference)}.`
+    );
+  }
+
+  return {
+    status,
+    guestGapPct,
+    netDirect,
+    netOta,
+    netAdvantage: netDirect - netOta,
+    indifferencePrice: indifference,
+    headroomPct: room,
+    recommendedBand,
+    promoDriven,
+    vsListGapPct,
+    notes,
+  };
+}
+
+/**
+ * Across channels, the binding constraint is the CHEAPEST guest-facing price — averaging hides the one
+ * that is actually losing you the booking. Returns the channel to beat.
+ */
+export function bestOffer<T extends { channel: string; otaTotal: number }>(offers: T[]): T | null {
+  if (!offers.length) return null;
+  return offers.reduce((best, o) => (o.otaTotal < best.otaTotal ? o : best));
+}
+
+/**
+ * Spread between the dearest and cheapest channel for the same nights. A wide spread is its own
+ * problem: one channel quietly undercuts the others, dragging down the floor direct has to beat and
+ * looking incoherent to any guest who checks twice.
+ */
+export function channelSpreadPct(offers: Array<{ otaTotal: number }>): number | null {
+  if (offers.length < 2) return null;
+  const totals = offers.map((o) => o.otaTotal);
+  const min = Math.min(...totals);
+  return min > 0 ? Math.max(...totals) / min - 1 : null;
+}

--- a/src/lib/growth/parityWorklist.ts
+++ b/src/lib/growth/parityWorklist.ts
@@ -1,0 +1,177 @@
+/**
+ * The parity worklist — the contract that makes a run COMPLETE rather than partial.
+ *
+ * The failure this exists to prevent: a probe list is generated, a human drives a browser through
+ * "enough" of it, and the report is assembled by hand from whatever came back. Gaps are invisible
+ * because a cell that was never captured simply doesn't appear in the table. The reader sees a tidy
+ * grid and reasonably assumes it is the whole picture.
+ *
+ * So: the unit of work is a CELL — one (window × occupancy × channel) — with a stable id. Every cell
+ * is owed an outcome. A cell with no observation renders as UNKNOWN and counts against coverage; it is
+ * never silently dropped. A channel that REFUSES to quote (Airbnb enforcing a 4-night minimum) is a
+ * recorded outcome with a reason, not a blank.
+ *
+ * Ids are stable across runs so the same cell can be compared over time — that is what turns a
+ * one-off snapshot into drift tracking.
+ *
+ * Pure: no clock, no I/O. `now` is injected so staleness is deterministic in tests.
+ */
+
+export type ObservationStatus =
+  /** A price was read. */
+  | 'captured'
+  /** The channel exists but will not quote this stay (min-stay, occupancy cap, closed dates). */
+  | 'refused'
+  /** The channel quotes nothing because the dates are taken. */
+  | 'unavailable'
+  /** The capture failed (bot check, timeout, layout change). Distinct from `refused` on purpose. */
+  | 'error';
+
+export interface WorklistCell {
+  cellId: string;
+  propertyId: string;
+  window: string;
+  checkIn: string;
+  checkOut: string;
+  nights: number;
+  guests: number;
+  channel: string;
+  priority: 'high' | 'normal';
+}
+
+export interface Observation {
+  cellId: string;
+  status: ObservationStatus;
+  /** Guest-facing total, or the direct total for channel `direct`. Null unless status is `captured`. */
+  guestTotal: number | null;
+  /** The struck-through pre-promotion price, when the page shows one. */
+  listTotal?: number | null;
+  promoActive?: boolean;
+  /** Why a channel refused or a capture failed — required for anything other than `captured`. */
+  reason?: string;
+  /** ISO timestamp. */
+  capturedAt: string;
+  /** `api` for the direct engine, `browser` for anything read off a page. */
+  source: 'api' | 'browser';
+  url?: string;
+}
+
+/**
+ * Stable, human-readable, and identical across runs for the same logical cell — so a February run can
+ * be diffed against a December one.
+ */
+export function cellId(
+  propertyId: string, checkIn: string, checkOut: string, guests: number, channel: string,
+): string {
+  return `${propertyId}|${checkIn}|${checkOut}|${guests}|${channel}`;
+}
+
+export interface ProbeInput {
+  label: string;
+  checkIn: string;
+  checkOut: string;
+  nights: number;
+  guests: number;
+  priority: 'high' | 'normal';
+}
+
+/**
+ * Expand probes into cells — one per channel, plus a `direct` cell so the site's own price is a
+ * recorded observation with provenance rather than an unexamined given.
+ */
+export function buildWorklist(propertyId: string, probes: ProbeInput[], channels: string[]): WorklistCell[] {
+  const cells: WorklistCell[] = [];
+  for (const p of probes) {
+    for (const channel of ['direct', ...channels]) {
+      cells.push({
+        cellId: cellId(propertyId, p.checkIn, p.checkOut, p.guests, channel),
+        propertyId, window: p.label, checkIn: p.checkIn, checkOut: p.checkOut,
+        nights: p.nights, guests: p.guests, channel, priority: p.priority,
+      });
+    }
+  }
+  return cells;
+}
+
+export interface Coverage {
+  total: number;
+  captured: number;
+  refused: number;
+  unavailable: number;
+  errored: number;
+  /** Cells with no observation at all. The number that matters. */
+  missing: number;
+  /** Cells resolved one way or another, over total. */
+  resolvedPct: number;
+  /** Age in days of the OLDEST observation in play — the report's honesty about staleness. */
+  oldestAgeDays: number | null;
+  /** Cells whose observation is older than the freshness budget. */
+  staleCellIds: string[];
+  missingCellIds: string[];
+  complete: boolean;
+}
+
+/**
+ * Coverage over a worklist. `complete` requires every cell resolved AND nothing stale — a run that
+ * cannot say both is a partial run and must present itself as one.
+ */
+export function computeCoverage(
+  cells: WorklistCell[],
+  observations: Observation[],
+  opts?: { now?: Date; freshnessDays?: number },
+): Coverage {
+  const now = opts?.now ?? new Date();
+  const freshnessDays = opts?.freshnessDays ?? 7;
+  const byId = new Map<string, Observation>();
+  for (const o of observations) {
+    const prev = byId.get(o.cellId);
+    if (!prev || o.capturedAt > prev.capturedAt) byId.set(o.cellId, o); // newest wins
+  }
+
+  let captured = 0, refused = 0, unavailable = 0, errored = 0;
+  const missingCellIds: string[] = [];
+  const staleCellIds: string[] = [];
+  let oldestMs: number | null = null;
+
+  for (const c of cells) {
+    const o = byId.get(c.cellId);
+    if (!o) { missingCellIds.push(c.cellId); continue; }
+    if (o.status === 'captured') captured++;
+    else if (o.status === 'refused') refused++;
+    else if (o.status === 'unavailable') unavailable++;
+    else errored++;
+
+    const ageMs = now.getTime() - Date.parse(o.capturedAt);
+    if (Number.isFinite(ageMs)) {
+      if (oldestMs === null || ageMs > oldestMs) oldestMs = ageMs;
+      if (ageMs > freshnessDays * 86_400_000) staleCellIds.push(c.cellId);
+    }
+  }
+
+  const resolved = captured + refused + unavailable;
+  return {
+    total: cells.length,
+    captured, refused, unavailable, errored,
+    missing: missingCellIds.length,
+    resolvedPct: cells.length ? resolved / cells.length : 0,
+    oldestAgeDays: oldestMs === null ? null : Math.floor(oldestMs / 86_400_000),
+    staleCellIds, missingCellIds,
+    // `errored` deliberately blocks completeness: a failed capture is unfinished work, not an answer.
+    complete: missingCellIds.length === 0 && errored === 0 && staleCellIds.length === 0,
+  };
+}
+
+/** The cells still owed work, highest priority first — what the skill should go and do next. */
+export function outstandingCells(
+  cells: WorklistCell[],
+  observations: Observation[],
+  opts?: { now?: Date; freshnessDays?: number },
+): WorklistCell[] {
+  const cov = computeCoverage(cells, observations, opts);
+  const owed = new Set([...cov.missingCellIds, ...cov.staleCellIds]);
+  const byId = new Map(observations.map((o) => [o.cellId, o]));
+  for (const c of cells) if (byId.get(c.cellId)?.status === 'error') owed.add(c.cellId);
+  return cells
+    .filter((c) => owed.has(c.cellId))
+    .sort((a, b) => (a.priority === b.priority ? 0 : a.priority === 'high' ? -1 : 1) || a.checkIn.localeCompare(b.checkIn));
+}

--- a/src/services/growth/parityObservations.ts
+++ b/src/services/growth/parityObservations.ts
@@ -1,0 +1,110 @@
+/**
+ * Persistence for parity observations — the piece that turns a manual browser session into a system.
+ *
+ * Without this, every run is hand-assembled: numbers go from a page, through someone's short-term
+ * memory, into a throwaway script. Gaps are invisible, staleness is invisible, and two runs cannot be
+ * compared. With it, a run is "work the outstanding list until coverage is complete", and a re-run six
+ * weeks later reuses the same cell ids so drift is measurable.
+ *
+ * Admin-SDK only. Nothing here judges prices — that is `parityMath`.
+ */
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { loggers } from '@/lib/logger';
+import type { Observation, ObservationStatus } from '@/lib/growth/parityWorklist';
+
+const logger = loggers.campaign;
+const COLLECTION = 'channelPriceObservations';
+
+export interface ObservationRecord extends Observation {
+  propertyId: string;
+  checkIn: string;
+  checkOut: string;
+  nights: number;
+  guests: number;
+  channel: string;
+  /** Login state / currency the capture was made in — a Genius or host session skews the number. */
+  sessionState?: string;
+  capturedBy?: string;
+}
+
+export interface RecordObservationInput {
+  propertyId: string;
+  cellId: string;
+  checkIn: string;
+  checkOut: string;
+  nights: number;
+  guests: number;
+  channel: string;
+  status: ObservationStatus;
+  guestTotal?: number | null;
+  listTotal?: number | null;
+  promoActive?: boolean;
+  reason?: string;
+  source: 'api' | 'browser';
+  url?: string;
+  sessionState?: string;
+  capturedBy?: string;
+  /** Injected so a batch of captures can share one timestamp; defaults to now. */
+  capturedAt?: string;
+}
+
+/**
+ * Append an observation. Append-only by design: a new capture never overwrites the old one, so the
+ * history of a cell is the price history of that window. Readers take the newest.
+ */
+export async function recordObservation(input: RecordObservationInput): Promise<string> {
+  if (input.status === 'captured' && typeof input.guestTotal !== 'number') {
+    throw new Error(`cell ${input.cellId}: status 'captured' requires a guestTotal`);
+  }
+  if (input.status !== 'captured' && !input.reason) {
+    throw new Error(`cell ${input.cellId}: status '${input.status}' requires a reason — a blank is not an outcome`);
+  }
+
+  const db = await getAdminDb();
+  const capturedAt = input.capturedAt ?? new Date().toISOString();
+  const doc: ObservationRecord & { createdAt: unknown } = {
+    cellId: input.cellId,
+    propertyId: input.propertyId,
+    checkIn: input.checkIn,
+    checkOut: input.checkOut,
+    nights: input.nights,
+    guests: input.guests,
+    channel: input.channel,
+    status: input.status,
+    guestTotal: input.guestTotal ?? null,
+    listTotal: input.listTotal ?? null,
+    promoActive: input.promoActive ?? false,
+    ...(input.reason ? { reason: input.reason } : {}),
+    source: input.source,
+    ...(input.url ? { url: input.url } : {}),
+    ...(input.sessionState ? { sessionState: input.sessionState } : {}),
+    ...(input.capturedBy ? { capturedBy: input.capturedBy } : {}),
+    capturedAt,
+    createdAt: FieldValue.serverTimestamp(),
+  };
+
+  const ref = await db.collection(COLLECTION).add(doc);
+  logger.info('parity observation recorded', {
+    cellId: input.cellId, channel: input.channel, status: input.status, total: input.guestTotal ?? null,
+  });
+  return ref.id;
+}
+
+/** Every observation for a property, newest first. The report reads this and nothing else. */
+export async function loadObservations(propertyId: string, sinceIso?: string): Promise<ObservationRecord[]> {
+  const db = await getAdminDb();
+  let q = db.collection(COLLECTION).where('propertyId', '==', propertyId);
+  if (sinceIso) q = q.where('capturedAt', '>=', sinceIso);
+  const snap = await q.get();
+  return snap.docs
+    .map((d) => d.data() as ObservationRecord)
+    .sort((a, b) => b.capturedAt.localeCompare(a.capturedAt));
+}
+
+/** Newest observation per cell — what coverage and the report table are built from. */
+export async function latestByCell(propertyId: string, sinceIso?: string): Promise<Map<string, ObservationRecord>> {
+  const all = await loadObservations(propertyId, sinceIso);
+  const map = new Map<string, ObservationRecord>();
+  for (const o of all) if (!map.has(o.cellId)) map.set(o.cellId, o); // already newest-first
+  return map;
+}


### PR DESCRIPTION
Answers "is the direct site still the best place to book?" for Airbnb and Booking.com, on demand, at a 4–6 week cadence.

## Net economics, not the headline gap

Commission never happens on a direct booking. At ~18.5% (Airbnb) and ~23% (Booking) against ~2.9% card costs, you can charge a guest **meaningfully less and still earn more** — ~16% and ~21% of room respectively. A flat "be 10% under" rule is arbitrary in both directions.

`parityMath.ts` computes the **indifference price** (where net is equal — the floor), the **net advantage**, and four verdicts: `losing` / `thin` / `healthy` / `overshoot`. That last one matters: priced below indifference you earn less than letting the OTA take the booking, while the headline gap looks flattering.

Promotions aren't obligations — parity is reported against both the promo and list price, and when a target-sized discount would fall below indifference the recommendation is to fix the promotion on that channel rather than match it.

## Year-agnostic probing

Special periods come from the **`holidays` collection** — fetched facts with per-row sources, the doctrine already set by `seed-holidays.ts`. Proven the hard way: a computed version got *every* school break wrong and invented a fixed February ski week where the official row says each county picks one week from a three-week window.

The probe list is the **union** of that calendar (why people travel) and the property's own `dateOverrides` (what it charges a premium for). New Year's Eve is the year's highest rate here and is **not** a public holiday — the legal calendar alone would miss it.

## The closed loop

The unit of work is a **cell** — one `(window × occupancy × channel)` with a stable id. Every cell is owed an outcome:

- no observation → prints `?`, counts as missing, re-queued
- a channel refusing to quote (Airbnb's 4-night minimum) → recorded outcome **with a reason**; `parity-capture` rejects a non-captured status without one
- an errored capture blocks completeness — unfinished work, not an answer
- stale observations re-queued, so the cadence never quietly reports old prices
- the table is rendered **from the store**, never hand-assembled, and prints `STATUS: INCOMPLETE — do NOT treat this table as the whole picture` whenever anything is missing, errored or stale

Append-only storage with stable cell ids, so re-runs produce drift history. Direct prices carry `source: 'api'` — the engine's number is not automatically what a browser renders (this site once showed `US$401` where the engine said `1,838 lei`).

## Testing

27 new tests (14 economics, 13 worklist/coverage), 74 growth tests pass, `npm run build` green. Verified end to end against live data: pack records direct cells, capture writes observations, report renders with `?`/`n/a` and an explicit incomplete status.

`channelPriceObservations` is Admin-SDK-write / owner-read — **rules need deploying with this**.