### PR TITLE
feat: landing-page engine P2 (example-stays reasoner) + P3 (generate + admin editor)

### DIFF
--- a/scripts/test-example-stays.ts
+++ b/scripts/test-example-stays.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env npx tsx
+/**
+ * Live test for the example-stays reasoner (landing-page engine P2). Runs buildExampleStays against
+ * REAL Firestore (availability + priceCalendars + holidays) for a dated window and a broad season, and
+ * prints the proposed stays so we can eyeball truth (free? min-stay OK? price sane? occasion real?).
+ *
+ * Usage:
+ *   npx tsx scripts/test-example-stays.ts
+ *   npx tsx scripts/test-example-stays.ts --property coltei-apartment-bucharest
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+import { buildExampleStays, type LandingPeriod } from '@/lib/landing/exampleStays';
+
+const arg = (n: string, d?: string) => {
+  const i = process.argv.indexOf(`--${n}`);
+  return i >= 0 ? process.argv[i + 1] : d;
+};
+const PROPERTY = arg('property', 'prahova-mountain-chalet')!;
+
+const cases: { title: string; period: LandingPeriod; opts?: Parameters<typeof buildExampleStays>[2] }[] = [
+  { title: 'WINDOW — heat campaign (23–31 Aug 2026)', period: { kind: 'window', start: '2026-08-23', end: '2026-08-31' } },
+  { title: 'SEASON — autumn (Oct→mid-Dec 2026, family occupancy)', period: { kind: 'season', start: '2026-10-01', end: '2026-12-15' }, opts: { guests: 6 } },
+  { title: 'SEASON — open-ended from today (150-day horizon)', period: { kind: 'season' } },
+];
+
+async function main() {
+  console.log(`\nProperty: ${PROPERTY}\n${'='.repeat(72)}`);
+  for (const c of cases) {
+    console.log(`\n▶ ${c.title}`);
+    const stays = await buildExampleStays(PROPERTY, c.period, c.opts);
+    if (!stays.length) { console.log('  (no stays proposed)'); continue; }
+    for (const s of stays) {
+      const occ = s.occasion ? `  [${s.occasion}]` : '';
+      const price = s.priceHint != null ? `de la ${s.priceHint.toLocaleString('ro-RO')} RON` : '(no price)';
+      const label = typeof s.label === 'string' ? s.label : s.label.ro;
+      console.log(`  • ${s.start} → ${s.end}  ${s.nights}n  ${s.guests}p  ${price}${occ}`);
+      console.log(`      "${label}"`);
+    }
+  }
+  console.log('');
+  process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/admin/landing/[slug]/page.tsx
+++ b/src/app/admin/landing/[slug]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { AdminPage } from '@/components/admin';
+import { ArrowLeft } from 'lucide-react';
+import { fetchLandingAction } from '../actions';
+import { LandingEditor } from '../_components/landing-editor';
+
+export const dynamic = 'force-dynamic';
+
+export default async function LandingEditorPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const data = await fetchLandingAction(slug);
+  if (!data) notFound();
+
+  return (
+    <AdminPage
+      title={`Edit landing · ${slug}`}
+      description="Edit copy, images and the proposed stays, then publish. Changes are saved to the /lp page; publishing makes it live."
+      actions={<Button asChild variant="outline" size="sm"><Link href="/admin/landing"><ArrowLeft className="mr-2 h-4 w-4" />All landings</Link></Button>}
+    >
+      <LandingEditor initialConfig={data.config} propertyImages={data.propertyImages} />
+    </AdminPage>
+  );
+}

--- a/src/app/admin/landing/_components/landing-editor.tsx
+++ b/src/app/admin/landing/_components/landing-editor.tsx
@@ -1,0 +1,238 @@
+'use client';
+/**
+ * Landing-page editor (P3). Holds the whole config in React state; edits copy (bilingual), hero + gallery
+ * images (picked from the property's images), the reasoner's example stays (editable + "regenerate from
+ * calendar"), and publish status. Saves the writable fields via saveLandingAction. Reuses the website
+ * editor toolkit (MultilingualInput / ImagePicker / SortableList) so there's no duplication.
+ */
+import { useMemo, useRef, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { Save, RotateCcw, Loader2, ExternalLink, RefreshCw } from 'lucide-react';
+import { MultilingualInput } from '@/app/admin/website/_components/multilingual-input';
+import { ImagePicker } from '@/app/admin/website/_components/image-picker';
+import { SortableList } from '@/app/admin/website/_components/sortable-list';
+import { saveLandingAction, regenerateStaysAction, setLandingStatusAction } from '../actions';
+import type { LandingConfig, ExampleStay } from '@/lib/landing/contracts';
+
+type PropImg = { url: string; storagePath: string; thumbnailUrl?: string; alt?: string };
+type MlObj = Record<string, string>;
+const asMl = (v: unknown): MlObj | undefined =>
+  v == null ? undefined : typeof v === 'string' ? { ro: v } : (v as MlObj);
+const daysBetween = (a?: string | null, b?: string | null) =>
+  a && b ? Math.max(0, Math.round((Date.parse(`${b}T00:00:00Z`) - Date.parse(`${a}T00:00:00Z`)) / 86400000)) : 0;
+
+export function LandingEditor({ initialConfig, propertyImages }: {
+  initialConfig: LandingConfig; propertyImages: Array<Record<string, unknown>>;
+}) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [saving, startSave] = useTransition();
+  const [busy, startBusy] = useTransition();
+
+  const images = useMemo<PropImg[]>(() => propertyImages.map(i => ({
+    url: String(i.url ?? ''), storagePath: String(i.storagePath ?? ''),
+    thumbnailUrl: i.thumbnailUrl as string | undefined, alt: (typeof i.alt === 'string' ? i.alt : undefined),
+  })), [propertyImages]);
+  const pickerImages = useMemo(() => images.map(i => ({ url: i.url, alt: i.alt, thumbnailUrl: i.thumbnailUrl })), [images]);
+  const urlOf = (sp?: string) => images.find(i => i.storagePath === sp)?.url ?? '';
+  const pathOf = (url?: string | null) => (url ? images.find(i => i.url === url)?.storagePath ?? url : '');
+
+  const [cfg, setCfg] = useState<LandingConfig>(initialConfig);
+  const savedRef = useRef<LandingConfig>(initialConfig);
+  const [dirty, setDirty] = useState(false);
+
+  const patch = (p: Partial<LandingConfig>) => { setCfg(c => ({ ...c, ...p })); setDirty(true); };
+  const lang = cfg.defaultLanguage || 'ro';
+
+  // ── save / discard / publish ──
+  const onSave = () => startSave(async () => {
+    const res = await saveLandingAction(cfg.slug, {
+      period: cfg.period, hero: cfg.hero, story: cfg.story, exampleStays: cfg.exampleStays,
+      gallery: cfg.gallery, offer: cfg.offer, cta: cfg.cta, defaultLanguage: cfg.defaultLanguage, status: cfg.status,
+    });
+    if (res.ok) { savedRef.current = cfg; setDirty(false); toast({ description: 'Saved.' }); router.refresh(); }
+    else toast({ variant: 'destructive', description: res.error });
+  });
+  const onDiscard = () => { setCfg(savedRef.current); setDirty(false); };
+  const onTogglePublish = () => startBusy(async () => {
+    const next = cfg.status === 'published' ? 'draft' : 'published';
+    const res = await setLandingStatusAction(cfg.slug, next);
+    if (res.ok) { setCfg(c => ({ ...c, status: next })); savedRef.current = { ...savedRef.current, status: next }; toast({ description: next === 'published' ? 'Published — live now.' : 'Unpublished.' }); }
+    else toast({ variant: 'destructive', description: res.error });
+  });
+  const onRegenStays = () => startBusy(async () => {
+    const res = await regenerateStaysAction(cfg.slug);
+    if (res.ok) { setCfg(c => ({ ...c, exampleStays: res.stays })); savedRef.current = { ...savedRef.current, exampleStays: res.stays }; toast({ description: `Refreshed ${res.stays.length} stay(s) from the live calendar.` }); }
+    else toast({ variant: 'destructive', description: res.error });
+  });
+
+  // ── example stays helpers ──
+  const stays = cfg.exampleStays ?? [];
+  const setStays = (next: ExampleStay[]) => patch({ exampleStays: next });
+  const updateStay = (i: number, u: Partial<ExampleStay>) => {
+    const next = stays.map((s, idx) => (idx === i ? { ...s, ...u } : s));
+    if (u.start !== undefined || u.end !== undefined) next[i].nights = daysBetween(next[i].start, next[i].end);
+    setStays(next);
+  };
+  const addStay = () => setStays([...stays, { start: '', end: '', nights: 0, label: { ro: '' }, occasion: null, priceHint: null, guests: null }]);
+
+  // ── gallery helpers (stored as storagePaths) ──
+  const gallery = cfg.gallery ?? [];
+  const setGallery = (next: string[]) => patch({ gallery: next });
+
+  return (
+    <div className="space-y-6 pb-24">
+      {/* Header: status + preview + language */}
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-3 py-4">
+          <Badge variant={cfg.status === 'published' ? 'default' : 'secondary'}>{cfg.status || 'draft'}</Badge>
+          <Button variant="outline" size="sm" disabled={busy} onClick={onTogglePublish}>
+            {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {cfg.status === 'published' ? 'Unpublish' : 'Publish'}
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <a href={`/lp/${cfg.slug}/${lang}`} target="_blank" rel="noopener noreferrer"><ExternalLink className="mr-2 h-4 w-4" />Preview</a>
+          </Button>
+          <div className="ml-auto flex items-center gap-2">
+            <Label className="text-xs text-muted-foreground">Default language</Label>
+            <Select value={lang} onValueChange={v => patch({ defaultLanguage: v })}>
+              <SelectTrigger className="w-24"><SelectValue /></SelectTrigger>
+              <SelectContent><SelectItem value="ro">Română</SelectItem><SelectItem value="en">English</SelectItem></SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Hero + period */}
+      <Card>
+        <CardHeader><CardTitle className="text-base">Hero</CardTitle><CardDescription>The first thing visitors see — scent-matched to the ad.</CardDescription></CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label className="mb-1 block text-xs text-muted-foreground">Hero image</Label>
+            <ImagePicker value={urlOf(cfg.hero?.imagePath)} onChange={u => patch({ hero: { ...cfg.hero, imagePath: pathOf(u) } })} propertyImages={pickerImages} />
+          </div>
+          <MultilingualInput label="Headline" value={asMl(cfg.hero?.headline)} onChange={v => patch({ hero: { ...cfg.hero, headline: v } })} />
+          <MultilingualInput label="Sub-copy" multiline value={asMl(cfg.hero?.subcopy)} onChange={v => patch({ hero: { ...cfg.hero, subcopy: v } })} />
+          <MultilingualInput label="Period badge" value={asMl(cfg.period?.label)} onChange={v => patch({ period: { ...cfg.period, kind: cfg.period?.kind ?? 'season', label: v } })} />
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div>
+              <Label className="mb-1 block text-xs text-muted-foreground">Type</Label>
+              <Select value={cfg.period?.kind ?? 'season'} onValueChange={v => patch({ period: { ...cfg.period, kind: v as 'window' | 'season' } })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent><SelectItem value="window">Window (dated)</SelectItem><SelectItem value="season">Season (broad)</SelectItem></SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="mb-1 block text-xs text-muted-foreground">Start</Label>
+              <Input type="date" value={cfg.period?.start ?? ''} onChange={e => patch({ period: { ...cfg.period, kind: cfg.period?.kind ?? 'window', start: e.target.value || null } })} />
+            </div>
+            <div>
+              <Label className="mb-1 block text-xs text-muted-foreground">End</Label>
+              <Input type="date" value={cfg.period?.end ?? ''} onChange={e => patch({ period: { ...cfg.period, kind: cfg.period?.kind ?? 'window', end: e.target.value || null } })} />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Story */}
+      <Card>
+        <CardHeader><CardTitle className="text-base">Story</CardTitle><CardDescription>The emotional invitation.</CardDescription></CardHeader>
+        <CardContent className="space-y-4">
+          <MultilingualInput label="Title" value={asMl(cfg.story?.title)} onChange={v => patch({ story: { ...cfg.story, title: v } })} />
+          <MultilingualInput label="Body" multiline value={asMl(cfg.story?.body)} onChange={v => patch({ story: { ...cfg.story, body: v } })} />
+        </CardContent>
+      </Card>
+
+      {/* Example stays */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div><CardTitle className="text-base">Example stays</CardTitle><CardDescription>Real, calendar-valid, priced stays. Regenerate pulls fresh from the live calendar.</CardDescription></div>
+            <Button variant="outline" size="sm" disabled={busy} onClick={onRegenStays}>
+              {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}Regenerate from calendar
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <SortableList
+            items={stays}
+            addLabel="Add a stay"
+            onReorder={setStays}
+            onRemove={i => setStays(stays.filter((_, idx) => idx !== i))}
+            onAdd={addStay}
+            renderItem={(s, i) => (
+              <div className="flex-1 space-y-3">
+                <MultilingualInput label="Card label" value={asMl(s.label)} onChange={v => updateStay(i, { label: v })} />
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  <div><Label className="mb-1 block text-xs text-muted-foreground">Check-in</Label><Input type="date" value={s.start} onChange={e => updateStay(i, { start: e.target.value })} /></div>
+                  <div><Label className="mb-1 block text-xs text-muted-foreground">Check-out</Label><Input type="date" value={s.end} onChange={e => updateStay(i, { end: e.target.value })} /></div>
+                  <div><Label className="mb-1 block text-xs text-muted-foreground">Nights</Label><Input type="number" value={s.nights} readOnly className="bg-muted/50" /></div>
+                  <div><Label className="mb-1 block text-xs text-muted-foreground">Guests</Label><Input type="number" value={s.guests ?? ''} onChange={e => updateStay(i, { guests: e.target.value ? Number(e.target.value) : null })} /></div>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div><Label className="mb-1 block text-xs text-muted-foreground">From-price (RON)</Label><Input type="number" value={s.priceHint ?? ''} onChange={e => updateStay(i, { priceHint: e.target.value ? Number(e.target.value) : null })} /></div>
+                  <div><Label className="mb-1 block text-xs text-muted-foreground">Occasion tag</Label><Input value={s.occasion ?? ''} onChange={e => updateStay(i, { occasion: e.target.value || null })} /></div>
+                </div>
+              </div>
+            )}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Gallery */}
+      <Card>
+        <CardHeader><CardTitle className="text-base">Gallery</CardTitle><CardDescription>A mosaic below the story. Pick from the property's images.</CardDescription></CardHeader>
+        <CardContent>
+          <SortableList
+            items={gallery}
+            addLabel="Add an image"
+            compact
+            onReorder={setGallery}
+            onRemove={i => setGallery(gallery.filter((_, idx) => idx !== i))}
+            onAdd={() => setGallery([...gallery, ''])}
+            renderItem={(sp, i) => (
+              <div className="flex-1">
+                <ImagePicker value={urlOf(sp)} onChange={u => setGallery(gallery.map((g, idx) => (idx === i ? pathOf(u) : g)))} propertyImages={pickerImages} />
+              </div>
+            )}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Offer + CTA */}
+      <Card>
+        <CardHeader><CardTitle className="text-base">Offer &amp; call-to-action</CardTitle></CardHeader>
+        <CardContent className="space-y-4">
+          <MultilingualInput label="Offer strip" value={asMl(cfg.offer?.text)} onChange={v => patch({ offer: { text: v } })} />
+          <div className="flex items-center gap-3">
+            <Switch checked={cfg.cta?.showBooking !== false} onCheckedChange={c => patch({ cta: { ...cfg.cta, showBooking: c } })} />
+            <Label className="text-sm">Show the “Check dates / booking” buttons</Label>
+          </div>
+          <div>
+            <Label className="mb-1 block text-xs text-muted-foreground">Phone override (optional — defaults to the property phone)</Label>
+            <Input value={cfg.cta?.phone ?? ''} onChange={e => patch({ cta: { ...cfg.cta, phone: e.target.value || null } })} placeholder="+40…" className="sm:w-64" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Sticky save bar */}
+      {dirty && (
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur">
+          <div className="mx-auto flex max-w-5xl items-center justify-end gap-3 px-4 py-3">
+            <span className="mr-auto text-sm text-muted-foreground">Unsaved changes</span>
+            <Button variant="ghost" onClick={onDiscard} disabled={saving}><RotateCcw className="mr-2 h-4 w-4" />Discard</Button>
+            <Button onClick={onSave} disabled={saving}>{saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}Save</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/landing/_components/landing-list.tsx
+++ b/src/app/admin/landing/_components/landing-list.tsx
@@ -1,0 +1,161 @@
+'use client';
+/**
+ * Landing pages list + "generate from campaign" control (P3). Row → /admin/landing/{slug} editor.
+ * Shapes are redeclared here because the 'use server' actions file can't export types.
+ */
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { Plus, ExternalLink, Pencil, Trash2, Loader2, Megaphone } from 'lucide-react';
+import { generateLandingAction, setLandingStatusAction, deleteLandingAction } from '../actions';
+
+type Ml = string | { en?: string; ro?: string };
+const ml = (v: Ml | undefined) => (v == null ? '' : typeof v === 'string' ? v : v.ro || v.en || '');
+
+interface LandingRow {
+  slug: string; status?: string; campaignRef?: string; defaultLanguage?: string;
+  period?: { kind?: string; start?: string | null; end?: string | null; label?: Ml };
+  hero?: { headline?: Ml }; updatedAt?: string;
+}
+interface CampaignOption {
+  id: string; status: string; occasionName: string; window: string | null;
+  suggestedSlug: string; hasLanding: boolean;
+}
+
+export function LandingList({ propertyId, landings, campaigns }: {
+  propertyId: string; landings: Array<Record<string, unknown>>; campaigns: CampaignOption[];
+}) {
+  const rows = landings as unknown as LandingRow[];
+  const router = useRouter();
+  const { toast } = useToast();
+  const [pending, startTransition] = useTransition();
+  const [campaignId, setCampaignId] = useState<string>('');
+  const [slug, setSlug] = useState<string>('');
+
+  const onPickCampaign = (id: string) => {
+    setCampaignId(id);
+    setSlug(campaigns.find(c => c.id === id)?.suggestedSlug ?? '');
+  };
+
+  const onGenerate = () => {
+    if (!campaignId) { toast({ variant: 'destructive', description: 'Pick a campaign first.' }); return; }
+    startTransition(async () => {
+      const res = await generateLandingAction(campaignId, slug);
+      if (res.ok) { toast({ description: `Draft landing “${res.slug}” created.` }); router.push(`/admin/landing/${res.slug}`); }
+      else toast({ variant: 'destructive', description: res.error });
+    });
+  };
+
+  const onToggleStatus = (row: LandingRow) => {
+    const next = row.status === 'published' ? 'draft' : 'published';
+    startTransition(async () => {
+      const res = await setLandingStatusAction(row.slug, next);
+      if (res.ok) { toast({ description: next === 'published' ? 'Published.' : 'Unpublished.' }); router.refresh(); }
+      else toast({ variant: 'destructive', description: res.error });
+    });
+  };
+
+  const onDelete = (row: LandingRow) => {
+    if (!window.confirm(`Delete landing “${row.slug}”? This cannot be undone.`)) return;
+    startTransition(async () => {
+      const res = await deleteLandingAction(row.slug);
+      if (res.ok) { toast({ description: 'Deleted.' }); router.refresh(); }
+      else toast({ variant: 'destructive', description: res.error });
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Generate from campaign */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base"><Megaphone className="h-4 w-4" /> Generate from a campaign</CardTitle>
+          <CardDescription>Creates a draft that echoes the ad (same photos + copy) and proposes real, calendar-valid stays. You edit it before publishing.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {campaigns.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No ad campaigns for this property yet. Create one in <Link href={`/admin/ads?propertyId=${propertyId}`} className="underline">Ads</Link> first.</p>
+          ) : (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="flex-1">
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Campaign</label>
+                <Select value={campaignId} onValueChange={onPickCampaign}>
+                  <SelectTrigger><SelectValue placeholder="Choose a campaign…" /></SelectTrigger>
+                  <SelectContent>
+                    {campaigns.map(c => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.occasionName.slice(0, 48)}{c.window ? ` · ${c.window}` : ''}{c.hasLanding ? ' · (has landing)' : ''}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="sm:w-56">
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Slug (/lp/…)</label>
+                <Input value={slug} onChange={e => setSlug(e.target.value)} placeholder="autumn-break" />
+              </div>
+              <Button onClick={onGenerate} disabled={pending || !campaignId}>
+                {pending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />} Generate
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Existing landings */}
+      <Card>
+        <CardHeader><CardTitle className="text-base">Landing pages</CardTitle></CardHeader>
+        <CardContent>
+          {rows.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">No landing pages yet — generate one above.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Page</TableHead><TableHead>Status</TableHead>
+                  <TableHead>Window</TableHead><TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map(row => {
+                  const lang = row.defaultLanguage || 'ro';
+                  return (
+                    <TableRow key={row.slug}>
+                      <TableCell>
+                        <div className="font-medium">{ml(row.hero?.headline) || row.slug}</div>
+                        <div className="text-xs text-muted-foreground">/lp/{row.slug} · {ml(row.period?.label)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={row.status === 'published' ? 'default' : 'secondary'}>{row.status || 'draft'}</Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {row.period?.start && row.period?.end ? `${row.period.start} → ${row.period.end}` : (row.period?.kind || '—')}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center justify-end gap-1">
+                          <Button asChild variant="ghost" size="sm"><Link href={`/admin/landing/${row.slug}`}><Pencil className="h-4 w-4" /></Link></Button>
+                          <Button asChild variant="ghost" size="sm"><a href={`/lp/${row.slug}/${lang}`} target="_blank" rel="noopener noreferrer"><ExternalLink className="h-4 w-4" /></a></Button>
+                          <Button variant="ghost" size="sm" disabled={pending} onClick={() => onToggleStatus(row)}>
+                            {row.status === 'published' ? 'Unpublish' : 'Publish'}
+                          </Button>
+                          <Button variant="ghost" size="sm" disabled={pending} onClick={() => onDelete(row)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/landing/actions.ts
+++ b/src/app/admin/landing/actions.ts
@@ -1,0 +1,168 @@
+'use server';
+/**
+ * Admin server actions for the landing-page engine (P3). A 'use server' file may only export async
+ * functions — shared shapes are redeclared in the client components. All actions are super-admin gated
+ * and return a discriminated union ({ok:true,...} | {ok:false,error}); reads return the data or null.
+ * Writes go to `landingPages/{slug}` via the Admin SDK (the collection's rules deny client writes).
+ */
+import { revalidatePath } from 'next/cache';
+import { loggers } from '@/lib/logger';
+import { requireSuperAdmin, handleAuthError, AuthorizationError } from '@/lib/authorization';
+import { getAdminDb, FieldValue } from '@/lib/firebaseAdminSafe';
+import { convertTimestampsToISOStrings } from '@/lib/utils';
+import { buildLandingDraftFromCampaign, suggestLandingSlug } from '@/lib/landing/generateLanding';
+import { buildExampleStays } from '@/lib/landing/exampleStays';
+import type { LandingConfig, ExampleStay } from '@/lib/landing/contracts';
+
+const logger = loggers.campaign;
+
+async function requireActor(): Promise<string> {
+  const user = await requireSuperAdmin();
+  return user.email || user.uid;
+}
+
+/** Firestore rejects `undefined` — round-trip to drop undefined keys before any write. */
+const clean = <T>(o: T): T => JSON.parse(JSON.stringify(o));
+
+// ── reads ──────────────────────────────────────────────────────────────────────────────────────
+
+/** All landing pages for a property (newest first). Returns [] on auth failure (initial-load fetch). */
+export async function fetchLandingsAction(propertyId: string) {
+  try { await requireActor(); } catch { return []; }
+  const db = await getAdminDb();
+  const snap = await db.collection('landingPages').where('propertyId', '==', propertyId).get();
+  return snap.docs
+    .map(d => convertTimestampsToISOStrings({ slug: d.id, ...d.data() }) as Record<string, unknown>)
+    .sort((a, b) => String(b.updatedAt ?? b.createdAt ?? '').localeCompare(String(a.updatedAt ?? a.createdAt ?? '')));
+}
+
+/** One landing config + the property's images (for the editor's pickers). null if missing / unauthorized. */
+export async function fetchLandingAction(slug: string) {
+  try { await requireActor(); } catch { return null; }
+  const db = await getAdminDb();
+  const doc = await db.collection('landingPages').doc(slug).get();
+  if (!doc.exists) return null;
+  const config = convertTimestampsToISOStrings({ slug: doc.id, ...doc.data() }) as unknown as LandingConfig;
+  const propSnap = await db.collection('properties').doc(config.propertyId).get();
+  const propertyImages = ((propSnap.data()?.images as unknown[]) ?? []) as Array<Record<string, unknown>>;
+  return { config, propertyImages };
+}
+
+/** Ad campaigns for a property that can seed a landing (have a proposal), newest first. */
+export async function fetchCampaignOptionsAction(propertyId: string) {
+  try { await requireActor(); } catch { return []; }
+  const db = await getAdminDb();
+  const [campaigns, landings] = await Promise.all([
+    db.collection('adCampaigns').where('propertyId', '==', propertyId).get(),
+    db.collection('landingPages').where('propertyId', '==', propertyId).get(),
+  ]);
+  const usedCampaignRefs = new Set(landings.docs.map(d => (d.data().campaignRef as string) || '').filter(Boolean));
+  return campaigns.docs
+    .map(d => {
+      const c = d.data();
+      const occ = (c.proposal?.occasion ?? {}) as { name?: string; start?: string; end?: string };
+      if (!c.proposal) return null;
+      return {
+        id: d.id,
+        status: (c.status as string) ?? 'draft',
+        occasionName: occ.name ?? '(no occasion)',
+        window: occ.start && occ.end ? `${occ.start} → ${occ.end}` : null,
+        suggestedSlug: suggestLandingSlug(occ.name, occ.start),
+        hasLanding: usedCampaignRefs.has(d.id),
+        createdAt: convertTimestampsToISOStrings({ v: c.createdAt }).v ?? null,
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => !!x)
+    .sort((a, b) => String(b.createdAt ?? '').localeCompare(String(a.createdAt ?? '')));
+}
+
+// ── mutations ──────────────────────────────────────────────────────────────────────────────────
+
+type Ok<T = unknown> = { ok: true } & T;
+type Err = { ok: false; error: string };
+
+async function guard<R>(fn: (actor: string) => Promise<R>): Promise<R | Err> {
+  let actor: string;
+  try { actor = await requireActor(); }
+  catch (e) {
+    if (e instanceof AuthorizationError) return { ok: false, error: handleAuthError(e).error };
+    throw e;
+  }
+  try { return await fn(actor); }
+  catch (e) { logger.error('landing action failed', e as Error); return { ok: false, error: (e as Error).message || 'internal-error' }; }
+}
+
+/** Generate a draft landing from an ad campaign at `slug`. Refuses if the slug is taken. */
+export async function generateLandingAction(campaignId: string, slug: string): Promise<Ok<{ slug: string }> | Err> {
+  return guard(async (actor) => {
+    const cleanSlug = slug.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+    if (!cleanSlug) return { ok: false, error: 'Enter a valid slug (letters, numbers, dashes).' };
+    const db = await getAdminDb();
+    if ((await db.collection('landingPages').doc(cleanSlug).get()).exists)
+      return { ok: false, error: `A landing page "${cleanSlug}" already exists — pick another slug.` };
+    const draft = await buildLandingDraftFromCampaign(campaignId, { slug: cleanSlug, createdBy: actor });
+    await db.collection('landingPages').doc(cleanSlug).set(clean({
+      ...draft, createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+    }));
+    logger.info('landing generated from campaign', { campaignId, slug: cleanSlug, actor });
+    revalidatePath('/admin/landing');
+    return { ok: true, slug: cleanSlug };
+  });
+}
+
+/** Save the edited config (owner-editable fields only; slug/propertyId/campaignRef are immutable). */
+export async function saveLandingAction(slug: string, patch: Partial<LandingConfig>): Promise<Ok | Err> {
+  return guard(async () => {
+    const db = await getAdminDb();
+    const ref = db.collection('landingPages').doc(slug);
+    if (!(await ref.get()).exists) return { ok: false, error: 'Landing page not found.' };
+    // Only these fields are writable from the editor.
+    const writable = clean({
+      period: patch.period, hero: patch.hero, story: patch.story, exampleStays: patch.exampleStays,
+      gallery: patch.gallery, offer: patch.offer, cta: patch.cta,
+      defaultLanguage: patch.defaultLanguage, status: patch.status,
+    });
+    await ref.set({ ...writable, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+    revalidatePath('/admin/landing');
+    revalidatePath(`/admin/landing/${slug}`);
+    return { ok: true };
+  });
+}
+
+/** Re-run the P2 reasoner for this landing's period and replace its example stays. */
+export async function regenerateStaysAction(slug: string): Promise<Ok<{ stays: ExampleStay[] }> | Err> {
+  return guard(async () => {
+    const db = await getAdminDb();
+    const ref = db.collection('landingPages').doc(slug);
+    const doc = await ref.get();
+    if (!doc.exists) return { ok: false, error: 'Landing page not found.' };
+    const cfg = doc.data() as LandingConfig;
+    const stays = await buildExampleStays(cfg.propertyId, {
+      kind: cfg.period?.kind ?? 'season', start: cfg.period?.start ?? null, end: cfg.period?.end ?? null,
+    });
+    await ref.set({ exampleStays: clean(stays), updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+    revalidatePath(`/admin/landing/${slug}`);
+    return { ok: true, stays };
+  });
+}
+
+/** Publish / unpublish. */
+export async function setLandingStatusAction(slug: string, status: 'draft' | 'published'): Promise<Ok | Err> {
+  return guard(async () => {
+    const db = await getAdminDb();
+    await db.collection('landingPages').doc(slug).set({ status, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+    revalidatePath('/admin/landing');
+    revalidatePath(`/admin/landing/${slug}`);
+    return { ok: true };
+  });
+}
+
+/** Delete a landing page. */
+export async function deleteLandingAction(slug: string): Promise<Ok | Err> {
+  return guard(async () => {
+    const db = await getAdminDb();
+    await db.collection('landingPages').doc(slug).delete();
+    revalidatePath('/admin/landing');
+    return { ok: true };
+  });
+}

--- a/src/app/admin/landing/page.tsx
+++ b/src/app/admin/landing/page.tsx
@@ -1,0 +1,31 @@
+import { AdminPage } from '@/components/admin';
+import { PropertyUrlSync } from '@/components/admin/PropertyUrlSync';
+import { fetchLandingsAction, fetchCampaignOptionsAction } from './actions';
+import { LandingList } from './_components/landing-list';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_PROPERTY = 'prahova-mountain-chalet';
+
+export default async function LandingIndexPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ propertyId?: string }>;
+}) {
+  const { propertyId } = await searchParams;
+  const property = propertyId || DEFAULT_PROPERTY;
+  const [landings, campaigns] = await Promise.all([
+    fetchLandingsAction(property),
+    fetchCampaignOptionsAction(property),
+  ]);
+
+  return (
+    <AdminPage
+      title="Landing pages"
+      description="Campaign landing pages (/lp). Generate one from an ad campaign — it echoes the ad and proposes real, calendar-valid stays — then edit the copy, images and stays before publishing. Nothing here spends."
+    >
+      <PropertyUrlSync />
+      <LandingList propertyId={property} landings={landings} campaigns={campaigns} />
+    </AdminPage>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -99,6 +99,7 @@ const navigationGroups = [
       { title: 'Situation', href: '/admin/situation', icon: Brain },
       { title: 'Campaigns', href: '/admin/campaigns', icon: Megaphone },
       { title: 'Ads', href: '/admin/ads', icon: Target },
+      { title: 'Landing pages', href: '/admin/landing', icon: PanelTop },
       { title: 'Page posts', href: '/admin/page-posts', icon: Newspaper },
     ],
   },

--- a/src/lib/growth/signals.ts
+++ b/src/lib/growth/signals.ts
@@ -158,6 +158,94 @@ export function computeOutreachLedger(
     });
 }
 
+// ── forward-inventory calendar signals (free runs + occasion/long-weekend windows) ──────────────
+// Extracted VERBATIM from the inline pack code (situationPack.ts §forward-inventory) so the situation
+// analyst AND the landing example-stays reasoner (src/lib/landing/exampleStays.ts) share one truth.
+// Pure over already-shaped data (dates + holiday docs) — output byte-identical to the old inline loops.
+
+/** A row from the `holidays` collection (subset the compute functions read). */
+export interface HolidayDoc { name: string; type: string; startDate: string; endDate: string; source?: string | null }
+/** An upcoming public holiday / school break, ready for the pack or a reasoner. */
+export interface Occasion { name: string; type: string; startDate: string; endDate: string; source: string | null }
+/** A contiguous run of free nights: `end` is the last free NIGHT (checkout = end + 1 day). */
+export interface FreeRun { start: string; end: string; nights: number }
+/** A long-weekend / bridge window: consecutive off-days (weekends + holidays), joined across 1-2
+ *  working-day bridges. `bridgeDaysRequired` = leave days to take the whole window (0 = already long). */
+export interface ExtendedWindow {
+  start: string; end: string; totalDays: number;
+  bridgeDaysRequired: number; bridgeDays: string[]; holidaysInside: string[];
+}
+
+/**
+ * Group an ordered list of `YYYY-MM-DD` dates into contiguous runs of free nights. `isFree(date)`
+ * decides each night (the pack passes `availByDate` with missing = available; the reasoner passes the
+ * inverse of the availability service's blocked set). `end` is the last free night in the run.
+ */
+export function computeFreeRuns(dates: string[], isFree: (ymd: string) => boolean): FreeRun[] {
+  const runs: FreeRun[] = [];
+  let cur: string[] = [];
+  for (const k of dates) {
+    if (isFree(k)) cur.push(k);
+    else { if (cur.length) runs.push({ start: cur[0], end: cur[cur.length - 1], nights: cur.length }); cur = []; }
+  }
+  if (cur.length) runs.push({ start: cur[0], end: cur[cur.length - 1], nights: cur.length });
+  return runs;
+}
+
+/** Upcoming occasions from the `holidays` collection (endDate on/after `asOf`), soonest first. */
+export function computeOccasions(holidays: HolidayDoc[], asOf: Date, limit = 20): Occasion[] {
+  return holidays
+    .filter(h => h.endDate >= ymd(asOf))
+    .sort((a, b) => String(a.startDate).localeCompare(String(b.startDate)))
+    .slice(0, limit)
+    .map(h => ({ name: h.name, type: h.type, startDate: h.startDate, endDate: h.endDate, source: h.source ?? null }));
+}
+
+/**
+ * Derive long-weekend / bridge windows over `horizonDays` from `asOf`: runs of off-days (Sat/Sun +
+ * holiday days) joined when only 1-2 working days separate them (those working days become the bridge).
+ * Only windows a guest would actually travel for (≥4 total days, anchored by a bridge or an edge
+ * holiday) are returned, newest-first, capped at 12. Byte-identical to the pack's inline IIFE.
+ */
+export function computeExtendedWindows(holidays: HolidayDoc[], asOf: Date, horizonDays = 400): ExtendedWindow[] {
+  const holidayDates = new Set<string>();
+  holidays
+    .filter(h => h.type === 'major' || h.type === 'minor' || h.type === 'bridge-day')
+    .forEach(h => {
+      for (let d = new Date(`${h.startDate}T00:00:00Z`); ymd(d) <= h.endDate; d = new Date(+d + 86400000)) holidayDates.add(ymd(d));
+    });
+  const isOff = (d: Date) => { const w = d.getUTCDay(); return w === 0 || w === 6 || holidayDates.has(ymd(d)); };
+  const offRuns: { start: Date; end: Date }[] = [];
+  let run: Date[] = [];
+  for (let d = new Date(asOf); d < new Date(+asOf + horizonDays * 86400000); d = new Date(+d + 86400000)) {
+    if (isOff(d)) run.push(new Date(d));
+    else { if (run.length) offRuns.push({ start: run[0], end: run[run.length - 1] }); run = []; }
+  }
+  if (run.length) offRuns.push({ start: run[0], end: run[run.length - 1] });
+  const windows: ExtendedWindow[] = [];
+  for (let i = 0; i < offRuns.length; i++) {
+    const start = offRuns[i].start;
+    let end = offRuns[i].end;
+    const bridges: string[] = [];
+    while (i + 1 < offRuns.length) {
+      const gap = nights(end, offRuns[i + 1].start) - 1;
+      if (gap >= 1 && gap <= 2) {
+        for (let k = 1; k <= gap; k++) bridges.push(ymd(new Date(+end + k * 86400000)));
+        end = offRuns[i + 1].end; i++;
+      } else break;
+    }
+    const total = nights(start, end) + 1;
+    if (total >= 4 && (bridges.length || holidayDates.has(ymd(start)) || holidayDates.has(ymd(end)))) {
+      windows.push({
+        start: ymd(start), end: ymd(end), totalDays: total,
+        bridgeDaysRequired: bridges.length, bridgeDays: bridges,
+        holidaysInside: [...holidayDates].filter(h => h >= ymd(start) && h <= ymd(end)).sort(),
+      });
+    }
+  }
+  return windows.slice(0, 12);
+}
+
 // ── convenience fetchers (propertyId → result) for in-app arms (Move 4). Server-only. ──
 
 function shapeBooking(id: string, x: Record<string, unknown>): SignalBooking {
@@ -200,4 +288,11 @@ export async function getOutreachLedger(propertyId: string, asOf: Date = new Dat
   const guests: SignalGuest[] = gSnap.docs.map(d => ({ id: d.id, bookingIds: (d.data() as { bookingIds?: string[] }).bookingIds }));
   const threads = new Map<string, SignalThread>(tSnap.docs.map(d => [d.id, d.data() as SignalThread]));
   return computeOutreachLedger(threads, guests, bookingById, asOf);
+}
+
+/** All rows from the `holidays` collection (shared by the analyst pack + the landing reasoner). */
+export async function getHolidays(): Promise<HolidayDoc[]> {
+  const db = await getAdminDb();
+  const snap = await db.collection('holidays').get();
+  return snap.docs.map(d => d.data() as HolidayDoc);
 }

--- a/src/lib/growth/situationPack.ts
+++ b/src/lib/growth/situationPack.ts
@@ -16,7 +16,7 @@
  */
 import { getAdminDb } from '@/lib/firebaseAdminSafe';
 import { getPageHealth, getAdAccountHealth } from '@/services/growth/metaAds/brandHealth';
-import { computeRecentCancellations, computeOutreachLedger } from '@/lib/growth/signals';
+import { computeRecentCancellations, computeOutreachLedger, computeFreeRuns, computeOccasions, computeExtendedWindows, type HolidayDoc } from '@/lib/growth/signals';
 import { getNotesByGuest, isTouch } from '@/services/guestNoteService';
 import { normalizeChannel } from '@/lib/channels';
 
@@ -536,14 +536,9 @@ export async function buildSituationPack(
   const forwardDates: string[] = [];
   for (let d = new Date(AS_OF); d < horizon; d = new Date(+d + 86400000)) forwardDates.push(ymd(d));
 
-  const runs: { start: string; end: string; nights: number }[] = [];
-  let cur: string[] = [];
-  for (const k of forwardDates) {
-    const known = availByDate.has(k);
-    const free = known ? availByDate.get(k)! : true; // missing doc = available (availability-service.ts)
-    if (free) cur.push(k); else { if (cur.length) runs.push({ start: cur[0], end: cur[cur.length - 1], nights: cur.length }); cur = []; }
-  }
-  if (cur.length) runs.push({ start: cur[0], end: cur[cur.length - 1], nights: cur.length });
+  // missing doc = available (availability-service.ts). The run-grouping walk lives in signals.ts so
+  // the landing example-stays reasoner shares the same truth (output byte-identical to the old loop).
+  const runs = computeFreeRuns(forwardDates, k => (availByDate.has(k) ? availByDate.get(k)! : true));
 
   // Min-stay is 2 nights year-round (exceptions: Christmas, New Year, school breaks — higher).
   // So a 1-NIGHT gap is UNSELLABLE: no one can book it. It only clears if the adjacent guest
@@ -600,12 +595,8 @@ export async function buildSituationPack(
   // (docs/implementation/firestore-pricing-structure.md §5). If empty, say so — outreach cannot
   // be justified without something true to say.
   const holidaysSnap = await db.collection('holidays').get();
-  const occasions = holidaysSnap.docs
-    .map(d => d.data() as any)
-    .filter(h => h.endDate >= ymd(AS_OF))
-    .sort((a, b) => String(a.startDate).localeCompare(String(b.startDate)))
-    .slice(0, 20)
-    .map(h => ({ name: h.name, type: h.type, startDate: h.startDate, endDate: h.endDate, source: h.source ?? null }));
+  const holidays = holidaysSnap.docs.map(d => d.data() as HolidayDoc);
+  const occasions = computeOccasions(holidays, AS_OF);
 
   // ---------- recent cancellations (re-opened inventory + a demand signal) ----------
   // Logic lives in src/lib/growth/signals.ts so any in-app arm can read the same signal (arch §7 M1).
@@ -647,50 +638,12 @@ export async function buildSituationPack(
           // Soft bridges: a public holiday sitting 1-2 working days away from a weekend (or from
           // another holiday) makes those working days likely days-off. This WIDENS the real
           // "people are actually free" window well beyond the legal holiday, and it is often the
-          // difference between a 2-night and a 5-night sell. Derived, not stored.
-          extendedWindows: (() => {
-            const holidayDates = new Set<string>();
-            holidaysSnap.docs.map(d => d.data() as any)
-              .filter(h => h.type === 'major' || h.type === 'minor' || h.type === 'bridge-day')
-              .forEach(h => {
-                for (let d = new Date(`${h.startDate}T00:00:00Z`); ymd(d) <= h.endDate; d = new Date(+d + 86400000)) holidayDates.add(ymd(d));
-              });
-            const isOff = (d: Date) => { const w = d.getUTCDay(); return w === 0 || w === 6 || holidayDates.has(ymd(d)); };
-            // walk the horizon, collect runs of off-days
-            const offRuns: { start: Date; end: Date }[] = [];
-            let run: Date[] = [];
-            for (let d = new Date(AS_OF); d < new Date(+AS_OF + 400 * 86400000); d = new Date(+d + 86400000)) {
-              if (isOff(d)) run.push(new Date(d));
-              else { if (run.length) offRuns.push({ start: run[0], end: run[run.length - 1] }); run = []; }
-            }
-            if (run.length) offRuns.push({ start: run[0], end: run[run.length - 1] });
-            // join runs separated by 1-2 working days → those days are the bridge
-            const windows: any[] = [];
-            for (let i = 0; i < offRuns.length; i++) {
-              let start = offRuns[i].start, end = offRuns[i].end;
-              const bridges: string[] = [];
-              while (i + 1 < offRuns.length) {
-                const gap = nightsBetween(end, offRuns[i + 1].start) - 1;
-                if (gap >= 1 && gap <= 2) {
-                  for (let k = 1; k <= gap; k++) bridges.push(ymd(new Date(+end + k * 86400000)));
-                  end = offRuns[i + 1].end; i++;
-                } else break;
-              }
-              const total = nightsBetween(start, end) + 1;
-              // only report windows a guest would actually travel for
-              if (total >= 4 && (bridges.length || holidayDates.has(ymd(start)) || holidayDates.has(ymd(end)))) {
-                windows.push({
-                  start: ymd(start), end: ymd(end), totalDays: total,
-                  bridgeDaysRequired: bridges.length, bridgeDays: bridges,
-                  holidaysInside: [...holidayDates].filter(h => h >= ymd(start) && h <= ymd(end)).sort(),
-                });
-              }
-            }
-            return {
-              note: 'A holiday next to a weekend with a 1-2 working-day gap: most people burn leave to bridge it. `bridgeDaysRequired` = leave days needed to take the whole window. 0 means it is already a long weekend.',
-              windows: windows.slice(0, 12),
-            };
-          })(),
+          // difference between a 2-night and a 5-night sell. Derived, not stored. Algorithm shared
+          // with the landing example-stays reasoner (signals.ts), output byte-identical to before.
+          extendedWindows: {
+            note: 'A holiday next to a weekend with a 1-2 working-day gap: most people burn leave to bridge it. `bridgeDaysRequired` = leave days needed to take the whole window. 0 means it is already a long weekend.',
+            windows: computeExtendedWindows(holidays, AS_OF),
+          },
         },
       };
 

--- a/src/lib/landing/exampleStays.ts
+++ b/src/lib/landing/exampleStays.ts
@@ -1,0 +1,275 @@
+/**
+ * Example-stays reasoner — landing-page engine P2 (docs/landing-page-engine-design.md §P2). Server-only.
+ *
+ * Given a campaign period (a dated WINDOW or a broad SEASON), it proposes 1-3 REAL, calendar-valid,
+ * priced "example stays" for the landing page's ⭐ section. The design principle of the whole promotion
+ * system holds here: guardrail the TRUTH, let framing be soft.
+ *   - Every proposed stay's nights are ACTUALLY free — read from the `availability` collection via
+ *     `checkAvailabilityWithFlags` (missing month/day = available), the single source of truth.
+ *   - Its length meets the per-date MINIMUM STAY (read from `priceCalendars`), so it can be booked as-is.
+ *   - Its `priceHint` is the REAL quoted total (`calculateBookingPrice` — occupancy + cleaning fee +
+ *     length-of-stay discount), identical to what the booking page will show. No invented numbers.
+ *   - A stay borrows an OCCASION reason (long weekend, school break, national-day bridge) only when the
+ *     calendar genuinely fits it — occasions + bridge windows come from the SAME shared algorithms the
+ *     situation analyst uses (`@/lib/growth/signals`), not a hardcoded list.
+ *
+ * Labels are deterministic + bilingual for now; an LLM voicing pass in the campaign's tone is a later,
+ * optional layer (the design says "deterministic first"). Nothing here sends, spends, or writes — it
+ * returns `ExampleStay[]` that P3's generate/editor stores into `landingPages/{slug}.exampleStays`.
+ */
+import { checkAvailabilityWithFlags } from '@/lib/availability-service';
+import { getPropertyWithDb, getPriceCalendarWithDb } from '@/lib/pricing/pricing-with-db';
+import { calculateBookingPrice } from '@/lib/pricing/price-calculation';
+import { computeFreeRuns, computeOccasions, computeExtendedWindows, getHolidays, type FreeRun } from '@/lib/growth/signals';
+import { loggers } from '@/lib/logger';
+import type { ExampleStay, Ml } from '@/lib/landing/contracts';
+
+const logger = loggers.campaign;
+const DAY = 86400000;
+
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const parseYmd = (s: string) => new Date(`${s}T00:00:00Z`);
+const addDays = (s: string, n: number) => ymd(new Date(+parseYmd(s) + n * DAY));
+const nightsBetween = (a: string, b: string) => Math.round((+parseYmd(b) - +parseYmd(a)) / DAY);
+const weekdayOf = (s: string) => parseYmd(s).getUTCDay(); // 0=Sun … 6=Sat
+const maxYmd = (...xs: string[]) => xs.reduce((a, b) => (a > b ? a : b));
+const minYmd = (...xs: string[]) => xs.reduce((a, b) => (a < b ? a : b));
+const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
+/** diacritic-insensitive contains, so DB names ("Craciunul") and typed copy both match */
+const norm = (s: string) => s.normalize('NFD').replace(new RegExp('[\u0300-\u036f]', 'g'), '').toLowerCase();
+
+export interface LandingPeriod { kind: 'window' | 'season'; start?: string | null; end?: string | null }
+export interface BuildExampleStaysOptions {
+  /** clock (default now); lets a test rewind it. Only future dates are ever proposed. */
+  asOf?: Date;
+  /** pricing occupancy + booking prefill; default = property base occupancy (a true "from" price). */
+  guests?: number;
+  /** how many stays to return (default 3). */
+  maxStays?: number;
+  /** for a SEASON campaign with no explicit end, how far ahead to look (default 150 days). */
+  seasonHorizonDays?: number;
+}
+
+interface Candidate {
+  start: string;                 // checkIn (YYYY-MM-DD)
+  nights: number;
+  kind: 'occasion' | 'weekend' | 'default';
+  occasionName: string | null;   // raw holiday name if occasion-anchored
+  score: number;
+}
+
+/**
+ * Propose calendar-valid, priced example stays for a campaign period. Returns `[]` (never throws) when
+ * there is nothing honest to show — no free inventory, no price data, or availability unreadable.
+ */
+export async function buildExampleStays(
+  propertyId: string,
+  period: LandingPeriod,
+  opts: BuildExampleStaysOptions = {},
+): Promise<ExampleStay[]> {
+  const asOf = opts.asOf ?? new Date();
+  const today = ymd(asOf);
+  const maxStays = opts.maxStays ?? 3;
+
+  // 1. Search window. For a dated WINDOW, the campaign's own [start,end] (clamped to not start in the
+  //    past). For a broad SEASON, from the later of today/period.start out to period.end or a horizon.
+  const searchStart = maxYmd(today, period.start ?? today);
+  const searchEnd = period.kind === 'window'
+    ? (period.end ?? addDays(searchStart, 30))
+    : (period.end ?? addDays(today, opts.seasonHorizonDays ?? 150));
+  if (searchStart > searchEnd) return [];
+
+  // 2. Availability across the window (one call). checkOut is EXCLUSIVE, so test through searchEnd by
+  //    passing searchEnd+1. unavailableDates lists blocked nights; missing month/day = available.
+  let unavailable: Set<string>;
+  try {
+    const res = await checkAvailabilityWithFlags(propertyId, parseYmd(searchStart), parseYmd(addDays(searchEnd, 1)));
+    unavailable = new Set(res.unavailableDates);
+  } catch (e) {
+    logger.warn('exampleStays: availability unreadable — no stays proposed', { propertyId, error: (e as Error).message });
+    return [];
+  }
+
+  // 3. Free runs (contiguous free nights) across the window — shared walker (signals.ts).
+  const dates: string[] = [];
+  for (let s = searchStart; s <= searchEnd; s = addDays(s, 1)) dates.push(s);
+  const freeRuns = computeFreeRuns(dates, k => !unavailable.has(k));
+  if (!freeRuns.length) return [];
+
+  // 4. Pricing + min-stay data: the property and every price calendar the window spans.
+  const property = await getPropertyWithDb(propertyId);
+  // getPropertyWithDb returns more fields at runtime (cleaningFee, defaultMinimumStay) than the declared
+  // PropertyPricing type carries — widen to read them (the pricing route does the same).
+  const px = property as typeof property & { cleaningFee?: number; defaultMinimumStay?: number };
+  const baseOccupancy = property.baseOccupancy ?? 2;
+  const maxGuests = property.maxGuests ?? 20;
+  const extraGuestFee = property.extraGuestFee ?? 0;
+  const cleaningFee = px.cleaningFee ?? 0;
+  const defaultMinStay = px.defaultMinimumStay ?? 1;
+  const guests = clamp(opts.guests ?? baseOccupancy, 1, maxGuests);
+  // UTC-safe month enumeration from the ymd window. (Not getMonthsBetweenDates — it does local-time
+  // month math that silently DROPS a month across a DST boundary, e.g. Oct→Dec skips December in
+  // Europe/Bucharest, which would leave late-year stays priceless.)
+  const monthKeys = [...new Set(dates.map(d => d.slice(0, 7)))];
+  const calendars = await Promise.all(monthKeys.map(mk => getPriceCalendarWithDb(propertyId, +mk.slice(0, 4), +mk.slice(5, 7))));
+  const dayCell = (dateStr: string) => {
+    const [y, mo, da] = dateStr.split('-').map(Number);
+    const cal = calendars.find(c => c && c.year === y && c.month === mo);
+    return cal?.days?.[String(da)] ?? null; // priceCalendars use an UNPADDED day key
+  };
+  const minStayFor = (dateStr: string) => {
+    const cell = dayCell(dateStr);
+    return cell && typeof cell.minimumStay === 'number' && cell.minimumStay > 0
+      ? cell.minimumStay
+      : defaultMinStay;
+  };
+
+  // 5. Occasions the free runs can borrow a true reason from (holidays + derived long-weekend/bridge
+  //    windows), restricted to ones overlapping the search window. Same source + algorithms as the analyst.
+  const holidays = await getHolidays();
+  const occasions = computeOccasions(holidays, asOf, 40).filter(o => o.startDate <= searchEnd && o.endDate >= searchStart);
+  const windows = computeExtendedWindows(holidays, asOf).filter(w => w.start <= searchEnd && w.end >= searchStart);
+
+  // 6. Candidate generation. Push a candidate only if it fits inside ONE free run and meets the minimum
+  //    stay on its own check-in date (grown to the minimum when the run can still host it).
+  const candidates: Candidate[] = [];
+  const includesWeekendNight = (start: string, nights: number) => {
+    for (let i = 0; i < nights; i++) { const w = weekdayOf(addDays(start, i)); if (w === 5 || w === 6) return true; }
+    return false;
+  };
+  const push = (start: string, wantNights: number, kind: Candidate['kind'], occasionName: string | null, base: number) => {
+    if (start < today) return;
+    const run = freeRuns.find(r => start >= r.start && start <= r.end);
+    if (!run) return;
+    const capacity = nightsBetween(start, addDays(run.end, 1)); // free nights from `start` to run end
+    const minStay = minStayFor(start);
+    const nights = clamp(wantNights, minStay, capacity);
+    if (nights < minStay || nights < 1) return; // run too short to host even the minimum from here
+    const daysOut = nightsBetween(today, start);
+    const score = base + (includesWeekendNight(start, nights) ? 15 : 0) - daysOut * 0.05;
+    candidates.push({ start, nights, kind, occasionName, score });
+  };
+  const firstWeekday = (run: FreeRun, weekday: number): string | null => {
+    for (let s = maxYmd(run.start, today); s <= run.end; s = addDays(s, 1)) if (weekdayOf(s) === weekday) return s;
+    return null;
+  };
+
+  for (const run of freeRuns) {
+    // (a) long-weekend / bridge windows overlapping this run — the strongest anchor
+    for (const w of windows) {
+      const s = maxYmd(w.start, run.start, today);
+      const e = minYmd(w.end, run.end);
+      if (s > e) continue;
+      const occ = occasions.find(o => o.startDate <= w.end && o.endDate >= w.start);
+      push(s, nightsBetween(s, addDays(e, 1)), 'occasion', occ?.name ?? null, 100);
+    }
+    // (b) holidays / school breaks overlapping this run (not necessarily a bridge)
+    for (const o of occasions) {
+      if (o.endDate < run.start || o.startDate > run.end) continue;
+      const multiDay = nightsBetween(o.startDate, addDays(o.endDate, 1)) >= 4;
+      push(maxYmd(o.startDate, run.start, today), multiDay ? 4 : 3, 'occasion', o.name, 80);
+    }
+    // (c) a weekend within this run (Fri→Mon, else Sat→Mon)
+    const fri = firstWeekday(run, 5);
+    if (fri) push(fri, 3, 'weekend', null, 50);
+    else { const sat = firstWeekday(run, 6); if (sat) push(sat, 2, 'weekend', null, 45); }
+    // (d) default fallback so the section is never empty when inventory exists
+    push(maxYmd(run.start, today), 3, 'default', null, 20);
+  }
+
+  // 7. Select: dedupe (start,nights) keeping the best score, rank, then pick non-overlapping stays for
+  //    variety (a page of three near-identical windows helps no one), chronological on the page.
+  const byKey = new Map<string, Candidate>();
+  for (const c of candidates) {
+    const key = `${c.start}_${c.nights}`;
+    const prev = byKey.get(key);
+    if (!prev || c.score > prev.score) byKey.set(key, c);
+  }
+  const ranked = [...byKey.values()].sort((a, b) => b.score - a.score || a.start.localeCompare(b.start));
+  const picked: Candidate[] = [];
+  const overlaps = (a: Candidate, b: Candidate) => a.start < addDays(b.start, b.nights) && b.start < addDays(a.start, a.nights);
+  for (const c of ranked) {
+    if (picked.length >= maxStays) break;
+    if (!picked.some(p => overlaps(p, c))) picked.push(c);
+  }
+  picked.sort((a, b) => a.start.localeCompare(b.start));
+
+  // 8. Price + label each pick.
+  const losDiscounts = property.pricingConfig?.lengthOfStayDiscounts;
+  const stays: ExampleStay[] = picked.map((c) => {
+    const { label, occasion } = describe(c);
+    return {
+      start: c.start,
+      end: addDays(c.start, c.nights), // checkout
+      nights: c.nights,
+      label,
+      occasion,
+      priceHint: priceStay(c.start, c.nights, guests, dayCell, { baseOccupancy, extraGuestFee, cleaningFee }, losDiscounts),
+      guests,
+    };
+  });
+
+  logger.info('exampleStays: proposed', {
+    propertyId, periodKind: period.kind, searchStart, searchEnd,
+    freeRuns: freeRuns.length, candidates: candidates.length, picked: stays.length,
+  });
+  return stays;
+}
+
+/** Real quoted total for a stay at `guests` occupancy (occupancy price + cleaning fee + LoS discount),
+ *  identical to the booking page. Null if any night lacks calendar data (card renders without a price). */
+function priceStay(
+  start: string, nights: number, guests: number,
+  dayCell: (d: string) => { prices?: Record<string, number>; adjustedPrice?: number; minimumStay?: number } | null,
+  property: { baseOccupancy: number; extraGuestFee: number; cleaningFee: number },
+  losDiscounts?: Parameters<typeof calculateBookingPrice>[2],
+): number | null {
+  const dailyPrices: Record<string, number> = {};
+  for (let i = 0; i < nights; i++) {
+    const date = addDays(start, i);
+    const cell = dayCell(date);
+    if (!cell) return null;
+    const perNight = cell.prices?.[String(guests)]
+      ?? (cell.adjustedPrice != null
+        ? cell.adjustedPrice + Math.max(0, guests - property.baseOccupancy) * (property.extraGuestFee || 0)
+        : undefined);
+    if (perNight == null) return null;
+    dailyPrices[date] = perNight;
+  }
+  const { total } = calculateBookingPrice(dailyPrices, property.cleaningFee || 0, losDiscounts);
+  return Math.round(total);
+}
+
+/** Deterministic bilingual label + short occasion tag for a candidate. Known Romanian holidays get a
+ *  hand-tuned phrasing (with diacritics); everything else falls back to length/weekend wording. */
+function describe(c: Candidate): { label: Ml; occasion: string | null } {
+  if (c.kind === 'occasion' && c.occasionName) {
+    const n = norm(c.occasionName);
+    if (n.includes('ziua nationala') || n.includes('sfantul andrei'))
+      return { label: { ro: 'Minivacanța de 1 Decembrie', en: 'The December 1st long weekend' }, occasion: 'Ziua Națională' };
+    if (n.includes('vacanta de toamna'))
+      return { label: { ro: 'Vacanța de toamnă la munte', en: 'Autumn school break in the mountains' }, occasion: 'Vacanța de toamnă' };
+    if (n.includes('vacanta de iarna'))
+      return { label: { ro: 'Vacanța de iarnă la munte', en: 'Winter school break in the mountains' }, occasion: 'Vacanța de iarnă' };
+    if (n.includes('craciun'))
+      return { label: { ro: 'Crăciun la munte', en: 'Christmas in the mountains' }, occasion: 'Crăciun' };
+    if (n.includes('anul nou') || n.includes('revelion'))
+      return { label: { ro: 'Revelion la munte', en: 'New Year in the mountains' }, occasion: 'Revelion' };
+    if (n.includes('adormirea') || n.includes('sfanta maria'))
+      return { label: { ro: 'Sfânta Maria la munte', en: 'A holiday weekend in the mountains' }, occasion: 'Sfânta Maria' };
+    if (n.includes('boboteaza'))
+      return { label: { ro: 'Bobotează la munte', en: 'A holiday weekend in the mountains' }, occasion: 'Bobotează' };
+    if (n.includes('unirii'))
+      return { label: { ro: '24 Ianuarie la munte', en: 'A holiday weekend in the mountains' }, occasion: '24 Ianuarie' };
+    if (n.includes('inceputul cursurilor') || n.includes('vacanta de vara'))
+      return { label: { ro: 'Ultimele zile de vară', en: 'The last days of summer' }, occasion: 'Sfârșit de vară' };
+    // generic occasion (unknown holiday) — use its own name
+    return { label: { ro: `${c.occasionName} la munte`, en: `${c.occasionName} in the mountains` }, occasion: c.occasionName };
+  }
+  if (c.kind === 'weekend') {
+    return c.nights >= 3
+      ? { label: { ro: 'Weekend prelungit la munte', en: 'A long weekend in the mountains' }, occasion: null }
+      : { label: { ro: 'Weekend la munte', en: 'A weekend in the mountains' }, occasion: null };
+  }
+  return { label: { ro: `Escapadă de ${c.nights} nopți`, en: `A ${c.nights}-night escape` }, occasion: null };
+}

--- a/src/lib/landing/generateLanding.ts
+++ b/src/lib/landing/generateLanding.ts
@@ -1,0 +1,102 @@
+/**
+ * generate-from-campaign — landing-page engine P3 (docs/landing-page-engine-design.md §P3). Server-only.
+ *
+ * Turns an existing ad campaign into a DRAFT landing config, so the landing echoes the ad (one coherent
+ * thing). It reuses the campaign's persisted `proposal` framing — occasion, chosen photos, and the copy
+ * the ad copywriter already wrote — plus the deterministic example-stays reasoner (P2). Copy is reused
+ * as-is for scent-match (headline/hero = the ad's winning variant, story = its most narrative one); an
+ * `emit_landing_copy` LLM pass in the ad's voice (mirroring adCopywriter.ts) is the intended follow-up.
+ * Nothing is written or sent here — the admin action persists the returned draft to `landingPages/{slug}`.
+ */
+import { getAdminDb } from '@/lib/firebaseAdminSafe';
+import { buildExampleStays } from '@/lib/landing/exampleStays';
+import type { LandingConfig, Ml } from '@/lib/landing/contracts';
+
+interface CampaignCopyVariant { primary?: string; headline?: string; cta?: string }
+interface CampaignProposal {
+  occasion?: { name?: string | null; start?: string; end?: string; nights?: number } | null;
+  goal?: string | null;
+  audience?: string | null;
+  creativeBrief?: string | null;
+  photos?: Array<{ storagePath?: string; url?: string }>;
+  copy?: CampaignCopyVariant[];
+}
+
+const stripDiacritics = (s: string) => s.normalize('NFD').replace(new RegExp('[\u0300-\u036f]', 'g'), '');
+const monthsRo = ['ian', 'feb', 'mar', 'apr', 'mai', 'iun', 'iul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+const shortDateRo = (iso: string) => { const [, m, d] = iso.split('-'); return `${+d} ${monthsRo[+m - 1]}`; };
+
+/** A short, URL-safe slug suggestion from the campaign occasion (owner can override in the picker). */
+export function suggestLandingSlug(occasionName?: string | null, start?: string | null, fallback = 'campaign'): string {
+  const words = stripDiacritics(occasionName || '')
+    .toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/)
+    .filter(w => w.length > 2 && !['din', 'the', 'and', 'pentru', 'catre', 'este'].includes(w));
+  const base = words.slice(0, 3).join('-') || (start ? `camp-${start.slice(2, 7).replace('-', '')}` : fallback);
+  return base.slice(0, 40);
+}
+
+/** Concise hero-badge label from the occasion: "<theme> · <date range>". Editable afterwards. */
+function occasionLabel(occ: CampaignProposal['occasion']): Ml {
+  const theme = (occ?.name || '').split(/[—\-(]/)[0].trim().slice(0, 32);
+  const range = occ?.start && occ?.end ? `${shortDateRo(occ.start)} – ${shortDateRo(occ.end)}` : '';
+  const ro = [theme, range].filter(Boolean).join(' · ');
+  return { ro: ro || 'La munte' };
+}
+
+/**
+ * Build a draft LandingConfig from an ad campaign. Throws if the campaign is missing. Returns the config
+ * (not persisted) with `status:'draft'` and `campaignRef` set. `slug` is chosen by the caller.
+ */
+export async function buildLandingDraftFromCampaign(
+  campaignId: string,
+  opts: { slug: string; createdBy?: string },
+): Promise<LandingConfig> {
+  const db = await getAdminDb();
+  const snap = await db.collection('adCampaigns').doc(campaignId).get();
+  if (!snap.exists) throw new Error(`ad campaign ${campaignId} not found`);
+  const c = snap.data()!;
+  const propertyId: string = c.propertyId;
+  const p: CampaignProposal = c.proposal ?? {};
+  const occ = p.occasion ?? {};
+
+  const start = occ.start ?? null;
+  const end = occ.end ?? null;
+  const kind: 'window' | 'season' = start && end ? 'window' : 'season';
+
+  // Example stays from the deterministic reasoner (P2) — real, calendar-valid, priced.
+  const exampleStays = await buildExampleStays(propertyId, { kind, start, end });
+
+  // Photos: the SAME assets the ad used (scent-match). First = hero, rest = gallery (deduped, ≤6).
+  const photos = [...new Set((p.photos ?? []).map(x => x.storagePath).filter((s): s is string => !!s))];
+  const heroImage = photos[0] ?? '';
+  const gallery = photos.filter(sp => sp !== heroImage).slice(0, 6);
+
+  // Copy: reuse the ad copywriter's output. Hero = winning variant; story body = the most narrative one.
+  const copy = p.copy ?? [];
+  const lead = copy[0] ?? {};
+  const narrative = copy.slice(1).reduce<CampaignCopyVariant | null>(
+    (best, v) => ((v.primary?.length ?? 0) > (best?.primary?.length ?? 0) ? v : best), null) ?? lead;
+
+  return {
+    slug: opts.slug,
+    propertyId,
+    defaultLanguage: 'ro',
+    status: 'draft',
+    campaignRef: campaignId,
+    period: { kind, start, end, label: occasionLabel(occ) },
+    hero: {
+      imagePath: heroImage,
+      headline: { ro: lead.headline || 'Escapadă la munte' },
+      subcopy: lead.primary ? { ro: lead.primary } : undefined,
+    },
+    story: {
+      title: { ro: (copy[1]?.headline || lead.headline || '') },
+      body: { ro: narrative.primary || '' },
+    },
+    exampleStays,
+    gallery,
+    offer: { text: { en: 'Direct booking — no commission', ro: 'Rezervare directă, fără comision' } },
+    cta: { showBooking: true },
+    createdBy: opts.createdBy,
+  };
+}


### PR DESCRIPTION
## What

**P2 — example-stays reasoner** (`src/lib/landing/exampleStays.ts`). `buildExampleStays(propertyId, period, opts)` proposes 1–3 real, calendar-valid, priced example stays for a campaign window or season. Truth-guardrailed:
- Free nights from the `availability` collection (single source of truth), missing = free.
- Per-date minimum stay + real from-price from `priceCalendars` via `calculateBookingPrice`.
- Occasion / long-weekend anchoring (Oct break, 30 Nov–1 Dec, etc.) from the shared holiday algorithms.
- Deterministic bilingual labels (LLM voicing deferred).

**Shared extraction.** Moved the free-run walk + occasions + bridge-window algorithms out of `situationPack.ts` into `signals.ts` (`computeFreeRuns` / `computeOccasions` / `computeExtendedWindows` / `getHolidays`) and refactored the pack to call them — a verbatim lift, pack output byte-identical (verified the pack still builds with intact freeRuns/occasions/windows).

**P3 — generate-from-campaign + admin editor.** `generateLanding.ts` reads `adCampaigns.proposal` (occasion, chosen photos, copy variants) into a draft landing that echoes the ad. New admin section `/admin/landing`: list + "Generate from campaign" picker + `[slug]` editor (bilingual copy, hero + gallery image pickers, editable/regenerable example stays, publish, preview). Reuses the website editor toolkit (`MultilingualInput` / `ImagePicker` / `SortableList`); super-admin gated actions; Admin-SDK-only writes to `landingPages`.

## Notes
- Tested against live Firestore: the reasoner and generate-from-campaign both produce correct, coherent output. The admin editor UI compiles and follows the established patterns but was not click-tested (needs admin login post-deploy).
- Copy is reused deterministically from the ad for scent-match; an `emit_landing_copy` LLM pass mirroring `adCopywriter.ts` is the intended follow-up.
- Worked around a DST bug in `getMonthsBetweenDates` (drops a month across the late-Oct DST switch) with UTC-safe month enumeration in the reasoner — the same helper backs `/api/check-pricing` and is worth a separate fix.
- `/lp` pages are `noindex`; `/admin` is auth-gated. The live heat ad still points at the property home (P4 not done), so this deploy does not change the ad's destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)