### PR TITLE
fix: gate number on arrival, full "Google Maps" label, keepers live a few houses away

### DIFF
--- a/scripts/seed-guest-guide.ts
+++ b/scripts/seed-guest-guide.ts
@@ -52,7 +52,7 @@ const prahovaGuide = {
         ro: 'Doamna Corina și domnul Gigi',
       },
       role: {
-        en: 'They look after the house - they live a few doors down',
+        en: 'They look after the house - they live a few houses away',
         ro: 'Se ocupă de casă - locuiesc la câteva case distanță',
       },
       phone: KEEPER_PHONE,
@@ -75,6 +75,7 @@ const prahovaGuide = {
     // the same coordinates as the Waze link above so the two agree.
     mapsUrl:
       'https://www.google.com/maps/dir/?api=1&destination=45.25477736,25.64310908',
+    gateNumber: '197',
     call: {
       en: 'Call Bogdan 10-15 minutes before you arrive. If Corina or Gigi are around they will meet you at the house with the key. If not, we will tell you exactly where to find it.',
       ro: 'Sunați-l pe Bogdan cu 10-15 minute înainte să ajungeți. Dacă doamna Corina sau domnul Gigi sunt prin zonă, vă întâmpină ei la casă cu cheia. Dacă nu, vă spunem exact unde o găsiți.',

--- a/src/app/guide/[bookingId]/_components/guide-view.tsx
+++ b/src/app/guide/[bookingId]/_components/guide-view.tsx
@@ -47,7 +47,8 @@ const COPY = {
     password: 'password',
     copied: 'Copied',
     arrival: 'Getting here',
-    maps: 'Maps',
+    maps: 'Google Maps',
+    gate: 'Look for this number on the gate',
     lockbox: 'Key box code',
     whoToCall: 'Who to call',
     trips: 'Trips & hikes',
@@ -78,7 +79,8 @@ const COPY = {
     password: 'parolă',
     copied: 'Copiat',
     arrival: 'Cum ajungeți',
-    maps: 'Maps',
+    maps: 'Google Maps',
+    gate: 'Căutați numărul acesta pe poartă',
     lockbox: 'Codul cutiei de chei',
     whoToCall: 'Pe cine suni',
     trips: 'Trasee și excursii',
@@ -262,6 +264,15 @@ function ArrivalCard({
           </a>
         )}
       </div>
+
+      {a.gateNumber && (
+        <p className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-[#DDDAC7] bg-[#F4F2E7] px-3 py-2.5">
+          <span className="text-[11.5px] leading-snug text-[#6D7154]">{t.gate}</span>
+          <strong className="font-mono text-xl font-bold tracking-[0.08em] text-[#23260F]">
+            {a.gateNumber}
+          </strong>
+        </p>
+      )}
 
       {a.call && (
         <p className="mt-3 rounded-lg bg-[#414A22] px-3 py-2.5 text-[12.5px] leading-relaxed text-[#F4F2E7]">

--- a/src/app/guide/[bookingId]/_lib/fetch-guide.ts
+++ b/src/app/guide/[bookingId]/_lib/fetch-guide.ts
@@ -68,6 +68,8 @@ export interface GuideSection {
 export interface GuideArrival {
   wazeUrl?: string;
   mapsUrl?: string;
+  /** The number on the gate, so a driver knows they have the right one. */
+  gateNumber?: string;
   call?: MultilingualString | string;
   access?: MultilingualString | string;
   /** Guest tier only, and never stored in the repo. */
@@ -117,6 +119,7 @@ export interface GuideData {
   arrival?: {
     wazeUrl?: string;
     mapsUrl?: string;
+    gateNumber?: string;
     call?: string;
     access?: string;
     lockboxCode?: string;
@@ -316,6 +319,7 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
       data.arrival = {
         wazeUrl: guide.arrival.wazeUrl,
         mapsUrl: guide.arrival.mapsUrl,
+        gateNumber: guide.arrival.gateNumber,
             call: getLocalizedString(guide.arrival.call, language, '') || undefined,
         access: getLocalizedString(guide.arrival.access, language, '') || undefined,
         lockboxCode: guide.arrival.lockboxCode,


### PR DESCRIPTION
Three owner corrections.

## Gate number

A guest who has navigated to the road still has to work out which gate is theirs, and the house sits 60 m back from it. The number now shows in the arrival card, **between the map buttons and the call instruction** - the point in the sequence where it is actually needed:

> Waze | Google Maps
> Look for this number on the gate **197**
> Call Bogdan 10-15 minutes before you arrive...

Stored as `arrival.gateNumber`, so the label translates and the number stays data. Any property can set its own.

## "Google Maps", not "Maps"

The short form was ambiguous sitting next to Waze, where both are app names.

## They live a few houses away

Not "a few doors down". The Romanian was already right (*"la câteva case distanță"*); the English was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)