### PR TITLE
feat: serve the guide in one language regardless of the booking

### DIFF
--- a/scripts/seed-guest-guide.ts
+++ b/scripts/seed-guest-guide.ts
@@ -36,6 +36,12 @@ const MAP_URL =
 const prahovaGuide = {
   enabled: true,
 
+  // TEMPORARY: serve the English guide to everyone, including Romanian guests.
+  // The Romanian copy below is complete but does not yet sound like the owner,
+  // so it stays in place and unserved until he has reworked it. Delete this line
+  // to go back to following each booking's language.
+  languageOverride: 'en',
+
   wifi: { network: 'coman_guest', password: WIFI_PASSWORD },
 
   contacts: [

--- a/src/app/guide/[bookingId]/_lib/fetch-guide.ts
+++ b/src/app/guide/[bookingId]/_lib/fetch-guide.ts
@@ -78,6 +78,13 @@ export interface GuideArrival {
 
 export interface GuestGuideConfig {
   enabled?: boolean;
+  /**
+   * Render the guide in this language whatever the guest booked in. Set while a
+   * translation is being reworked: the other language's content stays in place
+   * and untouched, it is simply not served yet. Remove the field to go back to
+   * following the booking.
+   */
+  languageOverride?: LanguageCode;
   wifi?: { network?: string; password?: string };
   contacts?: GuideContact[];
   arrival?: GuideArrival;
@@ -191,12 +198,19 @@ function buildContactHref(phone: string, channel: ContactChannel, message?: stri
   return `tel:${digits}`;
 }
 
-function resolveContacts(contacts: GuideContact[], language: LanguageCode): ResolvedContact[] {
+function resolveContacts(
+  contacts: GuideContact[],
+  language: LanguageCode,
+  guestLanguage: LanguageCode,
+): ResolvedContact[] {
   return contacts
     .filter((c) => c?.phone)
     .map((c) => {
-      const speaks = Array.isArray(c.speaks) && c.speaks.length > 0 ? c.speaks : [language];
-      const needsTranslation = !speaks.includes(language);
+      const speaks = Array.isArray(c.speaks) && c.speaks.length > 0 ? c.speaks : [guestLanguage];
+      // Against the guest's own language: a Romanian guest reading an English
+      // page still shares a language with Corina and Gigi, so no note and no
+      // pre-written message.
+      const needsTranslation = !speaks.includes(guestLanguage);
       const channel: ContactChannel = c.channel ?? 'whatsapp';
 
       // Only prefill when there's a language gap — a guest who shares a language
@@ -232,7 +246,9 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
   const propertySlug: string = booking.propertyId;
   if (!propertySlug) return null;
 
-  const language: LanguageCode = booking.language === 'ro' ? 'ro' : 'en';
+  // What the guest actually speaks. Drives whether a contact needs translating,
+  // which is a fact about the guest, not about which language the page is in.
+  const guestLanguage: LanguageCode = booking.language === 'ro' ? 'ro' : 'en';
 
   // ---- decide the tier -------------------------------------------------
   let tier: GuideTier = 'public';
@@ -266,6 +282,10 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
   const property = propertySnap.data() ?? {};
   const guide: GuestGuideConfig = overridesSnap.data()?.guestGuide ?? {};
   if (guide.enabled === false) return null;
+
+  // The language the page is written in, which an override can detach from the
+  // guest's own.
+  const language: LanguageCode = guide.languageOverride ?? guestLanguage;
 
   const propertyName = getLocalizedString(property.name, language, propertySlug);
 
@@ -303,7 +323,7 @@ export async function fetchGuide(bookingId: string, token?: string): Promise<Gui
     arrivalLeads: false,
     stayStarted: false,
     departing: false,
-    contacts: tier === 'guest' ? resolveContacts(guide.contacts ?? [], language) : [],
+    contacts: tier === 'guest' ? resolveContacts(guide.contacts ?? [], language, guestLanguage) : [],
     mapUrl: guide.mapUrl,
     routes,
     sections,


### PR DESCRIPTION
The Romanian copy does not yet sound like the owner, so English is served to everyone until he has reworked it.

`guestGuide.languageOverride` does this from Firestore. The Romanian content **stays in place and untouched** - it is simply not served. Deleting the field goes back to following each booking's language, with no deploy.

## The bug this would have introduced

The "they don't speak English" note and the pre-written Romanian message key off the page language. Forcing English naively would have told a **Romanian** guest that Corina and Gigi don't speak English, and handed them a Romanian message they are perfectly able to write themselves.

So display language and spoken language are now two different things:

- the page reads in `language`, which the override can detach from the booking
- whether a contact needs translating is decided against `guestLanguage`, taken from the booking - because that is a fact about the guest, not about which language the page happens to be in

## Verified

| | Page language | Language note | Prefilled message |
|---|---|---|---|
| Romanian booking | English | **no** | **no** |
| English booking | English | yes | yes |
| Public tier of a RO booking | English throughout | - | - |

🤖 Generated with [Claude Code](https://claude.com/claude-code)