### PR TITLE
fix: JSX comment placement broke build (from the gallery-width PR)

### DIFF
--- a/src/components/landing/landing-renderer.tsx
+++ b/src/components/landing/landing-renderer.tsx
@@ -145,9 +145,9 @@ export function LandingRenderer({ m }: { m: LandingModel }) {
         {/* ── GALLERY (no heading; balanced grid whose column count adapts to the image count so there
               are no orphaned/left-shifted cells; bigger images) ── */}
         {m.gallery.length > 0 && (
-          {/* w-full is REQUIRED: this section is a direct flex-column child, where mx-auto otherwise
-              shrinks it to content width — and fill-images have zero intrinsic width, collapsing it. */}
           <section className="mx-auto w-full max-w-5xl px-5 py-12 sm:py-16">
+            {/* w-full above is REQUIRED: as a direct flex-column child, mx-auto would otherwise shrink this
+                to content width, and fill-images have zero intrinsic width — collapsing the section to ~52px. */}
             <div className={`grid gap-3 ${galleryCols}`}>
               {m.gallery.map((g, i) => (
                 // Inline aspect-ratio (NOT the Tailwind `aspect-[4/3]` class — the slash in an arbitrary


### PR DESCRIPTION
PR #212's `w-full` gallery fix accidentally placed a `{/* */}` comment as a standalone sibling before `<section>` inside a `{cond && (...)}` — invalid (two adjacent expressions). Moved it inside the section. The `w-full` fix (the actual gallery/story width fix) is unchanged. Build compiles.