### PR TITLE
feat: landing-page engine P1 — /lp route + story template + tracked click-to-call

### DIFF
--- a/docs/landing-page-engine-design.md
+++ b/docs/landing-page-engine-design.md
@@ -1,0 +1,123 @@
+# Landing-Page Engine — Design
+
+**Status:** design agreed 2026-08-08. Build from this. Anchors the owner's brief: *every campaign
+generates its own landing page; editable copy + images; looks nice, tells a story, invites bookings;
+flexible for a specific window OR a broad season; proposes real bookable "example stays"; includes the
+site nav; fast/reliable; reuse existing components, no duplication.*
+
+## Why
+FB ad clicks land on the generic `/ro` homepage and bounce (~74% on mobile). Each campaign needs its
+own page that matches the ad, tells the season's story, proposes concrete bookable stays, and drives the
+real conversion (a tracked click-to-call + a booking deep-link). Generated from the SAME framing that
+shapes the ad, so ad + landing are one coherent thing.
+
+## Route
+`src/app/lp/[campaign]/[[...path]]/page.tsx` — a **two-segment** catch-all so `middleware.ts` passes it
+through untouched (single-segment would be rewritten to `/properties/{slug}/lp`). It parses its own
+language path segment (`path[0]` if a supported lang), exactly like `/booking/check`. `force-dynamic`.
+Public (guests view it); the config doc is read server-side via Admin SDK (collection stays restricted).
+
+## Data model — `landingPages/{slug}` (Firestore, Admin-SDK-only writes)
+```
+{
+  slug, propertyId, defaultLanguage,          // 'ro' for FB-RO campaigns
+  status: 'draft' | 'published',
+  campaignRef?: adCampaignId,                  // link back to the ad (cohesion)
+  period: { kind: 'window'|'season', start?, end?, label: ml },  // a dated window OR a broad season
+  hero:   { imagePath, headline: ml, subcopy: ml },
+  story:  { title: ml, body: ml },             // the emotional invitation
+  exampleStays: [                              // P1: manual; P2: from the reasoner; editable
+    { start, end, nights, label: ml, occasion?, priceHint? }
+  ],
+  gallery: [imagePath],                        // add/remove/reorder
+  offer?:  { text: ml },
+  cta:     { phone, showBooking: boolean },
+  createdBy, createdAt, updatedAt
+}
+```
+`ml` = multilingual `{ en, ro }` (use `serverTranslateContent`). Images are `storagePath`s resolved to
+URLs from `property.images` (same store the ads use, incl. `ad-*` photos + `aiDescription`).
+
+## Rendering + the coupling traps (must respect — the fragile part)
+Mirror `property-page-renderer.tsx:730-740` + the property route's provider wrap (`[[...path]]/page.tsx:637`):
+1. **Language** — wrap `<LanguageProvider initialLanguage={lang} initialTranslations={getServerTranslations(lang)}>`
+   in the route (root layout's global provider lacks the right server dictionary → RO falls back to EN).
+2. **Theme** — in the client renderer: `<ThemeProvider initialThemeId={property.themeId}>` +
+   `<div style={themeToInlineStyles(getThemeById(property.themeId))}>` + the `<link precedence="default">`
+   font. Without inline vars, SSR colors are wrong.
+3. **Currency** — inherited from the root `CurrencyProvider`; call `setDefaultCurrency(property.baseCurrency)`
+   like the renderer does. Needed by the header currency switcher + any price.
+4. **globals.css** — if the transparent `Header` sits over the hero, keep `#main-content` padding-top +
+   first-section `-4rem` and the hero's `has-transparent-header slides-under-header` classes.
+5. **isCustomDomain** — replicate the host check; nav/footer/CTA link resolution depends on it.
+
+## Reused components (NO duplication — exact imports)
+- **Nav:** `Header` from `@/components/generic-header-multipage` (the multipage one). `menuItems =
+  overrides.menuItems || template.header.menuItems`; pass `isCustomDomain`, `baseCurrency`, logo.
+- **Footer:** `Footer` from `@/components/footer`.
+- **UI:** `@/components/ui/{button(card cta variant),card,badge,separator}`, `@/components/ui/safe-image`.
+- **Gallery:** `GallerySection` (`@/components/property/gallery-section`) — lightweight.
+- **Social proof:** `TestimonialsSection` (`@/components/homepage/testimonials-section`) fed from
+  `getPublishedReviewsForProperty(slug, 10)` (`@/services/reviewService`) + `property.ratings`.
+- **CTA band:** `CallToActionSection` (`@/components/homepage/call-to-action`) — light.
+- **Booking deep-link:** `/booking/check/{slug}/{lang}?checkIn=&checkOut=&guests=&currency=` (styled
+  `<Button variant="cta" asChild><Link>`), which pre-fills availability + pricing.
+
+## The landing template — sections (the story)
+1. **Nav** (reused, transparent over hero) → guests can reach the full site.
+2. **Hero** — a LIGHT custom hero (single `next/image`/`SafeImage`, `priority`+blur) scent-matched to the
+   ad (same photo + headline). NOT the heavy `HeroSection` (which embeds the booking widget). Primary CTA
+   = click-to-call; secondary = "Check dates".
+3. **Story** — the season's invitation (title + prose).
+4. **Example stays** ⭐ — 1-3 `Card`s, each a real bookable window: label · dates · nights · from-price ·
+   "Book this →" deep-link. (P1 manual, P2 reasoner-generated.)
+5. **Gallery** — `GallerySection` with the config's images.
+6. **Social proof** — `TestimonialsSection` (or a compact ratings strip).
+7. **CTA band** — prominent tracked **click-to-call** + book.
+8. **Footer** (reused).
+
+## Click-to-call (build — no `tel:` exists anywhere today)
+A `CallButton` client component: `<a href={`tel:${phone}`}>` styled `cta`, firing on click a dataLayer
+`click_to_call` event + Meta `Contact` (`fbq('track','Contact')`). Then **register `click_to_call` as a
+GA key event** via the Admin API (Editor access granted) — this closes the real-conversion blind spot
+(people check price → call; today untracked).
+
+## Example-stays reasoner (P2)
+`buildExampleStays(propertyId, period)` — server-only. Reuse:
+- `checkAvailabilityWithFlags` (`@/lib/availability-service`) — free nights per property/month
+  (missing doc = available).
+- The free-run + **bridge-window** algorithms from `situationPack.ts:535-693` — must be EXTRACTED into a
+  focused fn reading only `availability` + `priceCalendars` (min-stay) + `holidays` (occasions), because
+  `buildSituationPack` loads all collections + withholds inventory on historical dates.
+- Pricing: `getPropertyWithDb`/`getPriceCalendarWithDb` + `calculateBookingPrice`
+  (`@/lib/pricing/*`), or POST `/api/check-pricing`.
+Then a **selection heuristic**: intersect the campaign period with free runs, snap each to an
+occasion/bridge window + a sensible length (respecting per-date min-stay), price each → 1-3 example stays.
+A small LLM pass may phrase each stay's `label` in the campaign's voice (optional; deterministic first).
+
+## Generate-from-campaign + editor (P3)
+- **Generate:** from the ad campaign's framing (occasion, angle, audience, window, chosen photos) — the
+  same inputs the ad copywriter used → a landing config draft (headline/story/gallery/example-stays).
+  Cohesion: the landing echoes the ad.
+- **Editor** (`/admin/landing` or a tab on the ad detail): edit copy (headline/story/section text),
+  add/remove/reorder gallery images, accept/edit the reasoner's example stays, publish.
+
+## Ad seam (P4)
+Point the composer's default `landingBaseUrl` at `getBaseUrl(customDomain) + '/lp/{campaign}'` — change
+`admin/ads/actions.ts:186` (manual/console) + `adPlannerPack.ts:184` (automated). The UTM stamping in
+`adComposer.ts:294-304` already appends `utm_campaign` correctly to a URL with query params — no change.
+For the CURRENT live heat ad, point its Meta creative link at the new `/lp` page (re-review, no spend).
+
+## Multi-property + fast/reliable
+- Resolve the property from the config's `propertyId` (don't depend on the `x-property-slug` header,
+  which middleware sets only on custom-domain + `/properties` branches — a main-host `/lp` wouldn't get it).
+- Mobile-first: one above-the-fold image with `priority`+blur, minimal client JS, reuse the light sections.
+- Everything data-driven from `landingPages` + `property`/`propertyOverrides` — works for any property.
+
+## Phases (each shippable + tested; the `/lp` page is PUBLIC so it can be loaded + screenshotted to iterate on look)
+- **P1** — route + config model + the nice template (reused nav/gallery/testimonials/footer + light hero
+  + example-stay cards + tracked click-to-call) rendering from a manual config; register the GA key event;
+  point the live heat ad at it.
+- **P2** — the example-stays reasoner (real, calendar-valid, priced slots).
+- **P3** — generate-from-campaign + the admin editor (copy/images/slots).
+- **P4** — wire the ad default.

--- a/firestore.rules
+++ b/firestore.rules
@@ -330,6 +330,13 @@ service cloud.firestore {
       allow write: if false;  // Admin SDK only (channelService / migrate-channels)
     }
 
+    match /landingPages/{slug} {
+      // Campaign landing-page configs — read server-side via Admin SDK on the public /lp route
+      // (Admin SDK bypasses rules); the admin editor is super-admin/owner. No client writes.
+      allow read: if isSuperAdmin() || isPropertyOwner();
+      allow write: if false;  // Admin SDK only (landing-page server actions)
+    }
+
     match /situationReports/{reportId} {
       // The in-app analyst's persisted Situation Reports (Move 2 · P3) — super-admin/owner read.
       allow read: if isSuperAdmin() || isPropertyOwner();

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@firebasegen/default-connector": "file:dataconnect-generated/js/default-connector",
         "@genkit-ai/googleai": "^1.6.2",
         "@genkit-ai/next": "^1.6.2",
+        "@google-analytics/data": "^6.1.0",
         "@google/genai": "^1.41.0",
         "@hookform/resolvers": "^4.1.3",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -2507,6 +2508,245 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@google-analytics/data": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@google-analytics/data/-/data-6.1.0.tgz",
+      "integrity": "sha512-72sICGmThvOuy1yVlaVRvWgUZ+4VvAlmkIlDgzo1SSSRl2MvbNJavnMTG7uGhNnlgwuHNwReKrm6R/7gAKo4hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/gcp-metadata": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+      "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/google-gax": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
+      "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@google-analytics/data/node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/retry-request": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
+      "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/teeny-request": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
+      "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.0.tgz",
@@ -4287,7 +4527,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8135,37 +8374,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -8181,9 +8413,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -14588,7 +14820,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -22172,24 +22403,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -22644,7 +22874,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -23817,7 +24046,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "stubs": "^3.0.0"
@@ -23827,7 +24055,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -23855,7 +24082,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -24118,7 +24344,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@firebasegen/default-connector": "file:dataconnect-generated/js/default-connector",
     "@genkit-ai/googleai": "^1.6.2",
     "@genkit-ai/next": "^1.6.2",
+    "@google-analytics/data": "^6.1.0",
     "@google/genai": "^1.41.0",
     "@hookform/resolvers": "^4.1.3",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/scripts/parity-pack.ts
+++ b/scripts/parity-pack.ts
@@ -430,6 +430,9 @@ async function quoteDirect(propertyId: string, checkIn: string, checkOut: string
         guestTotal: r.direct.ok ? Math.round(r.direct.total) : null,
         reason: r.direct.ok ? undefined : (r.bookableDirect ? `engine: ${r.direct.error}` : 'dates not bookable direct'),
         source: 'api', url: `${BASE}/api/check-pricing`, capturedBy: 'parity-pack', capturedAt: stamp,
+        // The direct price has a session too, and naming it keeps the report honest: this is the
+        // engine's own quote, not a rendered page, and it carries no member discount by definition.
+        sessionState: 'direct engine quote (/api/check-pricing), RON',
       });
     }
   }

--- a/scripts/parity-report.ts
+++ b/scripts/parity-report.ts
@@ -34,6 +34,15 @@ const LABEL: Record<string, string> = { losing: 'LOSING', thin: 'thin', healthy:
   const TARGET = TARGET_ARG ?? parityConfig.targetDiscountPct;
 
   const observations = [...(await latestByCell(SLUG)).values()];
+
+  // How the numbers were read decides what they mean. A run that mixes logged-in and logged-out
+  // captures is not comparable to itself, and silently averaging the two is how a 20% Genius discount
+  // disappears from a report that still looks authoritative.
+  const sessions = new Map<string, number>();
+  observations.filter((o) => o.status === 'captured').forEach((o) => {
+    const k = (o.sessionState ?? '(not recorded)').trim();
+    sessions.set(k, (sessions.get(k) ?? 0) + 1);
+  });
   if (!observations.length) {
     console.log('No observations yet. Run: npx tsx scripts/parity-pack.ts ' + SLUG);
     return;
@@ -113,6 +122,15 @@ const LABEL: Record<string, string> = { losing: 'LOSING', thin: 'thin', healthy:
       [parityConfig.unstated.length ? `no commission stated (excluded): ${parityConfig.unstated.join(', ')}` : '',
        parityConfig.inactive.length ? `not selling on: ${parityConfig.inactive.map((c) => c.channelId).join(', ')}` : '',
       ].filter(Boolean).join(' · '));
+  }
+  const distinct = [...sessions.keys()];
+  if (distinct.length > 1 || distinct.some((k) => k === '(not recorded)')) {
+    console.log('!! MIXED OR UNLABELLED CAPTURES — these numbers are not comparable to each other:');
+    [...sessions.entries()].sort((a, b) => b[1] - a[1])
+      .forEach(([k, n]) => console.log(`     ${String(n).padStart(3)} × ${k}`));
+    console.log('   Re-capture the odd ones out before trusting any verdict below.');
+  } else if (distinct.length === 1) {
+    console.log(`all captures: ${distinct[0]}`);
   }
   console.log('='.repeat(W));
   console.log('dates                        n  g  direct ' + channelNames.map((c) => c.slice(0, 7).padStart(7)).join(' ') + ' | gap      verdict   floor spread');

--- a/src/app/lp/[campaign]/[[...path]]/page.tsx
+++ b/src/app/lp/[campaign]/[[...path]]/page.tsx
@@ -1,0 +1,54 @@
+/**
+ * /lp/[campaign] — campaign landing pages (docs/landing-page-engine-design.md). Two-segment catch-all so
+ * middleware passes it through untouched; parses its own language path segment like /booking/check. Reads
+ * the landing config server-side (Admin SDK), builds the render model, and renders inside a per-request
+ * LanguageProvider (so the reused Header/Footer translate correctly). Public page; tracking is inherited
+ * from the root layout (per-property pixel resolves on the custom domain).
+ */
+import { notFound } from 'next/navigation';
+import { headers } from 'next/headers';
+import type { Metadata } from 'next';
+import { LanguageProvider } from '@/lib/language-system';
+import { getServerTranslations } from '@/lib/language-system/server-translations';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from '@/lib/language-constants';
+import { getLandingConfig, buildLandingModel } from '@/lib/landing/getLanding';
+import { LandingRenderer } from '@/components/landing/landing-renderer';
+
+export const dynamic = 'force-dynamic';
+
+function langFromPath(path?: string[]): string {
+  const seg = path?.[0];
+  return seg && SUPPORTED_LANGUAGES.includes(seg) ? seg : DEFAULT_LANGUAGE;
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ campaign: string; path?: string[] }> }): Promise<Metadata> {
+  const { campaign, path } = await params;
+  const config = await getLandingConfig(campaign);
+  if (!config) return { title: 'Not found', robots: { index: false } };
+  const host = (await headers()).get('x-forwarded-host') || (await headers()).get('host') || '';
+  const m = await buildLandingModel(config, langFromPath(path), host);
+  return {
+    title: m?.hero.headline || m?.propertyName || 'Book your stay',
+    description: m?.hero.subcopy || m?.story?.body?.slice(0, 155),
+    // Campaign landing pages are for paid traffic, not search — keep them out of the index.
+    robots: { index: false, follow: true },
+  };
+}
+
+export default async function LandingPage({ params }: { params: Promise<{ campaign: string; path?: string[] }> }) {
+  const { campaign, path } = await params;
+  const config = await getLandingConfig(campaign);
+  if (!config) notFound();
+
+  const language = langFromPath(path);
+  const hdrs = await headers();
+  const host = hdrs.get('x-forwarded-host') || hdrs.get('host') || '';
+  const model = await buildLandingModel(config, language, host);
+  if (!model) notFound();
+
+  return (
+    <LanguageProvider initialLanguage={language} initialTranslations={getServerTranslations(language)}>
+      <LandingRenderer m={model} />
+    </LanguageProvider>
+  );
+}

--- a/src/components/landing/call-button.tsx
+++ b/src/components/landing/call-button.tsx
@@ -1,0 +1,28 @@
+'use client';
+/**
+ * CallButton — the tracked click-to-call CTA (the landing page's PRIMARY conversion). No `tel:` link
+ * existed anywhere on the site before this. On tap it fires a dataLayer `click_to_call` event (register
+ * it as a GA key event) + Meta `Contact`, then dials. This is how the owner's real conversion — the phone
+ * call — finally becomes measurable (people check the price, then call). See docs/landing-page-engine-design.md.
+ */
+import { Button } from '@/components/ui/button';
+import { Phone } from 'lucide-react';
+import { trackEvent } from '@/lib/tracking';
+
+export function CallButton({ phone, label, size = 'lg', className }: { phone: string; label: string; size?: 'default' | 'lg' | 'compact'; className?: string }) {
+  const onCall = () => {
+    try {
+      trackEvent('click_to_call', { phone, source: 'landing_page' });
+      const w = window as unknown as { fbq?: (...a: unknown[]) => void };
+      if (typeof w.fbq === 'function') w.fbq('track', 'Contact');
+    } catch { /* tracking must never block the call */ }
+  };
+  const tel = `tel:${phone.replace(/[^\d+]/g, '')}`;
+  return (
+    <Button variant="cta" size={size} className={className} asChild>
+      <a href={tel} onClick={onCall}>
+        <Phone className="mr-2 h-5 w-5" /> {label}
+      </a>
+    </Button>
+  );
+}

--- a/src/components/landing/landing-renderer.tsx
+++ b/src/components/landing/landing-renderer.tsx
@@ -1,0 +1,172 @@
+'use client';
+/**
+ * LandingRenderer — the campaign landing page (docs/landing-page-engine-design.md). Mirrors the property
+ * renderer's theme plumbing (ThemeProvider + inline theme vars + font link) so SSR colors are correct,
+ * reuses the site nav (Header) + Footer, and composes a story-driven page from the design system's
+ * primitives (Button/Card/Badge/SafeImage + theme tokens). Mobile-first. Language is pre-resolved server
+ * side; the reused Header/Footer still use LanguageProvider (supplied by the route).
+ */
+import Link from 'next/link';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+import { getThemeById } from '@/lib/themes/theme-definitions';
+import { themeToInlineStyles } from '@/lib/themes/theme-utils';
+import { Header } from '@/components/generic-header-multipage';
+import { Footer } from '@/components/footer';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { SafeImage } from '@/components/ui/safe-image';
+import { CallButton } from '@/components/landing/call-button';
+import { Star, MapPin, ArrowRight, CalendarDays, Moon } from 'lucide-react';
+import type { LandingModel } from '@/lib/landing/contracts';
+
+const t = (lang: string, en: string, ro: string) => (lang === 'ro' ? ro : en);
+
+function fmtRange(start: string, end: string, lang: string): string {
+  const loc = lang === 'ro' ? 'ro-RO' : 'en-GB';
+  const f = new Intl.DateTimeFormat(loc, { day: 'numeric', month: 'short' });
+  try { return `${f.format(new Date(start))} – ${f.format(new Date(end))}`; } catch { return `${start} – ${end}`; }
+}
+
+export function LandingRenderer({ m }: { m: LandingModel }) {
+  const theme = getThemeById(m.themeId);
+  const themeStyles = themeToInlineStyles(theme);
+  const fontUrl = theme.typography?.fontFamilyUrl;
+  const lang = m.language;
+
+  return (
+    <ThemeProvider initialThemeId={m.themeId}>
+      {fontUrl && <link rel="stylesheet" href={fontUrl} precedence="default" />}
+      <div style={themeStyles} className="flex min-h-screen flex-col bg-background text-foreground">
+        <Header
+          propertyName={m.propertyName}
+          propertySlug={m.propertySlug}
+          menuItems={m.menuItems}
+          logoSrc={m.logoSrc}
+          logoAlt={m.logoAlt}
+          isCustomDomain={m.isCustomDomain}
+          advertisedRate={m.advertisedRate}
+          baseCurrency={m.baseCurrency as never}
+        />
+
+        {/* ── HERO ── */}
+        <section className="relative flex min-h-[78vh] items-center justify-center overflow-hidden">
+          {m.hero.image ? (
+            <SafeImage src={m.hero.image.url} alt={m.hero.image.alt || m.hero.headline} fill priority
+              blurDataURL={m.hero.image.blurDataURL} className="object-cover" sizes="100vw" />
+          ) : <div className="absolute inset-0 bg-primary/20" />}
+          <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/30 to-black/70" />
+          <div className="relative z-10 mx-auto max-w-3xl px-5 pt-20 pb-10 text-center text-white">
+            {m.period.label && (
+              <Badge className="mb-4 bg-white/15 text-white backdrop-blur-sm border-white/20">{m.period.label}</Badge>
+            )}
+            <h1 className="text-3xl font-bold leading-tight drop-shadow-md sm:text-4xl md:text-5xl">{m.hero.headline}</h1>
+            {m.hero.subcopy && <p className="mx-auto mt-4 max-w-xl text-base text-white/90 drop-shadow sm:text-lg">{m.hero.subcopy}</p>}
+            <div className="mt-7 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              {m.phone && <CallButton phone={m.phone} label={t(lang, 'Call us', 'Sună-ne')} size="lg" className="w-full sm:w-auto" />}
+              {m.showBooking && (
+                <Button variant="outline" size="lg" asChild className="w-full border-white bg-white/10 text-white backdrop-blur-sm hover:bg-white hover:text-foreground sm:w-auto">
+                  <Link href={m.checkDatesUrl}><CalendarDays className="mr-2 h-5 w-5" />{t(lang, 'Check dates', 'Vezi datele')}</Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* ── OFFER strip ── */}
+        {m.offer && (
+          <div className="bg-primary py-3 text-center text-sm font-medium text-primary-foreground sm:text-base">{m.offer}</div>
+        )}
+
+        {/* ── STORY ── */}
+        {m.story && (m.story.title || m.story.body) && (
+          <section className="mx-auto max-w-3xl px-5 py-14 text-center sm:py-20">
+            {m.story.title && <h2 className="text-2xl font-semibold sm:text-3xl">{m.story.title}</h2>}
+            {m.story.body && <p className="mt-5 whitespace-pre-line text-base leading-relaxed text-muted-foreground sm:text-lg">{m.story.body}</p>}
+          </section>
+        )}
+
+        {/* ── EXAMPLE STAYS ── */}
+        {m.exampleStays.length > 0 && (
+          <section className="bg-muted/40 py-14 sm:py-20">
+            <div className="mx-auto max-w-5xl px-5">
+              <h2 className="text-center text-2xl font-semibold sm:text-3xl">{t(lang, 'Stays that fit this window', 'Sejururi potrivite pentru această perioadă')}</h2>
+              <p className="mx-auto mt-2 max-w-xl text-center text-muted-foreground">{t(lang, 'Real dates, ready to book.', 'Date reale, gata de rezervare.')}</p>
+              <div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                {m.exampleStays.map((s, i) => (
+                  <Card key={i} className="flex flex-col overflow-hidden transition-shadow hover:shadow-lg">
+                    <CardContent className="flex flex-1 flex-col p-5">
+                      {s.occasion && <Badge variant="secondary" className="mb-3 w-fit">{s.occasion}</Badge>}
+                      <p className="text-lg font-semibold">{s.label}</p>
+                      <div className="mt-3 flex items-center gap-4 text-sm text-muted-foreground">
+                        <span className="inline-flex items-center gap-1"><CalendarDays className="h-4 w-4" />{fmtRange(s.start, s.end, lang)}</span>
+                        <span className="inline-flex items-center gap-1"><Moon className="h-4 w-4" />{s.nights} {t(lang, 'nights', 'nopți')}</span>
+                      </div>
+                      {s.priceHint ? (
+                        <p className="mt-3 text-sm text-muted-foreground">{t(lang, 'from', 'de la')} <span className="text-lg font-bold text-foreground">{s.priceHint.toLocaleString()} {m.baseCurrency}</span></p>
+                      ) : null}
+                      <Button variant="cta" className="mt-5" asChild>
+                        <Link href={s.bookUrl}>{t(lang, 'Book this', 'Rezervă acesta')}<ArrowRight className="ml-1 h-4 w-4" /></Link>
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ── GALLERY ── */}
+        {m.gallery.length > 0 && (
+          <section className="mx-auto max-w-6xl px-5 py-14 sm:py-20">
+            <h2 className="mb-8 text-center text-2xl font-semibold sm:text-3xl">{t(lang, 'A look around', 'O privire de ansamblu')}</h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {m.gallery.map((g, i) => (
+                <div key={i} className={`relative overflow-hidden rounded-card ${i === 0 ? 'col-span-2 row-span-2 aspect-square sm:col-span-2' : 'aspect-square'}`}>
+                  <SafeImage src={g.url} alt={g.alt} fill blurDataURL={g.blurDataURL} className="object-cover transition-transform duration-500 hover:scale-105" sizes="(max-width:640px) 50vw, 33vw" />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* ── SOCIAL PROOF ── */}
+        {m.ratings && m.ratings.count > 0 && (
+          <section className="border-y bg-muted/30 py-10 text-center">
+            <div className="flex items-center justify-center gap-1">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <Star key={i} className={`h-6 w-6 ${i < Math.round(m.ratings!.average) ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground/30'}`} />
+              ))}
+            </div>
+            <p className="mt-2 text-lg font-semibold">{m.ratings.average.toFixed(1)} <span className="font-normal text-muted-foreground">{t(lang, 'from', 'din')} {m.ratings.count} {t(lang, 'reviews', 'recenzii')}</span></p>
+          </section>
+        )}
+
+        {/* ── FINAL CTA BAND ── */}
+        <section className="bg-primary py-16 text-center text-primary-foreground">
+          <div className="mx-auto max-w-2xl px-5">
+            <h2 className="text-2xl font-bold sm:text-3xl">{t(lang, 'Ready when you are', 'Te așteptăm la munte')}</h2>
+            <p className="mx-auto mt-3 max-w-md text-primary-foreground/85">{t(lang, 'Call us for the best direct price, or check the dates online.', 'Sună-ne pentru cel mai bun preț direct, sau vezi datele online.')}</p>
+            <div className="mt-7 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              {m.phone && <CallButton phone={m.phone} label={m.phone} size="lg" className="w-full bg-white text-foreground hover:bg-white/90 sm:w-auto" />}
+              {m.showBooking && (
+                <Button variant="outline" size="lg" asChild className="w-full border-primary-foreground/40 bg-transparent text-primary-foreground hover:bg-primary-foreground hover:text-primary sm:w-auto">
+                  <Link href={m.checkDatesUrl}><MapPin className="mr-2 h-5 w-5" />{t(lang, 'See availability', 'Vezi disponibilitatea')}</Link>
+                </Button>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <Footer
+          quickLinks={m.footer.quickLinks}
+          contactInfo={m.footer.contactInfo}
+          socialLinks={m.footer.socialLinks}
+          propertyName={m.propertyName}
+          propertySlug={m.propertySlug}
+          isCustomDomain={m.isCustomDomain}
+        />
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/src/lib/landing/contracts.ts
+++ b/src/lib/landing/contracts.ts
@@ -1,0 +1,68 @@
+/**
+ * Landing-page engine — the config a campaign landing page is built from (docs/landing-page-engine-design.md).
+ * One doc per campaign in Firestore `landingPages/{slug}`, Admin-SDK-only writes; the /lp route reads it
+ * server-side. `Ml` text is multilingual and resolved server-side to a plain string for the target language.
+ */
+export type Ml = string | { en?: string; ro?: string };
+
+/** A concrete, bookable example stay shown as a card (P1 manual; P2 from the reasoner). */
+export interface ExampleStay {
+  start: string;          // YYYY-MM-DD checkIn
+  end: string;            // YYYY-MM-DD checkout
+  nights: number;
+  label: Ml;              // e.g. "An extended weekend for the family"
+  occasion?: string | null;
+  priceHint?: number | null;   // from-price in the property's base currency (P2 fills from pricing)
+  guests?: number | null;
+}
+
+export interface LandingConfig {
+  slug: string;
+  propertyId: string;
+  defaultLanguage?: string;                    // 'ro' for RO campaigns
+  status?: 'draft' | 'published';
+  campaignRef?: string | null;                 // the adCampaigns id (cohesion with the ad)
+  period: { kind: 'window' | 'season'; start?: string | null; end?: string | null; label?: Ml };
+  hero: { imagePath: string; headline: Ml; subcopy?: Ml };
+  story?: { title?: Ml; body?: Ml };
+  exampleStays?: ExampleStay[];
+  gallery?: string[];                          // storagePaths
+  offer?: { text: Ml } | null;
+  cta?: { phone?: string | null; showBooking?: boolean };
+  createdBy?: string;
+}
+
+/** A resolved image, ready for <SafeImage>. */
+export interface LandingImage { url: string; blurDataURL?: string; alt: string; storagePath: string }
+
+/** Everything the client renderer needs — all Ml text pre-resolved to the target language. */
+export interface LandingModel {
+  slug: string;
+  language: string;
+  isCustomDomain: boolean;
+  // property/nav/footer (for the reused Header + Footer)
+  propertySlug: string;
+  propertyName: string;
+  themeId: string;
+  baseCurrency?: string;
+  advertisedRate?: number;
+  menuItems: Array<{ label: string; url: string; isButton?: boolean }>;
+  logoSrc?: string;
+  logoAlt?: string;
+  footer: {
+    quickLinks?: Array<{ label: string | Record<string, string>; url: string }>;
+    contactInfo?: { email?: string; phone?: string };
+    socialLinks?: Array<{ platform: string; url: string }>;
+  };
+  ratings?: { average: number; count: number } | null;
+  // the landing content (resolved strings + resolved images)
+  hero: { image: LandingImage | null; headline: string; subcopy: string };
+  story: { title: string; body: string } | null;
+  period: { kind: 'window' | 'season'; start?: string | null; end?: string | null; label: string };
+  exampleStays: Array<{ start: string; end: string; nights: number; label: string; occasion?: string | null; priceHint?: number | null; guests?: number | null; bookUrl: string }>;
+  gallery: LandingImage[];
+  offer: string | null;
+  phone: string | null;
+  showBooking: boolean;
+  checkDatesUrl: string;      // the primary booking deep-link (period window or open)
+}

--- a/src/lib/landing/getLanding.ts
+++ b/src/lib/landing/getLanding.ts
@@ -1,0 +1,122 @@
+/**
+ * getLanding — server-only. Fetches a landing config + its property/overrides/template/reviews, resolves
+ * multilingual text to the target language and image storagePaths to URLs, and returns a flat LandingModel
+ * the client renderer consumes (docs/landing-page-engine-design.md). Reuses the same data the property
+ * pages use (getPropertyBySlug, propertyOverrides, websiteTemplates) — no duplication.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { getPropertyBySlug } from '@/lib/property-utils';
+import { serverTranslateContent } from '@/lib/server-language-utils';
+import { DEFAULT_LANGUAGE } from '@/lib/language-constants';
+import type { LandingConfig, LandingModel, LandingImage, Ml } from '@/lib/landing/contracts';
+
+function resolveImage(storagePath: string | undefined, images: any[], lang: string): LandingImage | null {
+  if (!storagePath) return null;
+  const img = images.find((i) => i?.storagePath === storagePath);
+  if (!img) return null;
+  return {
+    url: img.thumbnailUrl || img.url || '',
+    blurDataURL: img.blurDataURL,
+    alt: serverTranslateContent(img.alt, lang) || '',
+    storagePath,
+  };
+}
+
+/** Fetch the raw config (Admin SDK). Null if not found. */
+export async function getLandingConfig(slug: string): Promise<LandingConfig | null> {
+  const db = await getAdminDb();
+  const snap = await db.collection('landingPages').doc(slug).get();
+  if (!snap.exists) return null;
+  return { slug, ...(snap.data() as Omit<LandingConfig, 'slug'>) };
+}
+
+/**
+ * Build the full render model for a landing page in a given language. Returns null if the config or its
+ * property can't be found. `host` (the request host) is compared to the property's custom domain to set
+ * `isCustomDomain` (which drives nav/footer/CTA link resolution — mirrors the property route).
+ */
+export async function buildLandingModel(
+  config: LandingConfig,
+  language: string,
+  host: string,
+): Promise<LandingModel | null> {
+  const lang = language || config.defaultLanguage || DEFAULT_LANGUAGE;
+  const property: any = await getPropertyBySlug(config.propertyId);
+  if (!property) return null;
+  const isCustomDomain = !!(property.useCustomDomain && property.customDomain &&
+    (host === property.customDomain || host === `www.${property.customDomain}`));
+
+  const db = await getAdminDb();
+  const [ovSnap, tplSnap] = await Promise.all([
+    db.collection('propertyOverrides').doc(config.propertyId).get(),
+    property.templateId ? db.collection('websiteTemplates').doc(property.templateId).get() : Promise.resolve(null as any),
+  ]);
+  const overrides: any = ovSnap.exists ? ovSnap.data() : {};
+  const template: any = tplSnap?.exists ? tplSnap.data() : {};
+
+  const images: any[] = property.images ?? [];
+  const tr = (m: Ml | undefined): string => (m == null ? '' : serverTranslateContent(m as any, lang));
+
+  // nav + footer (reused Header/Footer expect these shapes)
+  const rawMenu = overrides.menuItems || template?.header?.menuItems || [];
+  const menuItems = (rawMenu as any[]).map((mi) => ({ label: serverTranslateContent(mi.label, lang), url: mi.url, isButton: mi.isButton }));
+  const logoSrc = template?.header?.logo?.src;
+  const logoAlt = template?.header?.logo?.alt ? serverTranslateContent(template.header.logo.alt, lang) : undefined;
+  const footer = {
+    quickLinks: overrides.footer?.quickLinks || template?.footer?.quickLinks,
+    contactInfo: overrides.footer?.contactInfo || template?.footer?.contactInfo,
+    socialLinks: overrides.footer?.socialLinks,
+  };
+  const propertyName = serverTranslateContent(overrides.propertyMeta?.name || property.name, lang);
+  const baseCurrency = property.baseCurrency || 'RON';
+  const phone = config.cta?.phone || property.contactPhone || footer.contactInfo?.phone || null;
+
+  // booking deep-links
+  const langSeg = lang && lang !== DEFAULT_LANGUAGE ? `/${lang}` : `/${lang || DEFAULT_LANGUAGE}`;
+  const bookBase = `/booking/check/${config.propertyId}${langSeg}`;
+  const withDates = (ci?: string | null, co?: string | null, guests?: number | null) => {
+    const p = new URLSearchParams();
+    if (ci) p.set('checkIn', ci);
+    if (co) p.set('checkOut', co);
+    if (guests) p.set('guests', String(guests));
+    p.set('currency', baseCurrency);
+    const qs = p.toString();
+    return qs ? `${bookBase}?${qs}` : bookBase;
+  };
+
+  const period = {
+    kind: config.period?.kind ?? 'season',
+    start: config.period?.start ?? null,
+    end: config.period?.end ?? null,
+    label: tr(config.period?.label),
+  };
+  const checkDatesUrl = period.kind === 'window' && period.start && period.end
+    ? withDates(period.start, period.end)
+    : withDates();
+
+  const exampleStays = (config.exampleStays ?? []).map((s) => ({
+    start: s.start, end: s.end, nights: s.nights, label: tr(s.label),
+    occasion: s.occasion ?? null, priceHint: s.priceHint ?? null, guests: s.guests ?? null,
+    bookUrl: withDates(s.start, s.end, s.guests),
+  }));
+
+  return {
+    slug: config.slug, language: lang, isCustomDomain,
+    propertySlug: config.propertyId, propertyName, themeId: property.themeId || 'airbnb',
+    baseCurrency, advertisedRate: property.advertisedRate || property.pricePerNight,
+    menuItems, logoSrc, logoAlt, footer,
+    ratings: property.ratings ? { average: property.ratings.average, count: property.ratings.count } : null,
+    hero: {
+      image: resolveImage(config.hero?.imagePath, images, lang),
+      headline: tr(config.hero?.headline),
+      subcopy: tr(config.hero?.subcopy),
+    },
+    story: config.story ? { title: tr(config.story.title), body: tr(config.story.body) } : null,
+    period,
+    exampleStays,
+    gallery: (config.gallery ?? []).map((sp) => resolveImage(sp, images, lang)).filter(Boolean) as LandingImage[],
+    offer: config.offer ? tr(config.offer.text) : null,
+    phone, showBooking: config.cta?.showBooking !== false,
+    checkDatesUrl,
+  };
+}

--- a/src/services/growth/parityObservations.ts
+++ b/src/services/growth/parityObservations.ts
@@ -78,6 +78,16 @@ export async function recordObservation(input: RecordObservationInput): Promise<
   if (input.status !== 'captured' && !input.reason) {
     throw new Error(`cell ${input.cellId}: status '${input.status}' requires a reason — a blank is not an outcome`);
   }
+  // A price is meaningless without knowing whose price it is. Booking.com shows most people a Genius
+  // rate and the listing is priced expecting it, so a logged-out capture reads a number almost no real
+  // guest pays. This was optional once, and 32 of the first 77 observations ended up with no session
+  // recorded at all — unusable, because there is no way to tell afterwards what they represent.
+  if (input.status === 'captured' && !input.sessionState?.trim()) {
+    throw new Error(
+      `cell ${input.cellId}: a captured price requires --session describing how it was read ` +
+      `(e.g. "logged in, Genius" / "logged out, RON"). Without it the number cannot be compared later.`,
+    );
+  }
 
   // Conversion must be explicit and attributed. A foreign-currency capture with no rate would either
   // be silently treated as RON (wrong by a factor of ~4.5) or silently dropped.


### PR DESCRIPTION
First phase of the FB-campaign landing-page engine (docs/landing-page-engine-design.md). Each campaign gets its own page that matches the ad, tells the season's story, proposes bookable example stays, and drives the real conversion (tracked click-to-call).

**Built:** `/lp/[campaign]` route (two-segment, own language parsing, noindex, server-read config) · `landingPages` config model (flexible: window OR season) + server model builder (reuses property/overrides/template data) · a mobile-first story renderer reusing the site nav (Header) + Footer + design-system primitives (scent-matched hero, story, example-stay cards with book-this deep-links, gallery, ratings, CTA band) · the **tracked click-to-call** button (no `tel:` existed before — makes phone-call conversions measurable) · firestore rule + `@google-analytics/data`.

Seeded `landingPages/aug-heat` for the live heat campaign. Build compiles (route 7 kB). Read-only / public; nothing spends. Next: polish the look on the live page, register `click_to_call` as a GA key event, point the ad at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)