### PR TITLE
fix: final pass - tap targets, undersized content, two content bugs

### DIFF
--- a/scripts/seed-guest-guide.ts
+++ b/scripts/seed-guest-guide.ts
@@ -279,8 +279,8 @@ const prahovaGuide = {
       group: 'around',
       title: { en: 'Closer to home', ro: 'Aproape de casă' },
       body: {
-        en: 'Some of our own favourites are within an hour, and all of them are pinned on the map above: Belvedere Comarnic, La Antene, Barajul Paltinu and the lake, Păstrăvăria Doftana, and Vistieru.\n\nAsk us - we will tell you which one suits the weather you have got.',
-        ro: 'Câteva dintre locurile noastre preferate sunt la mai puțin de o oră și toate sunt marcate pe harta de mai sus: Belvedere Comarnic, La Antene, Barajul Paltinu și lacul, Păstrăvăria Doftana și Vistieru.\n\nÎntrebați-ne - vă spunem care se potrivește cu vremea pe care o prindeți.',
+        en: 'Some of our own favourites are within an hour, and all of them are pinned on our map, linked just above: Belvedere Comarnic, La Antene, Barajul Paltinu and the lake, Păstrăvăria Doftana, and Vistieru.\n\nAsk us - we will tell you which one suits the weather you have got.',
+        ro: 'Câteva dintre locurile noastre preferate sunt la mai puțin de o oră și toate sunt marcate pe harta noastră, linkul e chiar mai sus: Belvedere Comarnic, La Antene, Barajul Paltinu și lacul, Păstrăvăria Doftana și Vistieru.\n\nÎntrebați-ne - vă spunem care se potrivește cu vremea pe care o prindeți.',
       },
     },
     {
@@ -330,8 +330,8 @@ const prahovaGuide = {
       group: 'house',
       title: { en: 'Before you go', ro: 'Înainte de plecare' },
       body: {
-        en: 'Linens - please leave the beds unmade, and put used towels and dishcloths in the bin upstairs.\n\nDishes - rinse and load the dishwasher, and run the cycle before you leave.\n\nFood - please empty the fridge and cupboards of open and perishable food.\n\nLights - make sure lights, appliances and electronics are off.\n\nFireplace - if you used it, remove the ash (there is a bin outside, next to the BBQ). Please don’t leave wood burning.\n\nWindows & doors - closed and locked, please.\n\nKeys - return them to the lockbox and message us when you leave.',
-        ro: 'Lenjerie - vă rugăm să lăsați paturile nefăcute și să puneți prosoapele și lavetele folosite în coșul de la etaj.\n\nVase - clătiți-le și puneți-le în mașina de spălat vase, apoi porniți un ciclu înainte de plecare.\n\nMâncare - vă rugăm să goliți frigiderul și dulapurile de alimente deschise sau perisabile.\n\nLumini - asigurați-vă că luminile, electrocasnicele și electronicele sunt oprite.\n\nȘemineu - dacă l-ați folosit, scoateți cenușa (există o găleată afară, lângă grătar). Vă rugăm să nu lăsați lemne care ard.\n\nFerestre și uși - vă rugăm să le închideți și încuiați.\n\nChei - lăsați-le în cutia de chei și scrieți-ne la plecare.',
+        en: 'Linens - please leave the beds unmade, and put used towels and dishcloths in the bin upstairs.\n\nDishes - rinse and load the dishwasher, and run the cycle before you leave.\n\nFood - please empty the fridge and cupboards of open and perishable food.\n\nLights - make sure lights, appliances and electronics are off.\n\nFireplace - if you used it, remove the ash (there is a bin outside, next to the BBQ). Please don’t leave wood burning.\n\nWindows & doors - closed and locked, please.\n\nKeys - leave them as we arranged when you arrived, and message us when you go.',
+        ro: 'Lenjerie - vă rugăm să lăsați paturile nefăcute și să puneți prosoapele și lavetele folosite în coșul de la etaj.\n\nVase - clătiți-le și puneți-le în mașina de spălat vase, apoi porniți un ciclu înainte de plecare.\n\nMâncare - vă rugăm să goliți frigiderul și dulapurile de alimente deschise sau perisabile.\n\nLumini - asigurați-vă că luminile, electrocasnicele și electronicele sunt oprite.\n\nȘemineu - dacă l-ați folosit, scoateți cenușa (există o găleată afară, lângă grătar). Vă rugăm să nu lăsați lemne care ard.\n\nFerestre și uși - vă rugăm să le închideți și încuiați.\n\nChei - lăsați-le așa cum am stabilit la sosire și scrieți-ne când plecați.',
       },
     },
   ],

--- a/src/app/guide/[bookingId]/_components/guide-view.tsx
+++ b/src/app/guide/[bookingId]/_components/guide-view.tsx
@@ -244,7 +244,7 @@ function TripsCard({ data, t }: { data: GuideData; t: typeof COPY.en }) {
                 {t.kinds[r.kind] ?? r.kind}
               </span>
               <span className="min-w-0 flex-1 truncate text-[#23260F]">{r.name}</span>
-              <span className="shrink-0 font-mono text-[10.5px] tabular-nums text-[#6D7154]">
+              <span className="shrink-0 font-mono text-[11px] tabular-nums text-[#6D7154]">
                 {r.km} km
               </span>
             </li>
@@ -313,7 +313,7 @@ function ArrivalCard({
 
       {a.gateNumber && (
         <p className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-[#DDDAC7] bg-[#F4F2E7] px-3 py-2.5">
-          <span className="text-[11.5px] leading-snug text-[#6D7154]">{t.gate}</span>
+          <span className="text-[12.5px] leading-snug text-[#6D7154]">{t.gate}</span>
           <strong className="font-mono text-xl font-bold tracking-[0.08em] text-[#23260F]">
             {a.gateNumber}
           </strong>
@@ -336,7 +336,7 @@ function ArrivalCard({
       )}
 
       {a.access && (
-        <p className="mt-2 text-[11.5px] leading-relaxed text-[#6D7154]">{a.access}</p>
+        <p className="mt-2 text-[13px] leading-relaxed text-[#6D7154]">{a.access}</p>
       )}
     </section>
   );
@@ -456,13 +456,13 @@ export default function GuideView({ data }: { data: GuideData }) {
                 >
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-bold leading-tight text-[#23260F]">{c.name}</p>
-                    {c.role && <p className="mt-0.5 text-[11px] leading-snug text-[#6D7154]">{c.role}</p>}
+                    {c.role && <p className="mt-0.5 text-[12px] leading-snug text-[#6D7154]">{c.role}</p>}
                   </div>
                   <a
                     href={c.href}
                     target={c.channel === 'whatsapp' ? '_blank' : undefined}
                     rel={c.channel === 'whatsapp' ? 'noopener noreferrer' : undefined}
-                    className="flex shrink-0 items-center gap-1.5 rounded-lg bg-[#414A22] px-3 py-2 text-[11px] font-bold text-[#F4F2E7] transition hover:bg-[#4E5A29] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7E9A33]"
+                    className="flex min-h-[44px] shrink-0 items-center gap-1.5 rounded-lg bg-[#414A22] px-3.5 py-2 text-[12px] font-bold text-[#F4F2E7] transition hover:bg-[#4E5A29] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7E9A33]"
                   >
                     {c.channel === 'call' ? (
                       <Phone className="h-3.5 w-3.5" />
@@ -480,12 +480,12 @@ export default function GuideView({ data }: { data: GuideData }) {
               .map((c) => (
                 <p
                   key={`${c.phone}-note`}
-                  className="mt-3 rounded-lg border border-[#DDDAC7] bg-[#F4F2E7] px-3 py-2.5 text-[11px] leading-relaxed text-[#6D7154]"
+                  className="mt-3 rounded-lg border border-[#DDDAC7] bg-[#F4F2E7] px-3 py-2.5 text-[12px] leading-relaxed text-[#6D7154]"
                 >
                   {t.translationNote(
                     LANGUAGE_NAMES[data.language]?.[c.prefillLanguage ?? 'ro'] ?? 'Romanian',
                   )}
-                  <span className="mt-1.5 block font-mono text-[10.5px] leading-relaxed text-[#414A22]">
+                  <span className="mt-1.5 block font-mono text-[11.5px] leading-relaxed text-[#414A22]">
                     „{c.prefillText}”
                   </span>
                 </p>
@@ -582,7 +582,7 @@ export default function GuideView({ data }: { data: GuideData }) {
         )}
 
         {isGuest && (
-          <p className="px-4 text-center text-[10.5px] leading-relaxed text-[#6D7154]">
+          <p className="px-4 text-center text-[11px] leading-relaxed text-[#6D7154]">
             {t.privateNote}
           </p>
         )}


### PR DESCRIPTION
Audit before sharing the guide with guests.

## Two content bugs, both live

**The lockbox does not exist yet.** "Keys - return them to the lockbox and message us when you leave" was telling guests on checkout morning to use something that has not been installed. Reworded to hold true whether the key goes to Corina and Gigi, to today's plastic box, or to the lockbox when it arrives - and it points back to the arrival call, where the arrangement is actually made.

**"pinned on the map above"** stopped being true when the route sketch was removed. The card above it is now a list and a link, not a map. Now reads "pinned on our map, linked just above".

## UI, measured on the live page

| Issue | Was | Now |
|---|---|---|
| WhatsApp buttons | 32px tall | **44px** (accepted floor; most-used controls on the page) |
| 60m access note | 11.5px | 13px |
| Contact roles | 11px | 12px |
| Romanian pre-written message | 10.5px | 11.5px |
| Route distances, footer note | 10.5px | 11px |

Uppercase eyebrow labels stay at 8.5-10px on purpose - that is a typographic device, and they are short, high-contrast and non-essential.

## Checked and already correct

- no horizontal overflow at phone width
- one `h1`, sensible heading order
- every `target=_blank` carries `rel=noopener`
- no image without `alt`
- contrast 4.85:1 to 15.5:1 - WCAG AA throughout
- `robots.txt` allows the crawl, so the `noindex` meta can actually be read
- unknown and traversal-shaped booking ids return 404, not a leak
- all three external links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)