### PR TITLE
fix: drop the Plus code from the guide, use a durable Maps URL

### DIFF
--- a/scripts/seed-guest-guide.ts
+++ b/scripts/seed-guest-guide.ts
@@ -70,8 +70,11 @@ const prahovaGuide = {
   arrival: {
     wazeUrl:
       'https://www.waze.com/en/live-map/directions?to=ll.45.25477736%2C25.64310908',
-    mapsUrl: 'https://goo.gl/maps/nw7UumH3r9mio4fUA',
-    plusCode: '7J3V+W77 Comarnic',
+    // Google's documented URL API rather than a goo.gl short link, which is a
+    // shortener Google has been retiring. Directions-to, not a place pin, and on
+    // the same coordinates as the Waze link above so the two agree.
+    mapsUrl:
+      'https://www.google.com/maps/dir/?api=1&destination=45.25477736,25.64310908',
     call: {
       en: 'Call Bogdan 10-15 minutes before you arrive. If Corina or Gigi are around they will meet you at the house with the key. If not, we will tell you exactly where to find it.',
       ro: 'Sunați-l pe Bogdan cu 10-15 minute înainte să ajungeți. Dacă doamna Corina sau domnul Gigi sunt prin zonă, vă întâmpină ei la casă cu cheia. Dacă nu, vă spunem exact unde o găsiți.',

--- a/src/app/guide/[bookingId]/_components/guide-view.tsx
+++ b/src/app/guide/[bookingId]/_components/guide-view.tsx
@@ -48,7 +48,6 @@ const COPY = {
     copied: 'Copied',
     arrival: 'Getting here',
     maps: 'Maps',
-    plusCode: 'Plus code',
     lockbox: 'Key box code',
     whoToCall: 'Who to call',
     trips: 'Trips & hikes',
@@ -80,7 +79,6 @@ const COPY = {
     copied: 'Copiat',
     arrival: 'Cum ajungeți',
     maps: 'Maps',
-    plusCode: 'Cod Plus',
     lockbox: 'Codul cutiei de chei',
     whoToCall: 'Pe cine suni',
     trips: 'Trasee și excursii',
@@ -227,19 +225,9 @@ function ArrivalCard({
   a: NonNullable<GuideData['arrival']>;
   t: typeof COPY.en;
 }) {
-  const [copied, setCopied] = useState(false);
-
-  const copyPlusCode = async () => {
-    if (!a.plusCode) return;
-    try {
-      await navigator.clipboard.writeText(a.plusCode);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // On screen anyway; nothing to recover from.
-    }
-  };
-
+  // No Plus code here on purpose: it resolves to the same point in the same app
+  // as the Maps link, but costs the guest a copy, an app switch and a paste. It
+  // stays in the platform message, where a link can be mangled or read aloud.
   const link =
     'flex items-center justify-center gap-1.5 rounded-lg border-[1.5px] border-[#414A22] px-2 py-2.5 text-[12px] font-bold text-[#414A22] transition hover:bg-[#F4F2E7] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7E9A33]';
 
@@ -250,22 +238,28 @@ function ArrivalCard({
         {t.arrival}
       </h2>
 
-      <div className="grid grid-cols-3 gap-2">
+      <div className="flex gap-2">
         {a.wazeUrl && (
-          <a className={link} href={a.wazeUrl} target="_blank" rel="noopener noreferrer">
+          <a
+            className={`${link} flex-1`}
+            href={a.wazeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Navigation className="h-3.5 w-3.5" />
             Waze
           </a>
         )}
         {a.mapsUrl && (
-          <a className={link} href={a.mapsUrl} target="_blank" rel="noopener noreferrer">
+          <a
+            className={`${link} flex-1`}
+            href={a.mapsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Map className="h-3.5 w-3.5" />
             {t.maps}
           </a>
-        )}
-        {a.plusCode && (
-          <button type="button" onClick={copyPlusCode} className={link}>
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? t.copied : t.plusCode}
-          </button>
         )}
       </div>
 

--- a/src/app/guide/[bookingId]/_lib/fetch-guide.ts
+++ b/src/app/guide/[bookingId]/_lib/fetch-guide.ts
@@ -68,7 +68,6 @@ export interface GuideSection {
 export interface GuideArrival {
   wazeUrl?: string;
   mapsUrl?: string;
-  plusCode?: string;
   call?: MultilingualString | string;
   access?: MultilingualString | string;
   /** Guest tier only, and never stored in the repo. */
@@ -118,7 +117,6 @@ export interface GuideData {
   arrival?: {
     wazeUrl?: string;
     mapsUrl?: string;
-    plusCode?: string;
     call?: string;
     access?: string;
     lockboxCode?: string;
@@ -318,8 +316,7 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
       data.arrival = {
         wazeUrl: guide.arrival.wazeUrl,
         mapsUrl: guide.arrival.mapsUrl,
-        plusCode: guide.arrival.plusCode,
-        call: getLocalizedString(guide.arrival.call, language, '') || undefined,
+            call: getLocalizedString(guide.arrival.call, language, '') || undefined,
         access: getLocalizedString(guide.arrival.access, language, '') || undefined,
         lockboxCode: guide.arrival.lockboxCode,
       };


### PR DESCRIPTION
## Plus code off the page

The Plus code and the Maps link resolve to the same point in the same app. On a page where both are tappable, the code costs the guest a copy, an app switch and a paste to reach the same place.

It **stays in the platform message**, where it earns its keep for a different reason: it is plain text, so it survives Airbnb and Booking rewriting links in their inbox, being read aloud over the phone, or written on paper.

## Durable Maps URL

`goo.gl/maps/...` replaced with Google's documented URL API:

```
https://www.google.com/maps/dir/?api=1&destination=45.25477736,25.64310908
```

The short link still resolved when tested, but it is a shortener Google has been retiring, and this link will be sent for years. The new form also opens **directions-to** rather than a place pin - what an arriving guest actually wants, and what the Waze link already did.

## One spot, not two

Both links now carry the same coordinates as the Waze pin, instead of landing about 30 m apart. Verified: both return HTTP 200 and parse to identical lat/lng.

Card is now two equal buttons with icons rather than three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)