### PR TITLE
feat: arrival block on the guest guide, and secrets out of the repo

### DIFF
--- a/scripts/seed-guest-guide.ts
+++ b/scripts/seed-guest-guide.ts
@@ -22,19 +22,27 @@ admin.initializeApp({
 
 const db = admin.firestore();
 
+// Contact numbers and any door code live in .env.local (untracked), not here -
+// this repo is public. Missing values are left unset rather than guessed, so a
+// half-configured guide simply omits that contact instead of shipping a blank.
+const HOST_PHONE = process.env.GUIDE_HOST_PHONE;
+const KEEPER_PHONE = process.env.GUIDE_KEEPER_PHONE;
+const WIFI_PASSWORD = process.env.GUIDE_WIFI_PASSWORD;
+const LOCKBOX_CODE = process.env.GUIDE_LOCKBOX_CODE;
+
 const MAP_URL =
   'https://www.google.com/maps/d/u/0/viewer?mid=1KGS8M8z9YF24TjVxeixWJYDr3gB6Uis';
 
 const prahovaGuide = {
   enabled: true,
 
-  wifi: { network: 'coman_guest', password: 'athome' },
+  wifi: { network: 'coman_guest', password: WIFI_PASSWORD },
 
   contacts: [
     {
       displayName: { en: 'Bogdan', ro: 'Bogdan' },
       role: { en: 'Your host', ro: 'Gazda' },
-      phone: '+40723200868',
+      phone: HOST_PHONE,
       channel: 'whatsapp',
       speaks: ['en', 'ro'],
     },
@@ -47,7 +55,7 @@ const prahovaGuide = {
         en: 'They look after the house - they live a few doors down',
         ro: 'Se ocupă de casă - locuiesc la câteva case distanță',
       },
-      phone: '+40726114540',
+      phone: KEEPER_PHONE,
       channel: 'whatsapp',
       speaks: ['ro'],
       prefill: {
@@ -55,6 +63,25 @@ const prahovaGuide = {
       },
     },
   ],
+
+  // Shown at the top of the guide until the day after check-in, then demoted.
+  // The call is not a courtesy: it is what resolves whether someone meets the
+  // guest or the key is waiting for them.
+  arrival: {
+    wazeUrl:
+      'https://www.waze.com/en/live-map/directions?to=ll.45.25477736%2C25.64310908',
+    mapsUrl: 'https://goo.gl/maps/nw7UumH3r9mio4fUA',
+    plusCode: '7J3V+W77 Comarnic',
+    call: {
+      en: 'Call Bogdan 10-15 minutes before you arrive. If Corina or Gigi are around they will meet you at the house with the key. If not, we will tell you exactly where to find it.',
+      ro: 'Sunați-l pe Bogdan cu 10-15 minute înainte să ajungeți. Dacă doamna Corina sau domnul Gigi sunt prin zonă, vă întâmpină ei la casă cu cheia. Dacă nu, vă spunem exact unde o găsiți.',
+    },
+    access: {
+      en: 'The house sits about 60 m up from the road, where you park. That climb is why it is quiet up here and why the terrace looks out over the valley - but it does mean soft bags travel better than hard trollers.',
+      ro: 'De la stradă, de unde parcați, până la casă e o alee de vreo 60 m. Urcușul ăsta e motivul pentru care e liniște sus și pentru care terasa are priveliștea pe care o are - dar înseamnă și că gențile moi se cară mai ușor decât trolerele.',
+    },
+    ...(LOCKBOX_CODE ? { lockboxCode: LOCKBOX_CODE } : {}),
+  },
 
   mapUrl: MAP_URL,
 

--- a/src/app/guide/[bookingId]/_components/guide-view.tsx
+++ b/src/app/guide/[bookingId]/_components/guide-view.tsx
@@ -20,6 +20,7 @@ import {
   Map,
   MessageCircle,
   Mountain,
+  Navigation,
   Phone,
   ScrollText,
   ShoppingBasket,
@@ -45,6 +46,10 @@ const COPY = {
     network: 'network',
     password: 'password',
     copied: 'Copied',
+    arrival: 'Getting here',
+    maps: 'Maps',
+    plusCode: 'Plus code',
+    lockbox: 'Key box code',
     whoToCall: 'Who to call',
     trips: 'Trips & hikes',
     openMap: 'Open in Google Maps',
@@ -73,6 +78,10 @@ const COPY = {
     network: 'rețea',
     password: 'parolă',
     copied: 'Copiat',
+    arrival: 'Cum ajungeți',
+    maps: 'Maps',
+    plusCode: 'Cod Plus',
+    lockbox: 'Codul cutiei de chei',
     whoToCall: 'Pe cine suni',
     trips: 'Trasee și excursii',
     openMap: 'Deschide în Google Maps',
@@ -211,6 +220,77 @@ function WifiCard({ network, password, t }: { network: string; password: string;
   );
 }
 
+function ArrivalCard({
+  a,
+  t,
+}: {
+  a: NonNullable<GuideData['arrival']>;
+  t: typeof COPY.en;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copyPlusCode = async () => {
+    if (!a.plusCode) return;
+    try {
+      await navigator.clipboard.writeText(a.plusCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // On screen anyway; nothing to recover from.
+    }
+  };
+
+  const link =
+    'flex items-center justify-center gap-1.5 rounded-lg border-[1.5px] border-[#414A22] px-2 py-2.5 text-[12px] font-bold text-[#414A22] transition hover:bg-[#F4F2E7] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7E9A33]';
+
+  return (
+    <section className="rounded-xl border border-[#DDDAC7] bg-white p-4">
+      <h2 className="mb-3 flex items-center gap-1.5 text-[10px] font-extrabold uppercase tracking-[0.15em] text-[#6D7154]">
+        <Navigation className="h-3 w-3" />
+        {t.arrival}
+      </h2>
+
+      <div className="grid grid-cols-3 gap-2">
+        {a.wazeUrl && (
+          <a className={link} href={a.wazeUrl} target="_blank" rel="noopener noreferrer">
+            Waze
+          </a>
+        )}
+        {a.mapsUrl && (
+          <a className={link} href={a.mapsUrl} target="_blank" rel="noopener noreferrer">
+            {t.maps}
+          </a>
+        )}
+        {a.plusCode && (
+          <button type="button" onClick={copyPlusCode} className={link}>
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? t.copied : t.plusCode}
+          </button>
+        )}
+      </div>
+
+      {a.call && (
+        <p className="mt-3 rounded-lg bg-[#414A22] px-3 py-2.5 text-[12.5px] leading-relaxed text-[#F4F2E7]">
+          {a.call}
+        </p>
+      )}
+
+      {a.lockboxCode && (
+        <p className="mt-2 flex items-baseline gap-2 rounded-lg border border-[#DDDAC7] bg-[#F4F2E7] px-3 py-2.5 text-[11px] text-[#6D7154]">
+          {t.lockbox}
+          <strong className="font-mono text-base tracking-[0.15em] text-[#23260F]">
+            {a.lockboxCode}
+          </strong>
+        </p>
+      )}
+
+      {a.access && (
+        <p className="mt-2 text-[11.5px] leading-relaxed text-[#6D7154]">{a.access}</p>
+      )}
+    </section>
+  );
+}
+
 export default function GuideView({ data }: { data: GuideData }) {
   const t = COPY[data.language] ?? COPY.en;
   const isGuest = data.tier === 'guest';
@@ -283,7 +363,11 @@ export default function GuideView({ data }: { data: GuideData }) {
       </header>
 
       <div className="flex flex-col gap-3 p-4">
+        {data.arrival && data.arrivalLeads && <ArrivalCard a={data.arrival} t={t} />}
+
         {data.wifi && <WifiCard network={data.wifi.network} password={data.wifi.password} t={t} />}
+
+        {data.arrival && !data.arrivalLeads && <ArrivalCard a={data.arrival} t={t} />}
 
         {data.contacts.length > 0 && (
           <section className="rounded-xl border border-[#DDDAC7] bg-white p-4">

--- a/src/app/guide/[bookingId]/_lib/fetch-guide.ts
+++ b/src/app/guide/[bookingId]/_lib/fetch-guide.ts
@@ -60,10 +60,26 @@ export interface GuideSection {
   image?: { url: string; alt?: MultilingualString | string };
 }
 
+/**
+ * Everything a guest needs on the road and at the gate. Rendered first until the
+ * day after check-in, then demoted below the WiFi - by then they are inside and
+ * arrival is history.
+ */
+export interface GuideArrival {
+  wazeUrl?: string;
+  mapsUrl?: string;
+  plusCode?: string;
+  call?: MultilingualString | string;
+  access?: MultilingualString | string;
+  /** Guest tier only, and never stored in the repo. */
+  lockboxCode?: string;
+}
+
 export interface GuestGuideConfig {
   enabled?: boolean;
   wifi?: { network?: string; password?: string };
   contacts?: GuideContact[];
+  arrival?: GuideArrival;
   mapUrl?: string;
   routes?: GuideRoute[];
   sections?: GuideSection[];
@@ -98,6 +114,17 @@ export interface GuideData {
   checkInTime?: string;
   checkOutTime?: string;
   wifi?: { network: string; password: string };
+  /** Guest tier only. Absent once the stay is under way. */
+  arrival?: {
+    wazeUrl?: string;
+    mapsUrl?: string;
+    plusCode?: string;
+    call?: string;
+    access?: string;
+    lockboxCode?: string;
+  };
+  /** True until the day after check-in: arrival still leads the page. */
+  arrivalLeads: boolean;
   contacts: ResolvedContact[];
   mapUrl?: string;
   routes: Array<{ name: string; kind: GuideRoute['kind']; km: number; mapUrl?: string }>;
@@ -268,6 +295,7 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
     language,
     propertyName,
     propertySlug,
+    arrivalLeads: false,
     contacts: tier === 'guest' ? resolveContacts(guide.contacts ?? [], language) : [],
     mapUrl: guide.mapUrl,
     routes,
@@ -284,6 +312,24 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
     data.checkOutTime = property.checkOutTime;
     if (guide.wifi?.network && guide.wifi?.password) {
       data.wifi = { network: guide.wifi.network, password: guide.wifi.password };
+    }
+
+    if (guide.arrival) {
+      data.arrival = {
+        wazeUrl: guide.arrival.wazeUrl,
+        mapsUrl: guide.arrival.mapsUrl,
+        plusCode: guide.arrival.plusCode,
+        call: getLocalizedString(guide.arrival.call, language, '') || undefined,
+        access: getLocalizedString(guide.arrival.access, language, '') || undefined,
+        lockboxCode: guide.arrival.lockboxCode,
+      };
+
+      // Arrival leads the page until the end of the arrival day. A whole day of
+      // slack means the exact hour, and the guest's timezone, never matter.
+      if (checkInDate) {
+        const demoteAfter = new Date(checkInDate.getTime() + 36 * 60 * 60 * 1000);
+        data.arrivalLeads = new Date() < demoteAfter;
+      }
     }
   }
 


### PR DESCRIPTION
The guide told a guest the WiFi password, the house rules and how to leave, but **nothing about arriving or getting in** - the one moment they are most likely to need help. This adds it, from the message the owner sends by hand the day before.

## Arrival card

Waze pin, Google Maps link and Plus code as tap targets (the Plus code copies to the clipboard), the call instruction, and the access-path note.

**It leads the page until 36 hours after check-in, then drops below the WiFi.** Before arrival, getting to the door is the only thing that matters; afterwards they are inside and the WiFi is what they reach for. A day of slack means the exact hour, and the guest's own timezone, never come into it.

Verified against two live bookings: one arriving Monday renders it first, one whose stay has ended renders it after the WiFi. Nothing leaks to the public tier.

## The call covers both branches on purpose

> "Call Bogdan 10-15 minutes before you arrive. If Corina or Gigi are around they will meet you at the house with the key. If not, we will tell you exactly where to find it."

The handover genuinely varies, and the call is what resolves which it is. Wording it this way gives the guest a reason to make the call, rather than promising a greeting that cannot always be delivered.

## The access note is framed as a feature

> "The house sits about 60 m up from the road, where you park. That climb is why it is quiet up here and why the terrace looks out over the valley - but it does mean soft bags travel better than hard trollers."

It is also an **accessibility fact**, so it belongs on the public listing and in the confirmation email as well. A guest packing hard trollers currently finds out the day before, which is already too late to act on. Those two placements are not in this PR.

## Secrets out of the repo

This repo is public, and `scripts/seed-guest-guide.ts` carried the WiFi password and the housekeepers' mobile. Both now read from `.env.local`, which is gitignored, along with any future lockbox code. The code renders on the guest tier only.

The values remain in git history. The remediation for that is rotating them, not rewriting a public history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)