### PR TITLE
feat: short guide links and a guess limit on the guide routes

### DIFF
--- a/src/app/g/[bookingId]/page.tsx
+++ b/src/app/g/[bookingId]/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { fetchGuide } from '../../guide/[bookingId]/_lib/fetch-guide';
+import GuideView from '../../guide/[bookingId]/_components/guide-view';
+
+// Short form of /guide/[bookingId]. New links use this; /guide still works so
+// that anything already sent to a guest keeps resolving.
+export const metadata: Metadata = {
+  title: 'Guest guide',
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ bookingId: string }>;
+  searchParams: Promise<{ t?: string }>;
+}
+
+export default async function ShortGuidePage({ params, searchParams }: PageProps) {
+  const { bookingId } = await params;
+  const { t: token } = await searchParams;
+
+  const data = await fetchGuide(bookingId, token);
+  if (!data) notFound();
+
+  return <GuideView data={data} />;
+}

--- a/src/lib/guide-token.ts
+++ b/src/lib/guide-token.ts
@@ -21,6 +21,14 @@ import { createHmac, timingSafeEqual } from 'crypto';
 
 const DOMAIN = 'guide';
 
+// Base62 rather than hex: 5.95 bits per character instead of 4, so eight
+// characters carry the same ~48 bits that twelve hex characters would. That is
+// far more than this needs - an attacker must already hold the booking's
+// 20-character random id before a token is worth guessing at all - and it keeps
+// the whole link short enough to sit on one line of a WhatsApp message.
+const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const TOKEN_LENGTH = 8;
+
 function getSecret(): string {
   const secret = process.env.REVIEW_TOKEN_SECRET;
   if (!secret) {
@@ -38,24 +46,48 @@ export function guideIdentity(guestInfo?: { email?: string | null; phone?: strin
   return raw.toLowerCase().trim();
 }
 
+function digest(bookingId: string, identity: string): Buffer {
+  const payload = `${DOMAIN}:${bookingId}:${identity.toLowerCase().trim()}`;
+  return createHmac('sha256', getSecret()).update(payload).digest();
+}
+
+function digestHex(bookingId: string, identity: string): string {
+  return digest(bookingId, identity).toString('hex');
+}
+
 /**
- * Generate an HMAC-SHA256 token for a guest guide URL.
+ * Generate the token for a guest guide URL.
  */
 export function generateGuideToken(bookingId: string, identity = ''): string {
-  const secret = getSecret();
-  const payload = `${DOMAIN}:${bookingId}:${identity.toLowerCase().trim()}`;
-  return createHmac('sha256', secret).update(payload).digest('hex');
+  // Six bytes of the digest is 48 bits, which stays exact in a double (< 2^53),
+  // so this needs no BigInt and works on the project's ES2017 target.
+  const bytes = digest(bookingId, identity);
+  let n = 0;
+  for (let i = 0; i < 6; i++) n = n * 256 + bytes[i];
+
+  let out = '';
+  for (let i = 0; i < TOKEN_LENGTH; i++) {
+    out = ALPHABET[n % 62] + out;
+    n = Math.floor(n / 62);
+  }
+  return out;
+}
+
+function matches(expected: string, token: string): boolean {
+  if (expected.length !== token.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(token));
 }
 
 /**
  * Validate a guide token using timing-safe comparison.
+ *
+ * Accepts the full 64-character hex token as well, so links already sent to
+ * guests keep working. Old links stay valid until they expire on their own.
  */
 export function validateGuideToken(bookingId: string, identity: string, token: string): boolean {
-  const expected = generateGuideToken(bookingId, identity);
-  if (expected.length !== token.length) {
-    return false;
-  }
-  return timingSafeEqual(Buffer.from(expected), Buffer.from(token));
+  if (!token) return false;
+  if (matches(generateGuideToken(bookingId, identity), token)) return true;
+  return matches(digestHex(bookingId, identity), token);
 }
 
 /**
@@ -64,5 +96,5 @@ export function validateGuideToken(bookingId: string, identity: string, token: s
  * NEXT_PUBLIC_APP_URL, which is not provisioned in App Hosting.
  */
 export function guidePath(bookingId: string, token: string): string {
-  return `/guide/${bookingId}?t=${token}`;
+  return `/g/${bookingId}?t=${token}`;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,43 @@ export const config = {
   ],
 };
 
+/**
+ * Guess-rate limit for the guest guide.
+ *
+ * The guide is a public URL whose only protection is an unguessable token, and
+ * a wrong guess costs three Firestore reads. Deliberately implemented inline
+ * rather than reusing lib/rate-limiter: middleware runs on the edge runtime,
+ * where that module's logger cannot write to stdout.
+ *
+ * In-memory, so the limit is per instance rather than global - the same caveat
+ * the existing limiter documents. It turns unbounded guessing into a crawl,
+ * which is all it needs to do.
+ */
+const GUIDE_WINDOW_MS = 60_000;
+const GUIDE_MAX = 30;
+const guideHits = new Map<string, { count: number; resetAt: number }>();
+
+function guideRateLimited(request: NextRequest): boolean {
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+  const now = Date.now();
+
+  // Sweep expired entries so the map cannot grow without bound.
+  if (guideHits.size > 5000) {
+    for (const [k, v] of guideHits) if (v.resetAt < now) guideHits.delete(k);
+  }
+
+  const entry = guideHits.get(ip);
+  if (!entry || entry.resetAt < now) {
+    guideHits.set(ip, { count: 1, resetAt: now + GUIDE_WINDOW_MS });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > GUIDE_MAX;
+}
+
 export async function middleware(request: NextRequest) {
   const url = request.nextUrl.clone();
   const pathname = url.pathname;
@@ -23,6 +60,17 @@ export async function middleware(request: NextRequest) {
 
   // Skip middleware for health check endpoints
   if (pathname === '/api/health' || pathname === '/api/readiness') {
+    return NextResponse.next();
+  }
+
+  // Guest guide: throttle token guessing before it reaches Firestore.
+  if (pathname.startsWith('/g/') || pathname.startsWith('/guide/')) {
+    if (guideRateLimited(request)) {
+      return new NextResponse('Too many requests', {
+        status: 429,
+        headers: { 'Retry-After': '60', 'Cache-Control': 'no-store' },
+      });
+    }
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Links: 119 characters to 59

| | Length |
|---|---|
| before | 119 |
| **after** | **59** |

Fits on one line of a WhatsApp message instead of wrapping across three.

Two changes get there:

- **hex to base62** - eight characters carry the ~48 bits that twelve hex characters would
- **short route** `/g/` alongside `/guide/`

**Nothing already sent breaks.** `/guide/` stays, and validation accepts the old 64-character hex token as well, so links already in guests' hands keep working until they expire on their own.

Encoding avoids `BigInt`: six bytes of the digest is 48 bits, which stays exact in a double, so this works on the project's ES2017 target rather than forcing that up. Checked over 3000 ids - all 8 characters, all distinct, full alphabet in use, round-trip and cross-reject correct.

## Rate limiting

The guide is a public URL whose only protection is an unguessable token, and nothing throttled guessing - I fired 20 rapid requests with bad tokens and all returned 200. Each wrong guess costs three Firestore reads.

Now **30 per minute per IP**, 429 with `Retry-After: 60` and `Cache-Control: no-store`.

Implemented inline in middleware rather than reusing `lib/rate-limiter`, which imports the logger and so cannot run on the edge runtime middleware uses. In-memory and therefore per instance - the same caveat that limiter documents in its own docblock. It turns unbounded guessing into a crawl, which is all it needs to do.

## Verified

| Case | Result |
|---|---|
| New short link | guest tier |
| Old long link | guest tier |
| Short token on old `/guide/` path | guest tier |
| Wrong token | public tier, no leak |
| 40 rapid bad tokens | 26 x 200 then 14 x 429 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)